### PR TITLE
Map /admin to login

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -82,4 +82,13 @@ public class HomePageTests
         var header = await _page.TextContentAsync("h2");
         Assert.That(header, Is.EqualTo("Subscribe to Notifications"));
     }
+
+    [Test]
+    public async Task Admin_Route_Should_Display_Login_Page()
+    {
+        await _page!.GotoAsync($"{BaseUrl}/admin");
+        await _page.Locator("h1").WaitForAsync();
+        var header = await _page.TextContentAsync("h1");
+        Assert.That(header, Does.Contain("Log in"));
+    }
 }

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -85,6 +85,11 @@ builder.Services.AddIdentity<IdentityUser, IdentityRole>()
     .AddDefaultUI()
     .AddDefaultTokenProviders();
 
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.LoginPath = "/admin";
+});
+
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
@@ -121,6 +126,7 @@ app.MapControllerRoute(
     name: "default",
     pattern: "mvc/{controller=Home}/{action=Index}/{id?}");
 app.MapRazorPages();
+app.MapGet("/admin", () => Results.Redirect("/Identity/Account/Login"));
 
 if (!app.Environment.IsEnvironment("Testing"))
     await ApplicationDbInitializer.SeedAdminUserAsync(app.Services);


### PR DESCRIPTION
## Summary
- configure Identity cookie to use /admin for login path
- map /admin route to default Identity login page
- add UI test to verify /admin shows login

## Testing
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6853281e52588328a29aa6cbfa5d362c