### PR TITLE
Fix deploy path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           app-name: 'predictorator5000'
           slot-name: 'Production'
-          package: ./app/publish
+          package: ./app
       - name: Get publish profile
         id: get_profile
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS Instructions
 
 The following guidelines apply to the entire repository and inform how Codex should work.
+This repository hosts a Blazor Server-Side Rendering (SSR) application.
 
 ## Development workflow
 


### PR DESCRIPTION
## Summary
- fix the app package path for the production deploy step
- note that the repo contains a Blazor SSR app

## Testing
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685277d169e88328a3651c741e7c87b4