### PR TITLE
Fix dark mode

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -11,7 +11,8 @@
     <HeadOutlet />
 </head>
 <body>
-    <MudThemeProvider IsDarkMode="@ThemeService.IsDarkMode"
+    <MudThemeProvider @rendermode="InteractiveServer"
+                      IsDarkMode="@ThemeService.IsDarkMode"
                       IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
     <MudSnackbarProvider />
     <Routes @rendermode="InteractiveServer" />
@@ -29,8 +30,9 @@
     {
         if (firstRender)
         {
-            await ThemeService.InitializeAsync();
             ThemeService.OnChange += OnThemeChanged;
+            await ThemeService.InitializeAsync();
+            StateHasChanged();
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the MudBlazor theme provider is interactive so toggling dark mode updates styles

## Testing
- `dotnet build --no-restore` *(fails: project assets missing)*
- `dotnet test Predictorator.sln --no-build` *(fails: invalid test arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685487fd078c8328a0315971863a2103