### PR TITLE
Add MudBlazor providers

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -4,10 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <HeadOutlet />
 </head>
 <body>
+    <MudThemeProvider />
+    <MudDialogProvider />
+    <MudSnackbarProvider />
     <Routes />
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>


### PR DESCRIPTION
## Summary
- include MudBlazor theme, dialog and snackbar providers
- add Roboto font per MudBlazor docs

## Testing
- `dotnet restore Predictorator.sln`
- `dotnet test Predictorator.sln`
- `dotnet build Predictorator.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6853f85b43308328bf7f3df7c1d36767