### PR TITLE
Refactor rate limit time handling

### DIFF
--- a/Predictorator.Tests/HomeControllerTests.cs
+++ b/Predictorator.Tests/HomeControllerTests.cs
@@ -20,7 +20,8 @@ public class HomeControllerTests : IClassFixture<WebApplicationFactory<Program>>
             {
                 services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
                 services.AddSingleton<IDateTimeProvider>(new SystemDateTimeProvider());
-                services.AddSingleton<IRateLimitService>(new InMemoryRateLimitService(100, TimeSpan.FromMinutes(1)));
+                services.AddSingleton<IRateLimitService>(sp =>
+                    new InMemoryRateLimitService(100, TimeSpan.FromMinutes(1), sp.GetRequiredService<IDateTimeProvider>()));
 
                 services.AddTransient<IFixtureService>(_ => new FakeFixtureService(
                     new FixturesResponse

--- a/Predictorator.Tests/InMemoryRateLimitServiceTests.cs
+++ b/Predictorator.Tests/InMemoryRateLimitServiceTests.cs
@@ -8,24 +8,23 @@ public class InMemoryRateLimitServiceTests
     [Fact]
     public void Limits_after_threshold_exceeded()
     {
-        var service = new InMemoryRateLimitService(1, TimeSpan.FromMinutes(1));
+        var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
+        var service = new InMemoryRateLimitService(1, TimeSpan.FromMinutes(1), provider);
 
-        var now = DateTime.UtcNow;
-        Assert.False(service.ShouldLimit("1.1.1.1", now));
-        Assert.True(service.ShouldLimit("1.1.1.1", now));
+        Assert.False(service.ShouldLimit("1.1.1.1"));
+        Assert.True(service.ShouldLimit("1.1.1.1"));
     }
 
     [Fact]
     public void Resets_after_time_window()
     {
-        var service = new InMemoryRateLimitService(1, TimeSpan.FromSeconds(1));
+        var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
+        var service = new InMemoryRateLimitService(1, TimeSpan.FromSeconds(1), provider);
         var ip = "1.1.1.1";
-        var now = DateTime.UtcNow;
 
-        Assert.False(service.ShouldLimit(ip, now));
-        Assert.True(service.ShouldLimit(ip, now));
-
-        var later = now.AddSeconds(2);
-        Assert.False(service.ShouldLimit(ip, later));
+        Assert.False(service.ShouldLimit(ip));
+        Assert.True(service.ShouldLimit(ip));
+        provider.UtcNow = provider.UtcNow.AddSeconds(2);
+        Assert.False(service.ShouldLimit(ip));
     }
 }

--- a/Predictorator.Tests/RateLimitingMiddlewareTests.cs
+++ b/Predictorator.Tests/RateLimitingMiddlewareTests.cs
@@ -11,7 +11,7 @@ public class RateLimitingMiddlewareTests
     public async Task Returns_429_when_limit_exceeded()
     {
         var service = Substitute.For<IRateLimitService>();
-        service.ShouldLimit(Arg.Any<string>(), Arg.Any<DateTime>()).Returns(true);
+        service.ShouldLimit(Arg.Any<string>()).Returns(true);
         var middleware = new RateLimitingMiddleware(_ => Task.CompletedTask, service);
         var context = new DefaultHttpContext();
         context.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
@@ -25,7 +25,7 @@ public class RateLimitingMiddlewareTests
     public async Task Invokes_next_when_not_limited()
     {
         var service = Substitute.For<IRateLimitService>();
-        service.ShouldLimit(Arg.Any<string>(), Arg.Any<DateTime>()).Returns(false);
+        service.ShouldLimit(Arg.Any<string>()).Returns(false);
         var called = false;
         var middleware = new RateLimitingMiddleware(ctx => { called = true; return Task.CompletedTask; }, service);
         var context = new DefaultHttpContext();

--- a/Predictorator/Middleware/RateLimitingMiddleware.cs
+++ b/Predictorator/Middleware/RateLimitingMiddleware.cs
@@ -23,9 +23,7 @@ public class RateLimitingMiddleware
             return;
         }
 
-        var now = DateTime.UtcNow;
-
-        if (_rateLimitService.ShouldLimit(ipAddress, now))
+        if (_rateLimitService.ShouldLimit(ipAddress))
         {
             context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
             return;

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -15,7 +15,8 @@ builder.Services.AddHttpClient("fixtures", client =>
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddTransient<IFixtureService, FixtureService>();
 builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
-builder.Services.AddSingleton<IRateLimitService>(new InMemoryRateLimitService(100, TimeSpan.FromDays(1)));
+builder.Services.AddSingleton<IRateLimitService>(sp =>
+    new InMemoryRateLimitService(100, TimeSpan.FromDays(1), sp.GetRequiredService<IDateTimeProvider>()));
 builder.Services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
 
 // Add services to the container.

--- a/Predictorator/Services/IRateLimitService.cs
+++ b/Predictorator/Services/IRateLimitService.cs
@@ -2,5 +2,5 @@ namespace Predictorator.Services;
 
 public interface IRateLimitService
 {
-    bool ShouldLimit(string ipAddress, DateTime now);
+    bool ShouldLimit(string ipAddress);
 }


### PR DESCRIPTION
## Summary
- inject `IDateTimeProvider` into `InMemoryRateLimitService`
- update middleware and tests to use new interface
- register service using DI

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_68515d84953c8328954ee45586c27970