### PR TITLE
Add subscriber verification workflow

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -70,4 +70,12 @@ public class HomePageTests
             Assert.Pass("No test token provided; skipping row check.");
         }
     }
+
+    [Test]
+    public async Task SubscribePage_Should_Display_Form()
+    {
+        await _page!.GotoAsync($"{BaseUrl}/Subscription/Subscribe");
+        var header = await _page.TextContentAsync("h2");
+        Assert.That(header, Is.EqualTo("Subscribe to Notifications"));
+    }
 }

--- a/Predictorator/Controllers/SubscriptionController.cs
+++ b/Predictorator/Controllers/SubscriptionController.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Predictorator.Services;
+
+namespace Predictorator.Controllers;
+
+public class SubscriptionController : Controller
+{
+    private readonly SubscriptionService _service;
+
+    public SubscriptionController(SubscriptionService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public IActionResult Subscribe()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Subscribe(string email)
+    {
+        if (!new EmailAddressAttribute().IsValid(email))
+        {
+            ModelState.AddModelError("email", "Invalid email");
+            return View();
+        }
+
+        var baseUrl = $"{Request.Scheme}://{Request.Host}";
+        await _service.AddSubscriberAsync(email, baseUrl);
+        return View("CheckEmail");
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Verify(string token)
+    {
+        var result = await _service.VerifyAsync(token);
+        return View(model: result);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Unsubscribe(string token)
+    {
+        var result = await _service.UnsubscribeAsync(token);
+        return View(model: result);
+    }
+}

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Predictorator.Models;
 
 namespace Predictorator.Data;
 
@@ -10,4 +11,6 @@ public class ApplicationDbContext : IdentityDbContext<IdentityUser>
         : base(options)
     {
     }
+
+    public DbSet<Subscriber> Subscribers => Set<Subscriber>();
 }

--- a/Predictorator/Models/Subscriber.cs
+++ b/Predictorator/Models/Subscriber.cs
@@ -1,0 +1,11 @@
+namespace Predictorator.Models;
+
+public class Subscriber
+{
+    public int Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public bool IsVerified { get; set; }
+    public string VerificationToken { get; set; } = string.Empty;
+    public string UnsubscribeToken { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.4" />
+    <PackageReference Include="Resend" Version="0.1.4" />
   </ItemGroup>
 
 </Project>

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Predictorator.Data;
 using Predictorator.Middleware;
 using Predictorator.Services;
+using Resend;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +22,13 @@ builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
 builder.Services.AddSingleton<IRateLimitService>(sp =>
     new InMemoryRateLimitService(100, TimeSpan.FromDays(1), sp.GetRequiredService<IDateTimeProvider>()));
 builder.Services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
+builder.Services.AddHttpClient<Resend.ResendClient>();
+builder.Services.Configure<Resend.ResendClientOptions>(o =>
+{
+    o.ApiToken = builder.Configuration["Resend:ApiToken"]!;
+});
+builder.Services.AddTransient<Resend.IResend, Resend.ResendClient>();
+builder.Services.AddTransient<SubscriptionService>();
 
 var dbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "predictorator.db");
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!.Replace("%DB_PATH%", dbPath);

--- a/Predictorator/Services/SubscriptionService.cs
+++ b/Predictorator/Services/SubscriptionService.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using Resend;
+using Predictorator.Data;
+using Predictorator.Models;
+
+namespace Predictorator.Services;
+
+public class SubscriptionService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IResend _resend;
+    private readonly IConfiguration _config;
+
+    public SubscriptionService(ApplicationDbContext db, IResend resend, IConfiguration config)
+    {
+        _db = db;
+        _resend = resend;
+        _config = config;
+    }
+
+    public async Task AddSubscriberAsync(string email, string baseUrl)
+    {
+        if (await _db.Subscribers.AnyAsync(s => s.Email == email))
+            return;
+
+        var subscriber = new Subscriber
+        {
+            Email = email,
+            IsVerified = false,
+            VerificationToken = Guid.NewGuid().ToString("N"),
+            UnsubscribeToken = Guid.NewGuid().ToString("N"),
+            CreatedAt = DateTime.UtcNow
+        };
+        _db.Subscribers.Add(subscriber);
+        await _db.SaveChangesAsync();
+
+        var verifyLink = $"{baseUrl}/Subscription/Verify?token={subscriber.VerificationToken}";
+        var unsubscribeLink = $"{baseUrl}/Subscription/Unsubscribe?token={subscriber.UnsubscribeToken}";
+
+        var message = new EmailMessage
+        {
+            From = _config["Resend:From"] ?? "no-reply@example.com",
+            Subject = "Verify your email",
+            HtmlBody = $"<p>Please <a href=\"{verifyLink}\">verify your email</a>.</p><p>If you did not request this, you can <a href=\"{unsubscribeLink}\">unsubscribe</a>.</p>"
+        };
+        message.To.Add(email);
+
+        await _resend.EmailSendAsync(message);
+    }
+
+    public async Task<bool> VerifyAsync(string token)
+    {
+        var subscriber = await _db.Subscribers.FirstOrDefaultAsync(s => s.VerificationToken == token);
+        if (subscriber == null) return false;
+        subscriber.IsVerified = true;
+        await _db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> UnsubscribeAsync(string token)
+    {
+        var subscriber = await _db.Subscribers.FirstOrDefaultAsync(s => s.UnsubscribeToken == token);
+        if (subscriber == null) return false;
+        _db.Subscribers.Remove(subscriber);
+        await _db.SaveChangesAsync();
+        return true;
+    }
+}

--- a/Predictorator/Views/Shared/_Layout.cshtml
+++ b/Predictorator/Views/Shared/_Layout.cshtml
@@ -34,6 +34,7 @@
             {
                 <a class="nav-link" asp-controller="Admin" asp-action="SendNotification">Admin</a>
             }
+            <a class="nav-link" asp-controller="Subscription" asp-action="Subscribe">Subscribe</a>
             <button id="darkModeToggle" class="btn btn-outline-secondary ms-auto">Dark Mode</button>
         </div>
     </nav>

--- a/Predictorator/Views/Subscription/CheckEmail.cshtml
+++ b/Predictorator/Views/Subscription/CheckEmail.cshtml
@@ -1,0 +1,5 @@
+@{
+    ViewData["Title"] = "Check Your Email";
+}
+<h2>@ViewData["Title"]</h2>
+<p>A verification link has been sent to your email address.</p>

--- a/Predictorator/Views/Subscription/Subscribe.cshtml
+++ b/Predictorator/Views/Subscription/Subscribe.cshtml
@@ -1,0 +1,11 @@
+@{
+    ViewData["Title"] = "Subscribe to Notifications";
+}
+<h2>@ViewData["Title"]</h2>
+<form method="post">
+    <div class="mb-3">
+        <label for="email" class="form-label">Email address</label>
+        <input type="email" class="form-control" id="email" name="email" required />
+    </div>
+    <button type="submit" class="btn btn-primary">Subscribe</button>
+</form>

--- a/Predictorator/Views/Subscription/Unsubscribe.cshtml
+++ b/Predictorator/Views/Subscription/Unsubscribe.cshtml
@@ -1,0 +1,13 @@
+@model bool
+@{
+    ViewData["Title"] = "Unsubscribe";
+}
+<h2>@ViewData["Title"]</h2>
+@if (Model)
+{
+    <p>You have been unsubscribed.</p>
+}
+else
+{
+    <p>Invalid unsubscribe link.</p>
+}

--- a/Predictorator/Views/Subscription/Verify.cshtml
+++ b/Predictorator/Views/Subscription/Verify.cshtml
@@ -1,0 +1,13 @@
+@model bool
+@{
+    ViewData["Title"] = "Verification";
+}
+<h2>@ViewData["Title"]</h2>
+@if (Model)
+{
+    <p>Your email has been verified.</p>
+}
+else
+{
+    <p>Invalid verification link.</p>
+}

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -11,5 +11,9 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=%DB_PATH%"
+  },
+  "Resend": {
+    "ApiToken": "",
+    "From": "no-reply@example.com"
   }
 }

--- a/flyway/sql/V2__AddSubscribers.sql
+++ b/flyway/sql/V2__AddSubscribers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "Subscribers" (
+    "Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "Email" TEXT NOT NULL,
+    "IsVerified" INTEGER NOT NULL,
+    "VerificationToken" TEXT NOT NULL,
+    "UnsubscribeToken" TEXT NOT NULL,
+    "CreatedAt" TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- enable Resend integration and subscriber service
- allow subscribing/unsubscribing to notifications
- create subscription views and controller
- add flyway migration for `Subscribers` table
- show Subscribe link in layout
- test that the subscribe page loads

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685198e883dc8328a36d553d06b6f8c0