### PR TITLE
Fix deployment conflicts

### DIFF
--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Avoid generating platform-specific host executable to prevent
+         conflicts with the source directory during deployment -->
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- disable app host to avoid conflicts during Kudu sync

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6852c37eb9e0832896e2c16534573173