### PR TITLE
Restore date filters and layout

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -1,9 +1,18 @@
 @inherits LayoutComponentBase
+@inject IHttpContextAccessor HttpContextAccessor
 <MudLayout>
     <MudAppBar Elevation="0" Color="Color.Primary">
-        <MudText Typo="Typo.h5" Class="ml-2">Predictotronix</MudText>
-        <MudSpacer />
-        <MudLink Href="/Subscription/Subscribe">Subscribe</MudLink>
+        <div class="container-fluid d-flex align-items-center">
+            <MudText Typo="Typo.h5" Class="navbar-brand header">Predictotronix</MudText>
+            @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
+                HttpContextAccessor.HttpContext.User.IsInRole("Admin"))
+            {
+                <MudLink Href="/mvc/Admin/SendNotification" Class="nav-link">Admin</MudLink>
+            }
+            <MudLink Href="/mvc/Subscription/Subscribe" Class="nav-link">Subscribe</MudLink>
+            <MudSpacer />
+            <MudButton Variant="Variant.Outlined" UserAttributes="@(new Dictionary<string, object> { { "id", "darkModeToggle" } })">Dark Mode</MudButton>
+        </div>
     </MudAppBar>
     <MudMainContent>
         <div class="container mt-4">

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -1,8 +1,26 @@
 @page "/"
+@using Microsoft.AspNetCore.WebUtilities
+@inject NavigationManager NavigationManager
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
 
 <h1>Premier League Fixtures</h1>
+
+@if (_autoWeek)
+{
+    <div>
+        <MudIconButton Icon="@Icons.Material.Filled.ArrowBack" Class="weekJump" OnClick="@(() => ChangeWeek(-1))" />
+        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Class="weekJump" OnClick="@(() => ChangeWeek(1))" />
+    </div>
+}
+
+<MudExpansionPanels Class="mb-4">
+    <MudExpansionPanel Text="@($"{_fromDate:dd/MM/yyyy} - {_toDate:dd/MM/yyyy}")">
+        <MudDatePicker @bind-Date="_fromDate" Label="From" Class="me-2" PickerVariant="PickerVariant.Static" />
+        <MudDatePicker @bind-Date="_toDate" Label="To" Class="me-2" PickerVariant="PickerVariant.Static" />
+        <MudButton OnClick="Reload" Color="Color.Primary" Variant="Variant.Filled" Class="mt-2">Reload</MudButton>
+    </MudExpansionPanel>
+</MudExpansionPanels>
 
 @if (_fixtures == null)
 {
@@ -61,10 +79,42 @@ else if (_fixtures.Response.Any())
 
 @code {
     private FixturesResponse? _fixtures;
+    private DateTime? _fromDate;
+    private DateTime? _toDate;
+    private bool _autoWeek;
+    private int _currentWeekOffset;
 
-    protected override async Task OnInitializedAsync()
+    [Parameter, SupplyParameterFromQuery(Name = "fromDate")] public DateTime? FromDate { get; set; }
+    [Parameter, SupplyParameterFromQuery(Name = "toDate")] public DateTime? ToDate { get; set; }
+    [Parameter, SupplyParameterFromQuery(Name = "weekOffset")] public int? WeekOffset { get; set; }
+
+    protected override async Task OnParametersSetAsync()
     {
-        var (from, to) = DateRangeCalculator.GetDates(null, null, null);
+        var (from, to) = DateRangeCalculator.GetDates(FromDate, ToDate, WeekOffset);
+        _fromDate = from;
+        _toDate = to;
+        _currentWeekOffset = WeekOffset ?? 0;
+        _autoWeek = FromDate == null && ToDate == null;
         _fixtures = await FixtureService.GetFixturesAsync(from, to);
+    }
+
+    private void Reload()
+    {
+        var uri = QueryHelpers.AddQueryString("/", new Dictionary<string, string?>
+        {
+            ["fromDate"] = _fromDate?.ToString("yyyy-MM-dd"),
+            ["toDate"] = _toDate?.ToString("yyyy-MM-dd")
+        });
+        NavigationManager.NavigateTo(uri);
+    }
+
+    private void ChangeWeek(int delta)
+    {
+        var offset = _currentWeekOffset + delta;
+        var uri = QueryHelpers.AddQueryString("/", new Dictionary<string, string?>
+        {
+            ["weekOffset"] = offset.ToString()
+        });
+        NavigationManager.NavigateTo(uri);
     }
 }

--- a/Predictorator/Components/_Imports.razor
+++ b/Predictorator/Components/_Imports.razor
@@ -6,6 +6,9 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.AspNetCore.Components.Authorization
 @using Predictorator
 @using Predictorator.Components
 @using Predictorator.Models.Fixtures


### PR DESCRIPTION
## Summary
- restore header links and dark mode button in `MainLayout`
- restore date filter form in `Index` page using MudBlazor controls
- wire date selection to query parameters
- update imports for needed namespaces

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6853251281d48328a256699c2fdcd6f5