### PR TITLE
Fix dark mode toggle

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -11,7 +11,8 @@
     <HeadOutlet />
 </head>
 <body>
-    <MudThemeProvider IsDarkMode="@ThemeService.IsDarkMode" />
+    <MudThemeProvider IsDarkMode="@ThemeService.IsDarkMode"
+                      IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
     <MudSnackbarProvider />
     <Routes @rendermode="InteractiveServer" />
     <script src="_framework/blazor.server.js"></script>


### PR DESCRIPTION
## Summary
- wire MudThemeProvider dark mode change event to ThemeService

## Testing
- `dotnet format --no-restore`
- `dotnet test Predictorator.sln --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68547cdb4278832882c839de3c81ce65