### PR TITLE
Add Docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY Predictorator/Predictorator.csproj Predictorator/
+RUN dotnet restore Predictorator/Predictorator.csproj
+COPY . .
+WORKDIR /src/Predictorator
+RUN dotnet publish -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+EXPOSE 8080
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Predictorator.dll"]

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ dotnet test Predictorator.sln
 The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application.
+
+To run the application in Docker using the latest Compose Specification:
+
+```bash
+docker compose up --build
+```
+
+This will start both the web application and a SQL Server container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Your_password123"
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql-data:/var/opt/mssql
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__DefaultConnection: Server=db;Database=Predictorator;User Id=sa;Password=Your_password123;Encrypt=False
+      ADMIN_EMAIL: admin@example.com
+      ADMIN_PASSWORD: Admin123!
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+
+volumes:
+  mssql-data:


### PR DESCRIPTION
## Summary
- add Dockerfile for Predictorator project
- add `docker-compose.yml` with SQL Server service
- document how to run via `docker compose`

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6855878041f08328b637aee107ed9097