### PR TITLE
Align fixture row layout

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -9,6 +9,8 @@ using Predictorator.Tests.Helpers;
 using MudBlazor.Services;
 using NSubstitute;
 using System.Linq;
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Components;
 using Predictorator.Components.Layout;
 using Xunit;
@@ -48,5 +50,41 @@ public class IndexPageBUnitTests
         var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
         var picker = cut.Find("#dateRangePicker");
         Assert.NotNull(picker);
+    }
+
+    [Fact]
+    public async Task FixtureRow_Should_Render_With_Alignment_Classes()
+    {
+        await using var ctx = CreateContext();
+        var fixtures = new FixturesResponse
+        {
+            Response = new List<FixtureData>
+            {
+                new()
+                {
+                    Fixture = new Fixture { Date = DateTime.UtcNow, Venue = new Venue { Name="A", City="B" } },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Home", Logo = string.Empty },
+                        Away = new Team { Name = "Away", Logo = string.Empty }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = null, Away = null } }
+                }
+            }
+        };
+        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+
+        RenderFragment body = b =>
+        {
+            b.OpenComponent<IndexPage>(0);
+            b.CloseComponent();
+        };
+
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+
+        var home = cut.Find(".fixture-line .home-name");
+        var away = cut.Find(".fixture-line .away-name");
+        Assert.NotNull(home);
+        Assert.NotNull(away);
     }
 }

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -40,15 +40,15 @@ else if (_fixtures.Response.Any())
                             <td colspan="3">
                                 <div class="fixture-line">
                                     <MudImage Src="@fixture.Teams.Home.Logo" Alt="@fixture.Teams.Home.Name" Width="30" Height="30" />
-                                    <span class="team-name">@fixture.Teams.Home.Name</span>
+                                    <span class="team-name home-name">@fixture.Teams.Home.Name</span>
                                     <MudNumericField T="int?" Class="score-input" Immediate="true"
                                                      @bind-Value="_predictions[fixture.Fixture.Id].Home"
                                                      Disabled="@(fixture.Score?.Fulltime.Home != null)" Max="20" Min="0" />
-                                    <span>-</span>
+                                    <span class="hyphen">-</span>
                                     <MudNumericField T="int?" Class="score-input" Immediate="true"
                                                      @bind-Value="_predictions[fixture.Fixture.Id].Away"
                                                      Disabled="@(fixture.Score?.Fulltime.Away != null)" Max="20" Min="0" />
-                                    <span class="team-name">@fixture.Teams.Away.Name</span>
+                                    <span class="team-name away-name">@fixture.Teams.Away.Name</span>
                                     <MudImage Src="@fixture.Teams.Away.Logo" Alt="@fixture.Teams.Away.Name" Width="30" Height="30" />
                                 </div>
                             </td>

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -14,10 +14,22 @@ html, body {
 
 /* Ensure fixture details stay on one horizontal line */
 .fixture-line {
-    display: flex;
+    display: grid;
+    grid-template-columns: 30px 1fr 2.5rem 1rem 2.5rem 1fr 30px;
     align-items: center;
     gap: 0.5rem;
-    flex-wrap: nowrap;
+}
+
+.home-name {
+    text-align: left;
+}
+
+.away-name {
+    text-align: right;
+}
+
+.hyphen {
+    text-align: center;
 }
 
 /* Allow team names to wrap while keeping the fixture on one line */


### PR DESCRIPTION
## Summary
- update fixture row markup with alignment classes
- add CSS grid layout for fixture lines
- test fixture row alignment using BUnit

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68545f2774088328a1840c24bf37a294