### PR TITLE
Fix MudBlazor CSS inclusion

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -5,10 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
     <link href="css/site.css" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <HeadOutlet />
 </head>
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 </html>

--- a/Predictorator/Views/Shared/_Layout.cshtml
+++ b/Predictorator/Views/Shared/_Layout.cshtml
@@ -13,6 +13,7 @@
     <title>@ViewData["Title"] - Predictotronix</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true"/>
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <meta property="og:title" content="Predictotronix"/>
     <meta property="og:description" content="A predicting robot from the future.">
     <meta property="og:image" content="https://predictotronix.com/images/lizwig.jpg"/>
@@ -54,6 +55,7 @@
 <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <script src="~/js/site.js" asp-append-version="true"></script>
 <script src="_framework/blazor.web.js"></script>
+<script src="_content/MudBlazor/MudBlazor.min.js"></script>
 @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include MudBlazor styles and scripts in the Blazor host page
- add the same CSS and JS references to the MVC layout

## Testing
- `dotnet format --no-restore` *(fails: `dotnet` not found)*
- `dotnet restore` *(fails: `dotnet` not found)*
- `dotnet test Predictorator.sln` *(fails: `dotnet` not found)*
- `dotnet build Predictorator.sln -c Release -warnaserror` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685329f8fc2083289eb8c42dcce62e79