### PR TITLE
Fix artifact download path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: app
+          path: ./app
       - uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_2687F5A3498747E1A95ADE36D92A159E }}


### PR DESCRIPTION
## Summary
- adjust CD workflow to specify artifact extraction path

## Testing
- `dotnet format --no-restore` *(fails: `dotnet: command not found`)*
- `dotnet restore Predictorator.sln` *(fails: `dotnet: command not found`)*
- `dotnet test Predictorator.sln` *(fails: `dotnet: command not found`)*
- `dotnet build Predictorator.sln -c Release -warnaserror` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852af6ab8788328891a54dffd888dea