### PR TITLE
Clean up unused CSS classes

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -18,7 +18,7 @@
         </MudContainer>
     </MudAppBar>
     <MudMainContent>
-        <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="main-container">
+        <MudContainer MaxWidth="MaxWidth.ExtraLarge">
             @Body
         </MudContainer>
     </MudMainContent>

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -35,7 +35,7 @@ else if (_fixtures.Response.Any())
         <div class="date-block">
             <MudCard Style="margin-bottom:1rem;">
                 <MudCardHeader>
-                    <MudText Typo="Typo.h6" Class="date-header">@group.Key.ToString("dddd, MMMM d, yyyy")</MudText>
+                    <MudText Typo="Typo.h6">@group.Key.ToString("dddd, MMMM d, yyyy")</MudText>
                 </MudCardHeader>
                 <MudCardContent>
                 <MudGrid Class="fixture-header">

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -87,10 +87,6 @@ h4 {
     margin-left: auto;
 }
 
-.title {
-    font-size: 2rem;
-}
-
 .weekJump {
     font-size: 1.5rem;
     text-decoration: none;
@@ -239,9 +235,6 @@ input[type=number] {
         padding: 0;
     }
 
-    .fixtures-container {
-        padding: 0;
-    }
 
     .appbar-container {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- remove unused `.title` and `.fixtures-container` styles
- drop undefined `main-container` and `date-header` classes in razor pages

## Testing
- `dotnet format --no-restore`
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6853c39db0788328b05597c9c1827402