### PR TITLE
Update CD to run tests on prod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,10 +28,10 @@ jobs:
           name: app
           path: publish
 
-  deploy_staging:
+  deploy_prod:
     runs-on: ubuntu-latest
     needs: build
-    environment: staging
+    environment: production
     outputs:
       url: ${{ steps.deploy.outputs.webapp-url }}
     steps:
@@ -48,15 +48,16 @@ jobs:
         uses: azure/webapps-deploy@v3
         with:
           app-name: 'predictorator5000'
-          slot-name: 'staging'
+          slot-name: 'Production'
           package: ./
 
   tests:
     runs-on: ubuntu-latest
-    needs: deploy_staging
+    needs: deploy_prod
     env:
       RUN_UI_TESTS: 'true'
-      BASE_URL: ${{ needs.deploy_staging.outputs.url }}
+      BASE_URL: ${{ needs.deploy_prod.outputs.url }}
+      UI_TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
@@ -70,31 +71,11 @@ jobs:
       - name: Run all tests
         run: dotnet test Predictorator.sln --logger trx
 
-  deploy_prod:
-    runs-on: ubuntu-latest
-    needs: tests
-    if: success()
-    environment: production
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: app
-      - uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_2687F5A3498747E1A95ADE36D92A159E }}
-          tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_F68BC6B164FA4A818B4561CE37FB31B5 }}
-          subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_E02E41A1857446D5AE38550D3A7CF31C }}
-      - name: Deploy to production
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: 'predictorator5000'
-          slot-name: 'Production'
-          package: ./
 
   rollback:
     if: failure() && needs.tests.result == 'failure'
     runs-on: ubuntu-latest
-    needs: [deploy_staging, tests]
+    needs: [deploy_prod, tests]
     steps:
       - uses: azure/login@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,5 +29,6 @@ The following guidelines apply to the entire repository and inform how Codex sho
 
 - Playwright tests live in the `Predictorator.UiTests` project.
 - Keep these tests current and add new coverage whenever the UI changes.
-- The CD workflow deploys to staging and then runs the Playwright tests against
-  that environment.
+- The CD workflow deploys directly to production and then runs the Playwright
+  tests against that environment. There is no staging deployment and the tests
+  use the `TEST_TOKEN` secret to populate `UI_TEST_TOKEN`.


### PR DESCRIPTION
## Summary
- clarify that UI tests run against prod and use TEST_TOKEN
- run tests against the production deployment and supply `UI_TEST_TOKEN`

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_68514bfa4f648328bb39f1ae46c475bb