### PR TITLE
Fix failing CD tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,14 +64,14 @@ jobs:
         with:
           dotnet-version: '8.0'
       - name: Build tests
-        run: dotnet build Predictorator.UiTests/Predictorator.UiTests.csproj --configuration Release
+        run: dotnet build Predictorator.sln --configuration Release
       - name: Install Playwright browsers
         run: |
           dotnet tool install --global Microsoft.Playwright.CLI
           export PATH="$PATH:/root/.dotnet/tools"
           playwright install
       - name: Run all tests
-        run: dotnet test Predictorator.sln --logger trx --no-build
+        run: dotnet test Predictorator.sln --logger trx --no-build --configuration Release
 
 
   rollback:


### PR DESCRIPTION
## Summary
- build full solution in release during CD tests
- run tests in release configuration

## Testing
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6851730cfe5c8328b4b5313f3d15cc7c