### PR TITLE
Fix .NET 9 install in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          global-json-file: global.json
+          include-prerelease: true
       - name: Build
         run: dotnet build Predictorator.sln --configuration Release
       - name: Publish
@@ -88,7 +89,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          global-json-file: global.json
+          include-prerelease: true
       - name: Build tests
         run: dotnet build Predictorator.sln --configuration Release
       - name: Install Playwright browsers

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          global-json-file: global.json
+          include-prerelease: true
       - name: Restore
         run: dotnet restore Predictorator.sln
       - name: Run unit tests


### PR DESCRIPTION
## Summary
- set up `actions/setup-dotnet` to respect `global.json`
- enable prerelease install for .NET 9 preview

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln --verbosity minimal`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68529c8ae42c8328b8f244e89f315c31