### PR TITLE
Fix database download URL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,7 +57,8 @@ jobs:
           az webapp deployment list-publishing-profiles \
             --name predictorator5000 --resource-group "$RG" \
             --output json > profile.json
-          echo "scm_url=$(jq -r '.[0].scmUri' profile.json)" >> "$GITHUB_OUTPUT"
+          scm_host=$(jq -r '.[0].publishUrl' profile.json | cut -d: -f1)
+          echo "scm_url=https://$scm_host" >> "$GITHUB_OUTPUT"
           auth=$(jq -r '.[0].userName + ":" + .[0].userPWD' profile.json | base64)
           echo "auth=$auth" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- fix the CD workflow to parse the publish URL for database operations

## Testing
- `dotnet format Predictorator.sln --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68518ae284bc8328b52c65588cf68d2d