### PR TITLE
Convert JS logic to C# interop

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @inject IHttpContextAccessor HttpContextAccessor
+@inject BrowserInteropService Browser
 <MudLayout>
     <MudAppBar Elevation="0" Color="Color.Primary">
         <div class="container-fluid d-flex align-items-center">
@@ -11,7 +12,9 @@
             }
             <MudLink Href="/mvc/Subscription/Subscribe" Class="nav-link">Subscribe</MudLink>
             <MudSpacer />
-            <MudButton Variant="Variant.Outlined" UserAttributes="@(new Dictionary<string, object> { { "id", "darkModeToggle" } })">Dark Mode</MudButton>
+            <MudButton Variant="Variant.Outlined"
+                       UserAttributes="@(new Dictionary<string, object> { { "id", "darkModeToggle" } })"
+                       OnClick="ToggleDarkMode">@(_darkMode ? "Light Mode" : "Dark Mode")</MudButton>
         </div>
     </MudAppBar>
     <MudMainContent>
@@ -20,3 +23,24 @@
         </div>
     </MudMainContent>
 </MudLayout>
+
+@code {
+    private bool _darkMode;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _darkMode = await Browser.GetDarkModeAsync();
+            await Browser.SetDarkModeAsync(_darkMode);
+            StateHasChanged();
+        }
+    }
+
+    private async Task ToggleDarkMode()
+    {
+        _darkMode = !_darkMode;
+        await Browser.SetDarkModeAsync(_darkMode);
+        await Browser.SaveDarkModeAsync(_darkMode);
+    }
+}

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -3,6 +3,7 @@
 @inject NavigationManager NavigationManager
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
+@inject BrowserInteropService Browser
 
 <h1>Premier League Fixtures</h1>
 
@@ -50,9 +51,15 @@ else if (_fixtures.Response.Any())
                             <span>@fixture.Teams.Home.Name</span>
                         </div>
                         <div class="col-4 text-center">
-                            <input type="number" class="form-control score-input d-inline-block text-center" maxlength="2" @(fixture.Score?.Fulltime.Home != null ? $"readonly value={fixture.Score.Fulltime.Home}" : "") />
+                            <input type="number" class="form-control score-input d-inline-block text-center" maxlength="2"
+                                   @bind="_predictions[fixture.Fixture.Id].Home"
+                                   @bind:event="oninput"
+                                   readonly="@(fixture.Score?.Fulltime.Home != null)" />
                             <span class="mx-2">-</span>
-                            <input type="number" class="form-control score-input d-inline-block text-center" maxlength="2" @(fixture.Score?.Fulltime.Away != null ? $"readonly value={fixture.Score.Fulltime.Away}" : "") />
+                            <input type="number" class="form-control score-input d-inline-block text-center" maxlength="2"
+                                   @bind="_predictions[fixture.Fixture.Id].Away"
+                                   @bind:event="oninput"
+                                   readonly="@(fixture.Score?.Fulltime.Away != null)" />
                         </div>
                         <div class="col-4 d-flex align-items-center justify-content-end">
                             <span>@fixture.Teams.Away.Name</span>
@@ -74,9 +81,9 @@ else if (_fixtures.Response.Any())
 }
 
 <div class="buttons mt-4">
-    <button class="mud-button mud-button-filled mud-theme-secondary" id="fillRandomBtn">Complete with Random Scores</button>
-    <button class="mud-button mud-button-filled mud-theme-warning" id="clearBtn">Clear Predictions</button>
-    <button class="mud-button mud-button-filled mud-theme-success" id="copyBtn">Copy Predictions to Clipboard</button>
+    <button class="mud-button mud-button-filled mud-theme-secondary" id="fillRandomBtn" @onclick="FillRandomScores">Complete with Random Scores</button>
+    <button class="mud-button mud-button-filled mud-theme-warning" id="clearBtn" @onclick="ClearScores">Clear Predictions</button>
+    <button class="mud-button mud-button-filled mud-theme-success" id="copyBtn" @onclick="CopyPredictionsAsync">Copy Predictions to Clipboard</button>
 </div>
 
 @code {
@@ -85,6 +92,7 @@ else if (_fixtures.Response.Any())
     private DateTime? _toDate;
     private bool _autoWeek;
     private int _currentWeekOffset;
+    private readonly Dictionary<int, PredictionInput> _predictions = new();
 
     [Parameter, SupplyParameterFromQuery(Name = "fromDate")] public DateTime? FromDate { get; set; }
     [Parameter, SupplyParameterFromQuery(Name = "toDate")] public DateTime? ToDate { get; set; }
@@ -98,6 +106,18 @@ else if (_fixtures.Response.Any())
         _currentWeekOffset = WeekOffset ?? 0;
         _autoWeek = FromDate == null && ToDate == null;
         _fixtures = await FixtureService.GetFixturesAsync(from, to);
+
+        if (_fixtures?.Response != null)
+        {
+            foreach (var f in _fixtures.Response)
+            {
+                if (!_predictions.ContainsKey(f.Fixture.Id))
+                    _predictions[f.Fixture.Id] = new PredictionInput();
+
+                _predictions[f.Fixture.Id].Home = f.Score?.Fulltime.Home;
+                _predictions[f.Fixture.Id].Away = f.Score?.Fulltime.Away;
+            }
+        }
     }
 
     private void Reload()
@@ -118,5 +138,91 @@ else if (_fixtures.Response.Any())
             ["weekOffset"] = offset.ToString()
         });
         NavigationManager.NavigateTo(uri);
+    }
+
+    private void FillRandomScores()
+    {
+        var possible = new[] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,4,4,5 };
+        var rnd = new Random();
+        if (_fixtures == null) return;
+
+        foreach (var f in _fixtures.Response)
+        {
+            var pred = _predictions[f.Fixture.Id];
+            if (f.Score?.Fulltime.Home == null && pred.Home == null)
+                pred.Home = possible[rnd.Next(possible.Length)];
+            if (f.Score?.Fulltime.Away == null && pred.Away == null)
+                pred.Away = possible[rnd.Next(possible.Length)];
+        }
+    }
+
+    private void ClearScores()
+    {
+        if (_fixtures == null) return;
+        foreach (var f in _fixtures.Response)
+        {
+            var pred = _predictions[f.Fixture.Id];
+            if (f.Score?.Fulltime.Home == null)
+                pred.Home = null;
+            if (f.Score?.Fulltime.Away == null)
+                pred.Away = null;
+        }
+    }
+
+    private async Task CopyPredictionsAsync()
+    {
+        if (_fixtures == null) return;
+
+        var sbText = new System.Text.StringBuilder();
+        var sbHtml = new System.Text.StringBuilder();
+        bool missing = false;
+        sbHtml.Append("<table border=\"1\" cellpadding=\"5\" cellspacing=\"0\" style=\"border-collapse: collapse;\">");
+
+        var groups = _fixtures.Response.GroupBy(f => f.Fixture.Date.Date).OrderBy(g => g.Key);
+        foreach (var group in groups)
+        {
+            var dateHeader = group.Key.ToString("dddd, MMMM d, yyyy");
+            sbText.AppendLine(dateHeader);
+            sbHtml.Append($"<thead><tr><th colspan=\"3\" style=\"background-color: #f2f2f2; text-align: center; padding: 10px;\">{dateHeader}</th></tr>");
+            sbHtml.Append("<tr><th style=\"background-color: #d9d9d9; text-align: left; padding: 5px; min-width: 120px\">Home Team</th>");
+            sbHtml.Append("<th style=\"background-color: #d9d9d9; text-align: center; padding: 5px;\">Score</th>");
+            sbHtml.Append("<th style=\"background-color: #d9d9d9; text-align: right; padding: 5px; min-width: 120px\">Away Team</th></tr></thead><tbody>");
+
+            foreach (var fixture in group.OrderBy(x => x.Fixture.Date).ThenBy(x => x.Teams.Home.Name))
+            {
+                var pred = _predictions[fixture.Fixture.Id];
+                var homeScore = pred.Home;
+                var awayScore = pred.Away;
+                if (homeScore == null || awayScore == null)
+                    missing = true;
+
+                var homeTeam = fixture.Teams.Home.Name.Trim();
+                var awayTeam = fixture.Teams.Away.Name.Trim();
+                sbText.AppendLine($"{homeTeam}    {homeScore} - {awayScore}    {awayTeam}");
+                sbHtml.Append($"<tr><td style=\"padding: 5px; text-align: left;\">{homeTeam}</td><td style=\"padding: 5px; text-align: center;\">{homeScore} - {awayScore}</td><td style=\"padding: 5px; text-align: right;\">{awayTeam}</td></tr>");
+            }
+
+            sbText.AppendLine();
+        }
+
+        sbHtml.Append("</tbody></table><br/>");
+
+        if (missing)
+        {
+            await Browser.AlertAsync("Error: Please fill in all score predictions before copying.");
+            return;
+        }
+
+        var mobile = await Browser.IsMobileDeviceAsync();
+        if (mobile)
+            await Browser.CopyToClipboardTextAsync(sbText.ToString());
+        else
+            await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+    }
+
+    private class PredictionInput
+    {
+        public int? Home { get; set; }
+        public int? Away { get; set; }
     }
 }

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -94,6 +94,7 @@ builder.Services.ConfigureApplicationCookie(options =>
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddMudServices();
+builder.Services.AddScoped<BrowserInteropService>();
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 

--- a/Predictorator/Services/BrowserInteropService.cs
+++ b/Predictorator/Services/BrowserInteropService.cs
@@ -1,0 +1,27 @@
+using Microsoft.JSInterop;
+
+namespace Predictorator.Services;
+
+public class BrowserInteropService
+{
+    private readonly IJSRuntime _js;
+
+    public BrowserInteropService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public ValueTask<bool> GetDarkModeAsync() => _js.InvokeAsync<bool>("app.getDarkMode");
+
+    public ValueTask SetDarkModeAsync(bool enable) => _js.InvokeVoidAsync("app.setDarkMode", enable);
+
+    public ValueTask SaveDarkModeAsync(bool enable) => _js.InvokeVoidAsync("app.saveDarkMode", enable);
+
+    public ValueTask CopyToClipboardTextAsync(string text) => _js.InvokeVoidAsync("app.copyToClipboardText", text);
+
+    public ValueTask CopyToClipboardHtmlAsync(string html) => _js.InvokeVoidAsync("app.copyToClipboardHtml", html);
+
+    public ValueTask<bool> IsMobileDeviceAsync() => _js.InvokeAsync<bool>("app.isMobileDevice");
+
+    public ValueTask AlertAsync(string message) => _js.InvokeVoidAsync("alert", message);
+}

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -1,158 +1,64 @@
-﻿// DOM Elements
-const toggleButton = document.getElementById('darkModeToggle');
-const body = document.body;
-const navbar = document.querySelector('.navbar');
-const accordion = document.querySelector('.accordion');
+window.app = (() => {
+    const body = document.body;
+    const navbar = document.querySelector('.navbar');
+    const accordion = document.querySelector('.accordion');
+    const toggleButton = document.getElementById('darkModeToggle');
 
-// Initialization
-initializeDarkMode();
-initializeEventListeners();
-
-// Dark Mode Functions
-function initializeDarkMode() {
-    const darkModeEnabled = localStorage.getItem('dark-mode') === 'enabled';
-    toggleDarkMode(darkModeEnabled);
-
-    toggleButton.addEventListener('click', () => {
-        const isEnabled = !body.classList.contains('dark-mode');
-        toggleDarkMode(isEnabled);
-    });
-}
-
-function toggleDarkMode(enable) {
-    body.classList.toggle('dark-mode', enable);
-    if (navbar) {
-        navbar.classList.toggle('bg-dark', enable);
-        navbar.classList.toggle('navbar-dark', enable);
-        navbar.classList.toggle('bg-white', !enable);
-        navbar.classList.toggle('navbar-light', !enable);
-    }
-    if (accordion) {
-        accordion.classList.toggle('accordion-dark', enable);
-    }
-    if (toggleButton) {
-        toggleButton.textContent = enable ? 'Light Mode' : 'Dark Mode';
-    }
-    localStorage.setItem('dark-mode', enable ? 'enabled' : 'disabled');
-}
-
-// Event Listeners Initialization
-function initializeEventListeners() {
-    const copyBtn = document.getElementById('copyBtn');
-    if (copyBtn) copyBtn.addEventListener('click', handleCopyButtonClick);
-    const fillRandomBtn = document.getElementById('fillRandomBtn');
-    if (fillRandomBtn) fillRandomBtn.addEventListener('click', fillRandomScores);
-    const clearBtn = document.getElementById('clearBtn');
-    if (clearBtn) clearBtn.addEventListener('click', clearScores);
-}
-
-// Copy Data Functions
-function handleCopyButtonClick() {
-    const isMobile = isMobileDevice();
-    const data = extractFixtureData();
-
-    if (data.missingScores) {
-        alert('Error: Please fill in all score predictions before copying.');
-        return;
+    function setDarkMode(enable) {
+        body.classList.toggle('dark-mode', enable);
+        if (navbar) {
+            navbar.classList.toggle('bg-dark', enable);
+            navbar.classList.toggle('navbar-dark', enable);
+            navbar.classList.toggle('bg-white', !enable);
+            navbar.classList.toggle('navbar-light', !enable);
+        }
+        if (accordion) {
+            accordion.classList.toggle('accordion-dark', enable);
+        }
+        if (toggleButton) {
+            toggleButton.textContent = enable ? 'Light Mode' : 'Dark Mode';
+        }
     }
 
-    if (isMobile) {
-        copyToClipboardText(data.text);
-    } else {
-        copyToClipboardHtml(data.html);
+    function saveDarkMode(enable) {
+        localStorage.setItem('dark-mode', enable ? 'enabled' : 'disabled');
     }
-}
 
-function extractFixtureData() {
-    let resultText = '';
-    let resultHtml = '<table border="1" cellpadding="5" cellspacing="0" style="border-collapse: collapse;">';
-    let missingScores = false;
+    function getDarkMode() {
+        return localStorage.getItem('dark-mode') === 'enabled';
+    }
 
-    document.querySelectorAll('.date-block').forEach(dateBlock => {
-        const dateHeader = dateBlock.querySelector('.date-header').innerText;
-        resultText += `${dateHeader}\n`;
-        resultHtml += createHtmlTableHeader(dateHeader);
-
-        dateBlock.querySelectorAll('.fixture-row').forEach(row => {
-            const homeTeam = row.children[0].innerText.trim();
-            const homeScore = row.children[1].querySelectorAll('input')[0].value;
-            const awayScore = row.children[1].querySelectorAll('input')[1].value;
-            const awayTeam = row.children[2].innerText.trim();
-
-            if (homeScore === '' || awayScore === '') {
-                missingScores = true;
-            }
-
-            resultText += `${homeTeam}    ${homeScore} - ${awayScore}    ${awayTeam}\n`;
-            resultHtml += createHtmlTableRow(homeTeam, homeScore, awayScore, awayTeam);
+    function copyToClipboardText(text) {
+        navigator.clipboard.writeText(text).then(() => {
+            alert('Predictions copied to clipboard!');
+        }).catch(err => {
+            console.error('Could not copy text: ', err);
         });
+    }
 
-        resultText += '\n';
-    });
+    function copyToClipboardHtml(html) {
+        navigator.clipboard.write([
+            new ClipboardItem({
+                'text/html': new Blob([html], { type: 'text/html' })
+            })
+        ]).then(() => {
+            alert('Predictions copied to clipboard!');
+        }).catch(err => {
+            console.error('Could not copy text: ', err);
+        });
+    }
 
-    resultHtml += '</tbody></table><br/>';
+    function isMobileDevice() {
+        return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ||
+            (window.innerWidth <= 800 && window.innerHeight <= 600);
+    }
 
-    return {text: resultText, html: resultHtml, missingScores};
-}
-
-function createHtmlTableHeader(dateHeader) {
-    return `<thead><tr><th colspan="3" style="background-color: #f2f2f2; text-align: center; padding: 10px;">${dateHeader}</th></tr>
-            <tr><th style="background-color: #d9d9d9; text-align: left; padding: 5px; min-width: 120px">Home Team</th>
-            <th style="background-color: #d9d9d9; text-align: center; padding: 5px;">Score</th>
-            <th style="background-color: #d9d9d9; text-align: right; padding: 5px; min-width: 120px">Away Team</th></tr></thead><tbody>`;
-}
-
-function createHtmlTableRow(homeTeam, homeScore, awayScore, awayTeam) {
-    return `<tr><td style="padding: 5px; text-align: left;">${homeTeam}</td>
-                <td style="padding: 5px; text-align: center;">${homeScore} - ${awayScore}</td>
-                <td style="padding: 5px; text-align: right;">${awayTeam}</td></tr>`;
-}
-
-function copyToClipboardText(text) {
-    navigator.clipboard.writeText(text).then(() => {
-        alert('Predictions copied to clipboard!');
-    }).catch(err => {
-        console.error('Could not copy text: ', err);
-    });
-}
-
-function copyToClipboardHtml(html) {
-    navigator.clipboard.write([
-        new ClipboardItem({
-            'text/html': new Blob([html], {type: 'text/html'})
-        })
-    ]).then(() => {
-        alert('Predictions copied to clipboard!');
-    }).catch(err => {
-        console.error('Could not copy text: ', err);
-    });
-}
-
-// Random Score and Clear Functions
-function fillRandomScores() {
-    const possibleScores = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 5];
-
-    document.querySelectorAll('.score-input').forEach(input => {
-        if (input.value === '') {
-            input.value = getRandomScore(possibleScores);
-        }
-    });
-}
-
-function getRandomScore(possibleScores) {
-    return possibleScores[Math.floor(Math.random() * possibleScores.length)];
-}
-
-function clearScores() {
-    document.querySelectorAll('.score-input').forEach(input => {
-        if (!input.readOnly) {
-            input.value = '';
-        }
-    });
-}
-
-// Utility Function
-function isMobileDevice() {
-    return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ||
-        (window.innerWidth <= 800 && window.innerHeight <= 600);
-}
+    return {
+        setDarkMode,
+        saveDarkMode,
+        getDarkMode,
+        copyToClipboardText,
+        copyToClipboardHtml,
+        isMobileDevice
+    };
+})();


### PR DESCRIPTION
## Summary
- add browser interop service
- toggle dark mode and buttons via C#
- migrate fixture page interactions to C#
- simplify site JavaScript to interop-only functions

## Testing
- `dotnet format --no-restore`
- `dotnet restore`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_68533b271900832893c677873d3664de