### PR TITLE
Fix Playwright browser install step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           dotnet tool install --global Microsoft.Playwright.CLI
           export PATH="$PATH:/root/.dotnet/tools"
-          playwright install --with-deps
+          playwright install
       - name: Run all tests
         run: dotnet test Predictorator.sln --logger trx --no-build
 


### PR DESCRIPTION
## Summary
- fix Playwright browser install on Ubuntu 24.04

## Testing
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685160fcb20c8328a44aff3f0781e9ea