### PR TITLE
Fix web app deploy path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           app-name: 'predictorator5000'
           slot-name: 'Production'
-          package: ./
+          package: ./app/publish
       - name: Get publish profile
         id: get_profile
         run: |


### PR DESCRIPTION
## Summary
- correct the `package` path in the deployment step

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68527548d608832889c0b58ecaf0f46f