### PR TITLE
Switch to SQL Server DB

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,25 +72,6 @@ jobs:
           auth=$(jq -r '.[0].userName + ":" + .[0].userPWD' profile.json | base64)
           echo "auth=$auth" >> "$GITHUB_OUTPUT"
 
-      - name: Download database
-        run: |
-          curl -f -L -o predictorator.db \
-            -H "Authorization: Basic ${{ steps.get_profile.outputs.auth }}" \
-            "${{ steps.get_profile.outputs.scm_url }}/api/vfs/home/.local/share/predictorator.db" \
-            || touch predictorator.db
-
-      - name: Run Flyway migrations
-        uses: joshuaavalon/flyway-action@v3.0.0
-        with:
-          url: 'jdbc:sqlite:predictorator.db'
-          locations: 'filesystem:./flyway/sql'
-          flyway-version: '11.9.1'
-
-      - name: Upload database
-        run: |
-          curl -T predictorator.db \
-            -H "Authorization: Basic ${{ steps.get_profile.outputs.auth }}" \
-            "${{ steps.get_profile.outputs.scm_url }}/api/vfs/home/.local/share/predictorator.db"
       - name: Disable maintenance mode
         run: |
           RG=$(az webapp list --query "[?name=='predictorator5000'].resourceGroup" -o tsv)

--- a/Predictorator/Data/ApplicationDbInitializer.cs
+++ b/Predictorator/Data/ApplicationDbInitializer.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace Predictorator.Data;
 
@@ -7,6 +8,8 @@ public static class ApplicationDbInitializer
     public static async Task SeedAdminUserAsync(IServiceProvider serviceProvider)
     {
         using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await context.Database.EnsureCreatedAsync();
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
         var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
 

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.6" />
     <PackageReference Include="MudBlazor" Version="7.2.0" />

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -70,10 +70,9 @@ builder.Services.Configure<Resend.ResendClientOptions>(o =>
 builder.Services.AddTransient<Resend.IResend, Resend.ResendClient>();
 builder.Services.AddTransient<SubscriptionService>();
 
-var dbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "predictorator.db");
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!.Replace("%DB_PATH%", dbPath);
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!;
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseSqlite(connectionString));
+    options.UseSqlServer(connectionString));
 builder.Services.AddIdentity<IdentityUser, IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultUI()

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -10,7 +10,7 @@
     "TestToken": "test-token"
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=%DB_PATH%"
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=Predictorator;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Resend": {
     "ApiToken": "",

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Predictorator5000
+
+This repository hosts a Blazor Server application. To run the application locally:
+
+```bash
+dotnet run --project Predictorator/Predictorator.csproj
+```
+
+Tests can be executed with:
+
+```bash
+dotnet test Predictorator.sln
+```


### PR DESCRIPTION
## Summary
- use SQL Server instead of SQLite
- create DB automatically on startup
- remove Flyway steps from CD pipeline
- add a basic README

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln --verbosity minimal`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6852ec08b8d48328b0bf4488e832838f