### PR TITLE
Add admin role and page

### DIFF
--- a/Predictorator/Controllers/AdminController.cs
+++ b/Predictorator/Controllers/AdminController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Predictorator.Controllers;
+
+[Authorize(Roles = "Admin")]
+public class AdminController : Controller
+{
+    [HttpGet]
+    public IActionResult SendNotification()
+    {
+        return View();
+    }
+}

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Predictorator.Data;
+
+public class ApplicationDbContext : IdentityDbContext<IdentityUser>
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/Predictorator/Data/ApplicationDbInitializer.cs
+++ b/Predictorator/Data/ApplicationDbInitializer.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Predictorator.Data;
+
+public static class ApplicationDbInitializer
+{
+    public static async Task SeedAdminUserAsync(IServiceProvider serviceProvider)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+        const string adminRole = "Admin";
+        const string adminEmail = "admin@example.com";
+        const string adminPassword = "Admin123!";
+
+        if (!await roleManager.RoleExistsAsync(adminRole))
+        {
+            await roleManager.CreateAsync(new IdentityRole(adminRole));
+        }
+
+        var user = await userManager.FindByEmailAsync(adminEmail);
+        if (user == null)
+        {
+            user = new IdentityUser { UserName = adminEmail, Email = adminEmail, EmailConfirmed = true };
+            await userManager.CreateAsync(user, adminPassword);
+        }
+
+        if (!await userManager.IsInRoleAsync(user, adminRole))
+        {
+            await userManager.AddToRoleAsync(user, adminRole);
+        }
+    }
+}

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -12,4 +12,10 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.4" />
+  </ItemGroup>
+
 </Project>

--- a/Predictorator/Views/Admin/SendNotification.cshtml
+++ b/Predictorator/Views/Admin/SendNotification.cshtml
@@ -1,0 +1,9 @@
+@{
+    ViewData["Title"] = "Send Notification";
+}
+
+<h2>Send Notification</h2>
+<form method="post">
+    <p>Confirm sending notification?</p>
+    <button type="submit" class="btn btn-primary">Send</button>
+</form>

--- a/Predictorator/Views/Shared/_Layout.cshtml
+++ b/Predictorator/Views/Shared/_Layout.cshtml
@@ -30,6 +30,10 @@
     <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
         <div class="container-fluid">
             <a class="navbar-brand header" asp-area="" asp-controller="Home" asp-action="Index">Predictotronix</a>
+            @if (User.Identity?.IsAuthenticated == true && User.IsInRole("Admin"))
+            {
+                <a class="nav-link" asp-controller="Admin" asp-action="SendNotification">Admin</a>
+            }
             <button id="darkModeToggle" class="btn btn-outline-secondary ms-auto">Dark Mode</button>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- add Identity DbContext and seed admin
- restrict new AdminController to Admin role
- show admin link only to admins
- wire up Identity with in-memory store

## Testing
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68516307e18083288cc440b5f62d2550