### PR TITLE
Fix Playwright navigation timeout

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -23,7 +23,7 @@ public class HomePageTests
             try
             {
                 await page.GotoAsync(url, new() { Timeout = 90000 });
-                await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+                await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
                 return;
             }
             catch (TimeoutException) when (attempt < maxAttempts)
@@ -34,7 +34,7 @@ public class HomePageTests
 
         // Final attempt without catching to surface the exception
         await page.GotoAsync(url, new() { Timeout = 90000 });
-        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
     }
 
     [OneTimeSetUp]


### PR DESCRIPTION
## Summary
- avoid waiting for `networkidle` which never occurs in Blazor Server

## Testing
- `dotnet format --no-restore` *(fails: `dotnet` not found)*
- `dotnet restore` *(fails: `dotnet` not found)*
- `dotnet test Predictorator.sln` *(fails: `dotnet` not found)*
- `dotnet build Predictorator.sln -c Release -warnaserror` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c56ddc588328842f5169a98cf677