### PR TITLE
Fix Dockerfile .NET SDK version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0.301 AS build
 WORKDIR /src
 COPY Predictorator/Predictorator.csproj Predictorator/
 RUN dotnet restore Predictorator/Predictorator.csproj


### PR DESCRIPTION
## Summary
- ensure Docker uses the same .NET SDK version as global.json

## Testing
- `dotnet test Predictorator.sln`
- `dotnet format --verify-no-changes`

------
https://chatgpt.com/codex/tasks/task_e_6855accc89b083288580fe8c3c1aa3fe