### PR TITLE
Add maintenance screen for deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,12 @@ jobs:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_2687F5A3498747E1A95ADE36D92A159E }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_F68BC6B164FA4A818B4561CE37FB31B5 }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_E02E41A1857446D5AE38550D3A7CF31C }}
+      - name: Enable maintenance mode
+        run: |
+          RG=$(az webapp list --query "[?name=='predictorator5000'].resourceGroup" -o tsv)
+          az webapp config appsettings set \
+            --name predictorator5000 --resource-group "$RG" \
+            --settings Maintenance__Enabled=true
       - name: Deploy to production
         id: deploy
         uses: azure/webapps-deploy@v3
@@ -83,6 +89,12 @@ jobs:
           curl -T predictorator.db \
             -H "Authorization: Basic ${{ steps.get_profile.outputs.auth }}" \
             "${{ steps.get_profile.outputs.scm_url }}/api/vfs/home/.local/share/predictorator.db"
+      - name: Disable maintenance mode
+        run: |
+          RG=$(az webapp list --query "[?name=='predictorator5000'].resourceGroup" -o tsv)
+          az webapp config appsettings set \
+            --name predictorator5000 --resource-group "$RG" \
+            --settings Maintenance__Enabled=false
 
   tests:
     runs-on: ubuntu-latest

--- a/Predictorator.Tests/MaintenanceMiddlewareTests.cs
+++ b/Predictorator.Tests/MaintenanceMiddlewareTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Predictorator.Middleware;
+
+namespace Predictorator.Tests;
+
+public class MaintenanceMiddlewareTests
+{
+    [Fact]
+    public async Task Returns_503_when_enabled()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "maintenance.html"), "test");
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.WebRootPath.Returns(tempDir);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Maintenance:Enabled"] = "true" })
+            .Build();
+
+        var middleware = new MaintenanceMiddleware(_ => Task.CompletedTask, config, env);
+        var context = new DefaultHttpContext();
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invokes_next_when_disabled()
+    {
+        var env = Substitute.For<IWebHostEnvironment>();
+        var config = new ConfigurationBuilder().Build();
+        var called = false;
+        var middleware = new MaintenanceMiddleware(_ => { called = true; return Task.CompletedTask; }, config, env);
+        var context = new DefaultHttpContext();
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(called);
+    }
+}

--- a/Predictorator/Middleware/MaintenanceMiddleware.cs
+++ b/Predictorator/Middleware/MaintenanceMiddleware.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace Predictorator.Middleware;
+
+public class MaintenanceMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IConfiguration _configuration;
+    private readonly IWebHostEnvironment _environment;
+
+    public MaintenanceMiddleware(RequestDelegate next, IConfiguration configuration, IWebHostEnvironment environment)
+    {
+        _next = next;
+        _configuration = configuration;
+        _environment = environment;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (_configuration.GetValue<bool>("Maintenance:Enabled"))
+        {
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            context.Response.ContentType = "text/html; charset=utf-8";
+            var file = Path.Combine(_environment.WebRootPath ?? "wwwroot", "maintenance.html");
+            await context.Response.SendFileAsync(file);
+            return;
+        }
+
+        await _next(context);
+    }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -53,6 +53,7 @@ builder.Services.AddRazorPages();
 var app = builder.Build();
 
 app.UseMiddleware<RateLimitingMiddleware>();
+app.UseMiddleware<MaintenanceMiddleware>();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/Predictorator/wwwroot/maintenance.html
+++ b/Predictorator/wwwroot/maintenance.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Maintenance</title>
+    <link href="css/site.css" rel="stylesheet" />
+</head>
+<body class="d-flex flex-column align-items-center justify-content-center" style="height:100vh;">
+    <h1>We'll be back soon!</h1>
+    <p>The site is undergoing maintenance. Please check back later.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show a maintenance page when `Maintenance:Enabled` is set
- serve static `maintenance.html` and add new middleware
- enable/disable maintenance mode during deployment
- test middleware logic

## Testing
- `dotnet test Predictorator.sln --configuration Release`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6852a3bf8c5083288bcf65672215f7f4