### PR TITLE
Fix missing popover provider

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -14,6 +14,7 @@
     <MudThemeProvider IsDarkMode="@ThemeService.IsDarkMode"
                       IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
     <MudSnackbarProvider />
+    <MudPopoverProvider />
     <Routes />
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>


### PR DESCRIPTION
## Summary
- add `MudPopoverProvider` to `App.razor`

## Testing
- `dotnet build Predictorator.sln`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685577856bd883289a1f0a85ed723820