### PR TITLE
Use env vars for admin seed

### DIFF
--- a/Predictorator/Data/ApplicationDbInitializer.cs
+++ b/Predictorator/Data/ApplicationDbInitializer.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Predictorator.Options;
 
 namespace Predictorator.Data;
 
@@ -14,12 +16,10 @@ public static class ApplicationDbInitializer
         var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
 
         const string adminRole = "Admin";
-        var adminEmail =
-            Environment.GetEnvironmentVariable("ADMIN_EMAIL") ??
-            "admin@example.com";
-        var adminPassword =
-            Environment.GetEnvironmentVariable("ADMIN_PASSWORD") ??
-            "Admin123!";
+        var options = scope.ServiceProvider
+            .GetRequiredService<IOptions<AdminUserOptions>>().Value;
+        var adminEmail = options.Email;
+        var adminPassword = options.Password;
 
         if (!await roleManager.RoleExistsAsync(adminRole))
         {

--- a/Predictorator/Options/AdminUserOptions.cs
+++ b/Predictorator/Options/AdminUserOptions.cs
@@ -1,0 +1,10 @@
+namespace Predictorator.Options;
+
+public class AdminUserOptions
+{
+    public const string SectionName = "AdminUser";
+
+    public string Email { get; set; } = "admin@example.com";
+
+    public string Password { get; set; } = "Admin123!";
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -9,6 +9,7 @@ using MudBlazor.Services;
 using Microsoft.Extensions.Caching.Hybrid;
 using Resend;
 using Predictorator.Startup;
+using Predictorator.Options;
 using Serilog;
 using Serilog.Events;
 
@@ -69,6 +70,12 @@ builder.Services.Configure<Resend.ResendClientOptions>(o =>
 });
 builder.Services.AddTransient<Resend.IResend, Resend.ResendClient>();
 builder.Services.AddTransient<SubscriptionService>();
+builder.Services.Configure<AdminUserOptions>(options =>
+{
+    builder.Configuration.GetSection(AdminUserOptions.SectionName).Bind(options);
+    options.Email = builder.Configuration["ADMIN_EMAIL"] ?? options.Email;
+    options.Password = builder.Configuration["ADMIN_PASSWORD"] ?? options.Password;
+});
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!;
 builder.Services.AddDbContext<ApplicationDbContext>(options =>

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -15,5 +15,9 @@
   "Resend": {
     "ApiToken": "",
     "From": "no-reply@example.com"
+  },
+  "AdminUser": {
+    "Email": "admin@example.com",
+    "Password": "Admin123!"
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Tests can be executed with:
 dotnet test Predictorator.sln
 ```
 
-Admin user credentials can be customized by setting `ADMIN_EMAIL` and
+The seeded admin account credentials are configured via `AdminUser` settings.
+You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application.


### PR DESCRIPTION
## Summary
- configure seeding to read credentials from `ADMIN_EMAIL` and `ADMIN_PASSWORD`
- document admin user environment variables

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6852ee6df4e0832892eff281b5a80da6