### PR TITLE
Fix MudBlazor popover error

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -5,6 +5,7 @@
 @using Predictorator.Components.Pages.Subscription
 <MudLayout Class="@LayoutClass">
     <MudDialogProvider />
+    <MudPopoverProvider />
     <MudAppBar Elevation="1" Color="Color.Primary">
         <MudText Typo="Typo.h5" Class="ml-2">Predictotronix</MudText>
         <MudSpacer />


### PR DESCRIPTION
## Summary
- add missing `MudPopoverProvider` in the main layout

## Testing
- `dotnet restore`
- `dotnet test Predictorator.Tests/Predictorator.Tests.csproj --logger "console;verbosity=detailed"`

------
https://chatgpt.com/codex/tasks/task_e_68541a4b0b188328b4c775072661dc7e