### PR TITLE
Fix fixtures page and tests

### DIFF
--- a/Predictorator.Tests/FixtureServiceTestTokenTests.cs
+++ b/Predictorator.Tests/FixtureServiceTestTokenTests.cs
@@ -47,4 +47,39 @@ public class FixtureServiceTestTokenTests
         Assert.Single(result.Response);
         Assert.Equal(0, handler.CallCount);
     }
+
+    [Fact]
+    public async Task Fetches_from_http_when_token_does_not_match()
+    {
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ApiSettings:TestToken"] = "token1"
+            })
+            .Build();
+
+        var context = new DefaultHttpContext();
+        context.Request.Headers["X-Test-Token"] = "token2";
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(context);
+
+        var fixtures = new FixturesResponse { Response = [], FromDate = DateTime.Today, ToDate = DateTime.Today };
+        var handler = new StubHttpMessageHandler(fixtures);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        httpClientFactory.CreateClient("fixtures").Returns(client);
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        var cache = services.BuildServiceProvider().GetRequiredService<HybridCache>();
+
+        var service = new FixtureService(httpClientFactory, cache, accessor, config, env);
+
+        var result = await service.GetFixturesAsync(DateTime.Today, DateTime.Today.AddDays(6));
+
+        Assert.Empty(result.Response);
+        Assert.Equal(1, handler.CallCount);
+    }
 }

--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -112,4 +112,18 @@ public class HomePageTests
         var header = await _page!.TextContentAsync("h1");
         Assert.That(header, Does.Contain("Log in"));
     }
+
+    [Test]
+    public async Task FillRandomButton_Should_Populate_Scores_When_Using_Mock_Data()
+    {
+        await NavigateWithRetriesAsync(_page!, BaseUrl);
+        if (Environment.GetEnvironmentVariable("UI_TEST_TOKEN") == null)
+        {
+            Assert.Pass("No test token provided; skipping random score test.");
+        }
+
+        await _page!.Locator("#fillRandomBtn").ClickAsync();
+        var value = await _page!.Locator(".score-input").First.InputValueAsync();
+        Assert.IsNotEmpty(value);
+    }
 }

--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -12,5 +12,6 @@
     <Routes />
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="js/site.js"></script>
 </body>
 </html>

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -31,11 +31,12 @@ else if (_fixtures.Response.Any())
     var groups = _fixtures.Response.GroupBy(f => f.Fixture.Date.Date).OrderBy(g => g.Key);
     foreach (var group in groups)
     {
-        <MudCard Class="mb-4">
-            <MudCardHeader>
-                <MudText Typo="Typo.h6">@group.Key.ToString("dddd, MMMM d, yyyy")</MudText>
-            </MudCardHeader>
-            <MudCardContent>
+        <div class="date-block">
+            <MudCard Class="mb-4">
+                <MudCardHeader>
+                    <MudText Typo="Typo.h6" Class="date-header">@group.Key.ToString("dddd, MMMM d, yyyy")</MudText>
+                </MudCardHeader>
+                <MudCardContent>
                 <div class="row fixture-header">
                     <div class="col-4">Home Team</div>
                     <div class="col-4 text-center">Prediction</div>
@@ -66,8 +67,9 @@ else if (_fixtures.Response.Any())
                         </div>
                     </div>
                 }
-            </MudCardContent>
-        </MudCard>
+                </MudCardContent>
+            </MudCard>
+        </div>
     }
 }
 

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -21,20 +21,29 @@ function initializeDarkMode() {
 
 function toggleDarkMode(enable) {
     body.classList.toggle('dark-mode', enable);
-    navbar.classList.toggle('bg-dark', enable);
-    navbar.classList.toggle('navbar-dark', enable);
-    navbar.classList.toggle('bg-white', !enable);
-    navbar.classList.toggle('navbar-light', !enable);
-    accordion.classList.toggle('accordion-dark', enable);
-    toggleButton.textContent = enable ? 'Light Mode' : 'Dark Mode';
+    if (navbar) {
+        navbar.classList.toggle('bg-dark', enable);
+        navbar.classList.toggle('navbar-dark', enable);
+        navbar.classList.toggle('bg-white', !enable);
+        navbar.classList.toggle('navbar-light', !enable);
+    }
+    if (accordion) {
+        accordion.classList.toggle('accordion-dark', enable);
+    }
+    if (toggleButton) {
+        toggleButton.textContent = enable ? 'Light Mode' : 'Dark Mode';
+    }
     localStorage.setItem('dark-mode', enable ? 'enabled' : 'disabled');
 }
 
 // Event Listeners Initialization
 function initializeEventListeners() {
-    document.getElementById('copyBtn').addEventListener('click', handleCopyButtonClick);
-    document.getElementById('fillRandomBtn').addEventListener('click', fillRandomScores);
-    document.getElementById('clearBtn').addEventListener('click', clearScores);
+    const copyBtn = document.getElementById('copyBtn');
+    if (copyBtn) copyBtn.addEventListener('click', handleCopyButtonClick);
+    const fillRandomBtn = document.getElementById('fillRandomBtn');
+    if (fillRandomBtn) fillRandomBtn.addEventListener('click', fillRandomScores);
+    const clearBtn = document.getElementById('clearBtn');
+    if (clearBtn) clearBtn.addEventListener('click', clearScores);
 }
 
 // Copy Data Functions


### PR DESCRIPTION
## Summary
- add site.js to the Blazor app template
- wrap daily fixture blocks with `date-block` and add `date-header`
- guard event listener logic in site.js
- test that FixtureService doesn't use mock data when token mismatches
- test that fill random scores button works

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685334746d4083289f87ca049e1e48aa