### PR TITLE
Fix duplicate MudBlazor provider IDs

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -10,9 +10,7 @@
 </head>
 <body>
     <MudThemeProvider />
-    <MudDialogProvider />
     <MudSnackbarProvider />
-    <MudPopoverProvider />
     <Routes />
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>


### PR DESCRIPTION
## Summary
- remove extra `MudDialogProvider` and `MudPopoverProvider` from `App.razor`
- keep layout providers to satisfy tests

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68542c25e3148328bbaab24ef1c7d341