### PR TITLE
Fix interactivity script path

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -16,7 +16,7 @@
                       IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
     <MudSnackbarProvider />
     <Routes />
-    <script src="_framework/blazor.server.js"></script>
+    <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/site.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- use blazor.web.js for interactive server mode

## Testing
- `dotnet build Predictorator.sln -c Release`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68556dfa25fc83289e6178d735beda88