### PR TITLE
Fix deploy error with cleanup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,7 @@ jobs:
           app-name: 'predictorator5000'
           slot-name: 'Production'
           package: ./app
+          clean: true
       - name: Get publish profile
         id: get_profile
         run: |


### PR DESCRIPTION
## Summary
- remove old site files before deploying to Azure

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6852c0c9192883289b8336b9c0c65b39