### PR TITLE
Fix Flyway migration parsing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           url: 'jdbc:sqlite:predictorator.db'
           locations: 'filesystem:./flyway/sql'
+          flyway-version: '11.9.1'
 
       - name: Upload database
         run: |

--- a/flyway/sql/V1__InitialCreate.sql
+++ b/flyway/sql/V1__InitialCreate.sql
@@ -1,8 +1,3 @@
-﻿CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
-    "MigrationId" TEXT NOT NULL CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY,
-    "ProductVersion" TEXT NOT NULL
-);
-
 BEGIN TRANSACTION;
 
 CREATE TABLE "AspNetRoles" (
@@ -85,9 +80,6 @@ CREATE INDEX "IX_AspNetUserRoles_RoleId" ON "AspNetUserRoles" ("RoleId");
 CREATE INDEX "EmailIndex" ON "AspNetUsers" ("NormalizedEmail");
 
 CREATE UNIQUE INDEX "UserNameIndex" ON "AspNetUsers" ("NormalizedUserName");
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20250617125725_InitialCreate', '8.0.4');
 
 COMMIT;
 


### PR DESCRIPTION
## Summary
- remove __EFMigrationsHistory references from `V1__InitialCreate.sql`
- bump Flyway version used in the CD workflow to 11.9.1

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685196b821ac83288561bfc933bc795d