### PR TITLE
Fix publish step by using artifact

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,11 @@ jobs:
         run: dotnet build Predictorator.sln --configuration Release
       - name: Publish
         run: dotnet publish Predictorator/Predictorator.csproj -c Release -o publish
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app
+          path: publish
 
   deploy_prod:
     runs-on: ubuntu-latest
@@ -32,8 +37,9 @@ jobs:
       url: ${{ steps.deploy.outputs.webapp-url }}
     steps:
       - uses: actions/checkout@v4
-      - name: Publish
-        run: dotnet publish Predictorator/Predictorator.csproj -c Release -o publish
+      - uses: actions/download-artifact@v4
+        with:
+          name: app
       - uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_2687F5A3498747E1A95ADE36D92A159E }}
@@ -45,7 +51,7 @@ jobs:
         with:
           app-name: 'predictorator5000'
           slot-name: 'Production'
-          package: ./publish
+          package: ./app
       - name: Get publish profile
         id: get_profile
         run: |


### PR DESCRIPTION
## Summary
- revert to using artifacts for CD deploy so publish happens once in build

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6852a02594d083289ecada44e7a29c13