### PR TITLE
Add bootstrap styles for Blazor pages

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
+    <link href="lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <HeadOutlet />
@@ -12,6 +13,7 @@
     <Routes />
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="js/site.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include Bootstrap assets in `App.razor` so Blazor pages use the same layout styling as MVC views

## Testing
- `dotnet format --no-restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`
- `dotnet restore Predictorator.sln` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6853ace169c083288bf3848bfb7a994c