### PR TITLE
Fix admin seeding failure

### DIFF
--- a/Predictorator.Tests/AdminUserSeedingTests.cs
+++ b/Predictorator.Tests/AdminUserSeedingTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using Predictorator.Data;
+using Predictorator.Options;
+
+namespace Predictorator.Tests;
+
+public class AdminUserSeedingTests
+{
+    private static ServiceProvider BuildServices(Action<IdentityOptions>? identityOpts, string email, string password)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddIdentity<IdentityUser, IdentityRole>(identityOpts ?? (_ => { }))
+            .AddEntityFrameworkStores<ApplicationDbContext>();
+        services.Configure<AdminUserOptions>(o => { o.Email = email; o.Password = password; });
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task Throws_when_creation_fails()
+    {
+        using var provider = BuildServices(opts =>
+        {
+            opts.Password.RequireDigit = false;
+            opts.Password.RequireLowercase = false;
+            opts.Password.RequireUppercase = false;
+            opts.Password.RequireNonAlphanumeric = false;
+            opts.Password.RequiredLength = 10;
+        }, "admin@example.com", "short");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ApplicationDbInitializer.SeedAdminUserAsync(provider));
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test covering admin user seeding errors

## Testing
- `dotnet format Predictorator.sln --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685313933dfc8328ac9ea3695d7ca95d