### PR TITLE
Improve subscribe modal layout

### DIFF
--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -2,21 +2,25 @@
 @inject SubscriptionService SubscriptionService
 @inject NavigationManager Navigation
 
-<h2>Subscribe to Notifications</h2>
+<MudPaper Class="pa-4" Elevation="1">
+    <h2>Subscribe to Notifications</h2>
 
-@if (_submitted)
-{
-    <p>A verification link has been sent to your email address.</p>
-}
-else
-{
-    <EditForm Model="this" OnValidSubmit="HandleSubmit">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
-        <MudTextField @bind-Value="Email" Label="Email address" For="@(() => Email)" />
-        <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
-    </EditForm>
-}
+    @if (_submitted)
+    {
+        <p>A verification link has been sent to your email address.</p>
+    }
+    else
+    {
+        <EditForm Model="this" OnValidSubmit="HandleSubmit">
+            <MudStack Spacing="2">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                <MudTextField @bind-Value="Email" Label="Email address" For="@(() => Email)" />
+                <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
+            </MudStack>
+        </EditForm>
+    }
+</MudPaper>
 
 @code {
     [Required, EmailAddress]


### PR DESCRIPTION
## Summary
- wrap subscription form in a MudPaper with padding
- arrange form controls using MudStack for better spacing

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_685465eb05f883289803a23dc66781ed