### PR TITLE
Handle DB init failures gracefully

### DIFF
--- a/Predictorator.Tests/AdminUserSeedingTests.cs
+++ b/Predictorator.Tests/AdminUserSeedingTests.cs
@@ -35,4 +35,25 @@ public class AdminUserSeedingTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => ApplicationDbInitializer.SeedAdminUserAsync(provider));
     }
+
+    [Fact]
+    public async Task Does_not_throw_when_database_unavailable()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseSqlServer("Server=localhost;Database=invalid;" +
+                                  "User Id=sa;Password=bad;Connect Timeout=1"));
+        services.AddIdentity<IdentityUser, IdentityRole>()
+            .AddEntityFrameworkStores<ApplicationDbContext>();
+        services.Configure<AdminUserOptions>(o =>
+        {
+            o.Email = "admin@example.com";
+            o.Password = "Admin123!";
+        });
+        await using var provider = services.BuildServiceProvider();
+
+        await ApplicationDbInitializer.SeedAdminUserAsync(provider);
+    }
 }
+

--- a/Predictorator/Data/ApplicationDbInitializer.cs
+++ b/Predictorator/Data/ApplicationDbInitializer.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
 using Predictorator.Options;
 using System.Linq;
 
@@ -11,8 +12,19 @@ public static class ApplicationDbInitializer
     public static async Task SeedAdminUserAsync(IServiceProvider serviceProvider)
     {
         using var scope = serviceProvider.CreateScope();
+        var logger = scope.ServiceProvider
+            .GetService<ILoggerFactory>()?
+            .CreateLogger("ApplicationDbInitializer");
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        await context.Database.EnsureCreatedAsync();
+        try
+        {
+            await context.Database.EnsureCreatedAsync();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Unable to connect to database");
+            return;
+        }
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
         var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
 


### PR DESCRIPTION
## Summary
- stop app startup from crashing when the database can't be reached
- test that database failures during startup do not throw exceptions

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68531d7d90d48328b7dc445d1042d6f9