### PR TITLE
Fix partial date handling

### DIFF
--- a/Predictorator.Tests/DateRangeCalculatorTests.cs
+++ b/Predictorator.Tests/DateRangeCalculatorTests.cs
@@ -32,4 +32,30 @@ public class DateRangeCalculatorTests
         Assert.Equal(new DateTime(2024,4,26), resultFrom);
         Assert.Equal(new DateTime(2024,5,2), resultTo);
     }
+
+    [Fact]
+    public void Uses_from_date_when_only_from_provided()
+    {
+        var provider = new FakeDateTimeProvider { Today = new DateTime(2024,1,1) };
+        var calculator = new DateRangeCalculator(provider);
+
+        var from = new DateTime(2024,3,1);
+        var (resultFrom, resultTo) = calculator.GetDates(from, null, null);
+
+        Assert.Equal(from, resultFrom);
+        Assert.Equal(from.AddDays(6), resultTo);
+    }
+
+    [Fact]
+    public void Uses_to_date_when_only_to_provided()
+    {
+        var provider = new FakeDateTimeProvider { Today = new DateTime(2024,1,1) };
+        var calculator = new DateRangeCalculator(provider);
+
+        var to = new DateTime(2024,3,7);
+        var (resultFrom, resultTo) = calculator.GetDates(null, to, null);
+
+        Assert.Equal(to.AddDays(-6), resultFrom);
+        Assert.Equal(to, resultTo);
+    }
 }

--- a/Predictorator/Services/DateRangeCalculator.cs
+++ b/Predictorator/Services/DateRangeCalculator.cs
@@ -11,24 +11,28 @@ public class DateRangeCalculator : IDateRangeCalculator
 
     public (DateTime From, DateTime To) GetDates(DateTime? fromDate, DateTime? toDate, int? weekOffset)
     {
-        var effectiveFrom = fromDate;
-        var effectiveTo = toDate;
-        if (effectiveFrom != null && effectiveTo != null)
-            return (effectiveFrom.Value, effectiveTo.Value);
+        if (fromDate.HasValue && toDate.HasValue)
+            return (fromDate.Value, toDate.Value);
 
-        effectiveFrom = _dateTimeProvider.Today;
-        while (effectiveFrom.Value.DayOfWeek != DayOfWeek.Tuesday)
+        if (fromDate.HasValue)
+            return (fromDate.Value, fromDate.Value.AddDays(6));
+
+        if (toDate.HasValue)
+            return (toDate.Value.AddDays(-6), toDate.Value);
+
+        var effectiveFrom = _dateTimeProvider.Today;
+        while (effectiveFrom.DayOfWeek != DayOfWeek.Tuesday)
         {
-            effectiveFrom = effectiveFrom.Value.AddDays(-1);
+            effectiveFrom = effectiveFrom.AddDays(-1);
         }
-        effectiveFrom = effectiveFrom.Value.AddDays(3);
+        effectiveFrom = effectiveFrom.AddDays(3);
 
         if (weekOffset.HasValue)
         {
-            effectiveFrom = effectiveFrom.Value.AddDays(weekOffset.Value * 7);
+            effectiveFrom = effectiveFrom.AddDays(weekOffset.Value * 7);
         }
 
-        effectiveTo = effectiveFrom.Value.AddDays(6);
-        return (effectiveFrom.Value, effectiveTo.Value);
+        var effectiveTo = effectiveFrom.AddDays(6);
+        return (effectiveFrom, effectiveTo);
     }
 }


### PR DESCRIPTION
## Summary
- handle provided `fromDate` or `toDate` in `DateRangeCalculator`
- add unit tests covering partial date inputs

## Testing
- `dotnet build --no-restore`
- `dotnet vstest Predictorator.Tests/bin/Debug/net8.0/Predictorator.Tests.dll`


------
https://chatgpt.com/codex/tasks/task_e_6842c14198e88328bf11ab382cf01de4