### PR TITLE
Fix dark mode with MudBlazor theme provider

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -26,7 +26,11 @@ public class IndexPageBUnitTests
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
         var jsRuntime = Substitute.For<IJSRuntime>();
         ctx.Services.AddSingleton<IJSRuntime>(jsRuntime);
-        ctx.Services.AddSingleton(new BrowserInteropService(jsRuntime));
+        var browser = new BrowserInteropService(jsRuntime);
+        ctx.Services.AddSingleton(browser);
+        var theme = new ThemeService(browser);
+        theme.InitializeAsync().GetAwaiter().GetResult();
+        ctx.Services.AddSingleton(theme);
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
         var provider = new FakeDateTimeProvider

--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -24,7 +24,11 @@ public class MainLayoutBUnitTests
         var jsRuntime = Substitute.For<IJSRuntime>();
         jsRuntime.InvokeAsync<bool>("app.getDarkMode", Arg.Any<object[]?>()).Returns(new ValueTask<bool>(false));
         ctx.Services.AddSingleton<IJSRuntime>(jsRuntime);
-        ctx.Services.AddSingleton(new BrowserInteropService(jsRuntime));
+        var browser = new BrowserInteropService(jsRuntime);
+        ctx.Services.AddSingleton(browser);
+        var theme = new ThemeService(browser);
+        theme.InitializeAsync().GetAwaiter().GetResult();
+        ctx.Services.AddSingleton(theme);
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         return ctx;
     }

--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -1,3 +1,4 @@
+@implements IDisposable
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -10,7 +11,7 @@
     <HeadOutlet />
 </head>
 <body>
-    <MudThemeProvider />
+    <MudThemeProvider IsDarkMode="@ThemeService.IsDarkMode" />
     <MudSnackbarProvider />
     <Routes @rendermode="InteractiveServer" />
     <script src="_framework/blazor.server.js"></script>
@@ -18,3 +19,24 @@
     <script src="js/site.js"></script>
 </body>
 </html>
+
+@code {
+    [Inject]
+    private ThemeService ThemeService { get; set; } = null!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await ThemeService.InitializeAsync();
+            ThemeService.OnChange += OnThemeChanged;
+        }
+    }
+
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ThemeService.OnChange -= OnThemeChanged;
+    }
+}

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -1,9 +1,10 @@
+@implements IDisposable
 @inherits LayoutComponentBase
 @inject IHttpContextAccessor HttpContextAccessor
-@inject BrowserInteropService Browser
+@inject ThemeService ThemeService
 @inject IDialogService DialogService
 @using Predictorator.Components.Pages.Subscription
-<MudLayout Class="@LayoutClass">
+<MudLayout>
     <MudDialogProvider />
     <MudPopoverProvider />
     <MudAppBar Elevation="1" Color="Color.Primary">
@@ -15,7 +16,7 @@
             <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
         }
         <MudButton Variant="Variant.Text" OnClick="@OpenSubscribe">Subscribe</MudButton>
-        <MudIconButton Icon="@(_darkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+        <MudIconButton Icon="@(ThemeService.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
                        OnClick="@ToggleDarkMode"
                        UserAttributes="@(new Dictionary<string, object>{{"id","darkModeToggle"}})" />
     </MudAppBar>
@@ -29,21 +30,14 @@
 </MudLayout>
 
 @code {
-    private bool _darkMode;
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnInitialized()
     {
-        if (firstRender)
-        {
-            _darkMode = await Browser.GetDarkModeAsync();
-            StateHasChanged();
-        }
+        ThemeService.OnChange += OnThemeChanged;
     }
 
     private async Task ToggleDarkMode()
     {
-        _darkMode = !_darkMode;
-        await Browser.SaveDarkModeAsync(_darkMode);
+        await ThemeService.ToggleDarkModeAsync();
     }
 
     private void OpenSubscribe()
@@ -51,5 +45,10 @@
         DialogService.Show<Subscribe>("Subscribe");
     }
 
-    private string? LayoutClass => _darkMode ? "mud-theme-dark" : null;
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ThemeService.OnChange -= OnThemeChanged;
+    }
 }

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -99,6 +99,7 @@ razorComponentsBuilder.AddInteractiveServerComponents(options =>
 });
 builder.Services.AddMudServices();
 builder.Services.AddScoped<BrowserInteropService>();
+builder.Services.AddScoped<ThemeService>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Predictorator.Services;
+
+public class ThemeService
+{
+    private readonly BrowserInteropService _browser;
+
+    public bool IsDarkMode { get; private set; }
+
+    public event Action? OnChange;
+
+    public ThemeService(BrowserInteropService browser)
+    {
+        _browser = browser;
+    }
+
+    public async Task InitializeAsync()
+    {
+        IsDarkMode = await _browser.GetDarkModeAsync();
+    }
+
+    public async Task ToggleDarkModeAsync()
+    {
+        IsDarkMode = !IsDarkMode;
+        await _browser.SaveDarkModeAsync(IsDarkMode);
+        OnChange?.Invoke();
+    }
+
+    public async Task SetDarkModeAsync(bool value)
+    {
+        if (IsDarkMode != value)
+        {
+            IsDarkMode = value;
+            await _browser.SaveDarkModeAsync(value);
+            OnChange?.Invoke();
+        }
+    }
+}

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -2,12 +2,10 @@ window.app = (() => {
 
     function saveDarkMode(enable) {
         localStorage.setItem('dark-mode', enable ? 'enabled' : 'disabled');
-        document.body.classList.toggle('mud-theme-dark', enable);
     }
 
     function getDarkMode() {
         const enabled = localStorage.getItem('dark-mode') === 'enabled';
-        document.body.classList.toggle('mud-theme-dark', enabled);
         return enabled;
     }
 


### PR DESCRIPTION
## Summary
- add `ThemeService` to handle dark mode via MudBlazor theme provider
- update `MainLayout` and `App.razor` to use the service
- remove custom CSS switching from `site.js`
- register the service in Program
- adjust BUnit tests for the new service

## Testing
- `dotnet test Predictorator.sln`
- `dotnet format Predictorator.sln --no-restore` *(failed: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6854725f5110832888ba3768967d5683