### PR TITLE
Add SQL error diagnostics and Kudu sink

### DIFF
--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.AzureAppServices" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.AzureApp" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -27,7 +27,7 @@ builder.Host.UseSerilog((context, services, configuration) =>
         .ReadFrom.Configuration(context.Configuration)
         .WriteTo.File(Path.Combine(logDir, "app.log"), rollingInterval: RollingInterval.Day)
         .WriteTo.Console()
-        .WriteTo.AzureAppServices();
+        .WriteTo.AzureApp();
 });
 
 var error = StartupValidator.Validate(builder);
@@ -90,7 +90,7 @@ builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =
         .UseLoggerFactory(loggerFactory)
         .EnableDetailedErrors()
         .EnableSensitiveDataLogging()
-        .LogTo(efLogger.LogError, LogLevel.Error);
+        .LogTo(message => efLogger.LogError(message), LogLevel.Error);
 });
 builder.Services.AddIdentity<IdentityUser, IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()


### PR DESCRIPTION
## Summary
- log Entity Framework Core errors with detailed diagnostics
- send logs to the Kudu log stream via console and Azure App Services sinks
- include new Serilog packages for console and Azure App Services logging

## Testing
- `dotnet format --no-restore`
- `dotnet test Predictorator.Tests/Predictorator.Tests.csproj --verbosity minimal` *(fails: Microsoft.Build.Exceptions.InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_68552d78d474832893e248686daeecaf