### PR TITLE
Fix week navigation query parsing

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -93,6 +93,11 @@ else if (_fixtures.Response.Any())
 
     protected override async Task OnParametersSetAsync()
     {
+        var query = QueryHelpers.ParseQuery(new Uri(NavigationManager.Uri).Query);
+        if (!query.ContainsKey("fromDate")) FromDate = null;
+        if (!query.ContainsKey("toDate")) ToDate = null;
+        if (!query.ContainsKey("weekOffset")) WeekOffset = null;
+
         var (from, to) = DateRangeCalculator.GetDates(FromDate, ToDate, WeekOffset);
         _fromDate = from;
         _toDate = to;


### PR DESCRIPTION
## Summary
- ensure week navigation resets unused query parameters
- parse query string in `Index.razor` to drop stale date range values

## Testing
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68712b4eb3e08328a25b0396e31204fb