### PR TITLE
Fix environment name case in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
   deploy_prod:
     runs-on: ubuntu-latest
     needs: build
-    environment: production
+    environment: Production
     outputs:
       url: ${{ steps.deploy.outputs.webapp-url }}
     steps:


### PR DESCRIPTION
## Summary
- correct environment name casing in CD workflow YAML

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68515b9ba05083288ec577f47a42f44b