### PR TITLE
Add mock fixture mode and tests

### DIFF
--- a/Predictorator.Tests/FixtureServiceTestTokenTests.cs
+++ b/Predictorator.Tests/FixtureServiceTestTokenTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Hosting;
+using NSubstitute;
+using Predictorator.Models.Fixtures;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Predictorator.Tests;
+
+public class FixtureServiceTestTokenTests
+{
+    [Fact]
+    public async Task Returns_mock_data_when_token_matches()
+    {
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ApiSettings:TestToken"] = "token"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Test-Token"] = "token";
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(context);
+
+        var handler = new StubHttpMessageHandler(new object());
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        httpClientFactory.CreateClient("fixtures").Returns(client);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        var service = new FixtureService(httpClientFactory, cache, accessor, config, env);
+
+        var result = await service.GetFixturesAsync(DateTime.Today, DateTime.Today.AddDays(6));
+
+        Assert.Single(result.Response);
+        Assert.Equal(0, handler.CallCount);
+    }
+}

--- a/Predictorator.Tests/FixtureServiceTests.cs
+++ b/Predictorator.Tests/FixtureServiceTests.cs
@@ -3,6 +3,10 @@ using NSubstitute;
 using Predictorator.Models.Fixtures;
 using Predictorator.Services;
 using Predictorator.Tests.Helpers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
 
 namespace Predictorator.Tests;
 
@@ -17,7 +21,11 @@ public class FixtureServiceTests
         var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
         httpClientFactory.CreateClient("fixtures").Returns(client);
         var cache = new MemoryCache(new MemoryCacheOptions());
-        var service = new FixtureService(httpClientFactory, cache);
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        var config = Substitute.For<IConfiguration>();
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
+        var service = new FixtureService(httpClientFactory, cache, accessor, config, env);
 
         var result1 = await service.GetFixturesAsync(DateTime.Today, DateTime.Today);
         var result2 = await service.GetFixturesAsync(DateTime.Today, DateTime.Today);

--- a/Predictorator.Tests/RateLimitingMiddlewareTests.cs
+++ b/Predictorator.Tests/RateLimitingMiddlewareTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Predictorator.Middleware;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class RateLimitingMiddlewareTests
+{
+    [Fact]
+    public async Task Returns_429_when_limit_exceeded()
+    {
+        var service = Substitute.For<IRateLimitService>();
+        service.ShouldLimit(Arg.Any<string>(), Arg.Any<DateTime>()).Returns(true);
+        var middleware = new RateLimitingMiddleware(_ => Task.CompletedTask, service);
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status429TooManyRequests, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invokes_next_when_not_limited()
+    {
+        var service = Substitute.For<IRateLimitService>();
+        service.ShouldLimit(Arg.Any<string>(), Arg.Any<DateTime>()).Returns(false);
+        var called = false;
+        var middleware = new RateLimitingMiddleware(ctx => { called = true; return Task.CompletedTask; }, service);
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(called);
+        Assert.NotEqual(StatusCodes.Status429TooManyRequests, context.Response.StatusCode);
+    }
+}

--- a/Predictorator/MockData/fixtures.json
+++ b/Predictorator/MockData/fixtures.json
@@ -1,0 +1,44 @@
+{
+  "FromDate": "2024-04-20T00:00:00Z",
+  "ToDate": "2024-04-26T00:00:00Z",
+  "Get": "fixtures",
+  "Parameters": {},
+  "Errors": [],
+  "Results": 1,
+  "Paging": { "Current": 1, "Total": 1 },
+  "CurrentWeekOffset": 0,
+  "AutoWeek": false,
+  "Response": [
+    {
+      "Fixture": {
+        "Id": 1,
+        "Timezone": "UTC",
+        "Date": "2024-04-21T12:00:00Z",
+        "Timestamp": 0,
+        "Periods": { "First": null, "Second": null },
+        "Venue": { "Id": 1, "Name": "Mock Stadium", "City": "Mock City" },
+        "Status": { "Long": "Not Started", "Short": "NS", "Elapsed": null }
+      },
+      "League": {
+        "Id": 39,
+        "Name": "Premier League",
+        "Country": "England",
+        "Logo": "",
+        "Flag": "",
+        "Season": 2024,
+        "Round": "Regular Season - 1"
+      },
+      "Teams": {
+        "Home": { "Id": 1, "Name": "Home", "Logo": "", "Winner": null },
+        "Away": { "Id": 2, "Name": "Away", "Logo": "", "Winner": null }
+      },
+      "Goals": { "Home": null, "Away": null },
+      "Score": {
+        "Halftime": { "Home": null, "Away": null },
+        "Fulltime": { "Home": null, "Away": null },
+        "Extratime": { "Home": null, "Away": null },
+        "Penalty": { "Home": null, "Away": null }
+      }
+    }
+  ]
+}

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -1,9 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Update="MockData/fixtures.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
 </Project>

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddHttpClient("fixtures", client =>
     client.DefaultRequestHeaders.Add("x-rapidapi-key", rapidApiKey);
 });
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddTransient<IFixtureService, FixtureService>();
 builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
 builder.Services.AddSingleton<IRateLimitService>(new InMemoryRateLimitService(100, TimeSpan.FromDays(1)));

--- a/Predictorator/Services/FixtureService.cs
+++ b/Predictorator/Services/FixtureService.cs
@@ -1,5 +1,11 @@
-﻿using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using System.IO;
+using System.Text.Json;
+using System.Linq;
 using Predictorator.Models.Fixtures;
 
 namespace Predictorator.Services
@@ -8,12 +14,23 @@ namespace Predictorator.Services
     {
         private readonly HttpClient _httpClient;
         private readonly IMemoryCache _cache;
+        private readonly IHttpContextAccessor _contextAccessor;
+        private readonly IConfiguration _configuration;
+        private readonly IWebHostEnvironment _environment;
         private readonly TimeSpan _cacheDuration = TimeSpan.FromHours(12);
 
-        public FixtureService(IHttpClientFactory httpClientFactory, IMemoryCache cache)
+        public FixtureService(
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache cache,
+            IHttpContextAccessor contextAccessor,
+            IConfiguration configuration,
+            IWebHostEnvironment environment)
         {
             _httpClient = httpClientFactory.CreateClient("fixtures");
             _cache = cache;
+            _contextAccessor = contextAccessor;
+            _configuration = configuration;
+            _environment = environment;
         }
 
         public async Task<FixturesResponse> GetFixturesAsync(DateTime fromDate, DateTime toDate)
@@ -21,6 +38,18 @@ namespace Predictorator.Services
             var cacheKey = $"{fromDate:yyyy-MM-dd}_{toDate:yyyy-MM-dd}";
 
             if (_cache.TryGetValue(cacheKey, out FixturesResponse? cachedResponse)) return cachedResponse!;
+
+            var token = _configuration["ApiSettings:TestToken"];
+            var headerToken = _contextAccessor.HttpContext?.Request.Headers["X-Test-Token"].FirstOrDefault();
+            if (!string.IsNullOrEmpty(token) && headerToken == token)
+            {
+                var path = Path.Combine(_environment.ContentRootPath, "MockData", "fixtures.json");
+                await using var stream = File.OpenRead(path);
+                cachedResponse = await JsonSerializer.DeserializeAsync<FixturesResponse>(stream);
+                if (cachedResponse == null) throw new Exception("Failed to load mock fixtures");
+                _cache.Set(cacheKey, cachedResponse, _cacheDuration);
+                return cachedResponse;
+            }
 
             var query = new Dictionary<string, string?>()
             {

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -6,4 +6,8 @@
     }
   },
   "AllowedHosts": "*"
+,
+  "ApiSettings": {
+    "TestToken": "test-token"
+  }
 }


### PR DESCRIPTION
## Summary
- support mock responses for `FixtureService` using `X-Test-Token`
- copy mock fixtures into build output
- configure `HttpContextAccessor` in Program
- extend unit tests and UI tests
- add middleware unit tests

## Testing
- `dotnet restore Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68514964e82c8328aaa8975688ea3dc0