### PR TITLE
Implement email subscription feature

### DIFF
--- a/Predictorator.Tests/SubscriptionControllerTests.cs
+++ b/Predictorator.Tests/SubscriptionControllerTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Predictorator.Data;
+using Predictorator.Services;
+using Predictorator.Models;
+
+namespace Predictorator.Tests;
+
+public class SubscriptionControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public SubscriptionControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase("SubDb"));
+                services.RemoveAll(typeof(IEmailService));
+                var email = Substitute.For<IEmailService>();
+                services.AddSingleton(email);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Get_Subscribe_Returns_OK()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/Subscription/Subscribe");
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task Post_Subscribe_Creates_Subscriber()
+    {
+        var client = _factory.CreateClient();
+        var content = new FormUrlEncodedContent(new Dictionary<string, string> { ["email"] = "test@example.com" });
+        var response = await client.PostAsync("/Subscription/Subscribe", content);
+        response.EnsureSuccessStatusCode();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var sub = await db.Subscribers.FirstOrDefaultAsync(s => s.Email == "test@example.com");
+        Assert.NotNull(sub);
+    }
+}

--- a/Predictorator/Controllers/SubscriptionController.cs
+++ b/Predictorator/Controllers/SubscriptionController.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Mvc;
+using Predictorator.Services;
+
+namespace Predictorator.Controllers;
+
+public class SubscriptionController : Controller
+{
+    private readonly ISubscriberService _subscriberService;
+    private readonly IEmailService _emailService;
+    private readonly IConfiguration _config;
+
+    public SubscriptionController(ISubscriberService subscriberService, IEmailService emailService, IConfiguration config)
+    {
+        _subscriberService = subscriberService;
+        _emailService = emailService;
+        _config = config;
+    }
+
+    [HttpGet]
+    public IActionResult Subscribe()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Subscribe(string email)
+    {
+        if (!new System.ComponentModel.DataAnnotations.EmailAddressAttribute().IsValid(email))
+        {
+            ModelState.AddModelError("email", "Invalid email");
+            return View();
+        }
+        var sub = await _subscriberService.AddAsync(email);
+        var baseUrl = _config["BaseUrl"] ?? $"{Request.Scheme}://{Request.Host}";
+        var verifyLink = $"{baseUrl}/Subscription/Verify?token={sub.Token}";
+        await _emailService.SendVerificationEmailAsync(email, verifyLink);
+        ViewData["Message"] = "Please check your email to verify.";
+        return View("SubscribeResult");
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Verify(Guid token)
+    {
+        var sub = await _subscriberService.GetByTokenAsync(token);
+        if (sub == null) return NotFound();
+        await _subscriberService.VerifyAsync(sub);
+        ViewData["Message"] = "Email verified!";
+        var baseUrl = _config["BaseUrl"] ?? $"{Request.Scheme}://{Request.Host}";
+        var unsubscribe = $"{baseUrl}/Subscription/Unsubscribe?token={token}";
+        await _emailService.SendUnsubscribeEmailAsync(sub.Email, unsubscribe);
+        return View("SubscribeResult");
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Unsubscribe(Guid token)
+    {
+        var sub = await _subscriberService.GetByTokenAsync(token);
+        if (sub == null) return NotFound();
+        await _subscriberService.UnsubscribeAsync(sub);
+        ViewData["Message"] = "You have been unsubscribed.";
+        return View("SubscribeResult");
+    }
+}

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -4,10 +4,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Predictorator.Data;
 
+using Predictorator.Models;
+
 public class ApplicationDbContext : IdentityDbContext<IdentityUser>
 {
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
     {
     }
+
+    public DbSet<Subscriber> Subscribers => Set<Subscriber>();
 }

--- a/Predictorator/Models/Subscriber.cs
+++ b/Predictorator/Models/Subscriber.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Predictorator.Models;
+
+public class Subscriber
+{
+    public int Id { get; set; }
+
+    [EmailAddress]
+    public required string Email { get; set; }
+
+    public bool Verified { get; set; }
+
+    public Guid Token { get; set; }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -21,6 +21,8 @@ builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
 builder.Services.AddSingleton<IRateLimitService>(sp =>
     new InMemoryRateLimitService(100, TimeSpan.FromDays(1), sp.GetRequiredService<IDateTimeProvider>()));
 builder.Services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
+builder.Services.AddTransient<ISubscriberService, SubscriberService>();
+builder.Services.AddHttpClient<IEmailService, ResendEmailService>();
 
 var dbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "predictorator.db");
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!.Replace("%DB_PATH%", dbPath);

--- a/Predictorator/Services/IEmailService.cs
+++ b/Predictorator/Services/IEmailService.cs
@@ -1,0 +1,7 @@
+namespace Predictorator.Services;
+
+public interface IEmailService
+{
+    Task SendVerificationEmailAsync(string to, string link);
+    Task SendUnsubscribeEmailAsync(string to, string link);
+}

--- a/Predictorator/Services/ISubscriberService.cs
+++ b/Predictorator/Services/ISubscriberService.cs
@@ -1,0 +1,11 @@
+using Predictorator.Models;
+
+namespace Predictorator.Services;
+
+public interface ISubscriberService
+{
+    Task<Subscriber?> GetByTokenAsync(Guid token);
+    Task<Subscriber> AddAsync(string email);
+    Task VerifyAsync(Subscriber subscriber);
+    Task UnsubscribeAsync(Subscriber subscriber);
+}

--- a/Predictorator/Services/ResendEmailService.cs
+++ b/Predictorator/Services/ResendEmailService.cs
@@ -1,0 +1,51 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+
+namespace Predictorator.Services;
+
+public class ResendEmailService : IEmailService
+{
+    private readonly HttpClient _client;
+    private readonly string _from;
+
+    public ResendEmailService(HttpClient client, IConfiguration configuration)
+    {
+        _client = client;
+        _client.BaseAddress = new Uri("https://api.resend.com/");
+        var apiKey = configuration["Resend:ApiKey"];
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        }
+        _from = configuration["Resend:From"] ?? "no-reply@example.com";
+    }
+
+    public Task SendVerificationEmailAsync(string to, string link)
+    {
+        var subject = "Verify your email";
+        var html = $"<p>Please verify your email by <a href='{link}'>clicking here</a>.</p>";
+        return SendAsync(to, subject, html);
+    }
+
+    public Task SendUnsubscribeEmailAsync(string to, string link)
+    {
+        var subject = "Unsubscribe";
+        var html = $"<p>If you wish to unsubscribe click <a href='{link}'>here</a>.</p>";
+        return SendAsync(to, subject, html);
+    }
+
+    private async Task SendAsync(string to, string subject, string html)
+    {
+        var content = new
+        {
+            from = _from,
+            to,
+            subject,
+            html
+        };
+        var json = JsonSerializer.Serialize(content);
+        using var stringContent = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+        await _client.PostAsync("emails", stringContent);
+    }
+}

--- a/Predictorator/Services/SubscriberService.cs
+++ b/Predictorator/Services/SubscriberService.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Data;
+using Predictorator.Models;
+
+namespace Predictorator.Services;
+
+public class SubscriberService : ISubscriberService
+{
+    private readonly ApplicationDbContext _db;
+
+    public SubscriberService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Subscriber> AddAsync(string email)
+    {
+        var subscriber = await _db.Set<Subscriber>().FirstOrDefaultAsync(x => x.Email == email);
+        if (subscriber == null)
+        {
+            subscriber = new Subscriber { Email = email, Token = Guid.NewGuid(), Verified = false };
+            _db.Add(subscriber);
+            await _db.SaveChangesAsync();
+        }
+        return subscriber;
+    }
+
+    public Task<Subscriber?> GetByTokenAsync(Guid token) =>
+        _db.Set<Subscriber>().FirstOrDefaultAsync(x => x.Token == token);
+
+    public async Task VerifyAsync(Subscriber subscriber)
+    {
+        subscriber.Verified = true;
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task UnsubscribeAsync(Subscriber subscriber)
+    {
+        _db.Remove(subscriber);
+        await _db.SaveChangesAsync();
+    }
+}

--- a/Predictorator/Views/Shared/_Layout.cshtml
+++ b/Predictorator/Views/Shared/_Layout.cshtml
@@ -30,6 +30,7 @@
     <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
         <div class="container-fluid">
             <a class="navbar-brand header" asp-area="" asp-controller="Home" asp-action="Index">Predictotronix</a>
+            <a class="nav-link" asp-controller="Subscription" asp-action="Subscribe">Subscribe</a>
             @if (User.Identity?.IsAuthenticated == true && User.IsInRole("Admin"))
             {
                 <a class="nav-link" asp-controller="Admin" asp-action="SendNotification">Admin</a>

--- a/Predictorator/Views/Subscription/Subscribe.cshtml
+++ b/Predictorator/Views/Subscription/Subscribe.cshtml
@@ -1,0 +1,12 @@
+@{
+    ViewData["Title"] = "Subscribe";
+}
+
+<h2>Subscribe</h2>
+<form method="post">
+    <div class="mb-3">
+        <label for="email" class="form-label">Email</label>
+        <input type="email" class="form-control" id="email" name="email" required />
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>

--- a/Predictorator/Views/Subscription/SubscribeResult.cshtml
+++ b/Predictorator/Views/Subscription/SubscribeResult.cshtml
@@ -1,0 +1,4 @@
+@{
+    ViewData["Title"] = "Subscription";
+}
+<p>@ViewData["Message"]</p>

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -11,5 +11,9 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=%DB_PATH%"
+  },
+  "Resend": {
+    "ApiKey": "your-api-key",
+    "From": "no-reply@example.com"
   }
 }

--- a/flyway/sql/V2__CreateSubscribers.sql
+++ b/flyway/sql/V2__CreateSubscribers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "Subscribers" (
+    "Id" INTEGER PRIMARY KEY AUTOINCREMENT,
+    "Email" TEXT NOT NULL,
+    "Verified" INTEGER NOT NULL,
+    "Token" TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_Subscribers_Email" ON "Subscribers" ("Email");


### PR DESCRIPTION
## Summary
- add a `Subscriber` entity and DB migration
- implement email services using Resend API
- create subscription controller and views
- expose Subscribe link in layout
- wire up services in Program.cs
- add integration tests for subscription flow

## Testing
- `dotnet format Predictorator.sln --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685198e883dc8328a36d553d06b6f8c0