### PR TITLE
Persist DataProtection keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+dp-keys/
 
 # Uncomment if needed, or add a specific file extension for other build directories
 #**/[Bb]uild/

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -10,6 +10,7 @@ using Predictorator.Startup;
 using Resend;
 using Serilog;
 using Serilog.Events;
+using Microsoft.AspNetCore.DataProtection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -110,6 +111,14 @@ builder.Services.AddMudServices();
 builder.Services.AddScoped<BrowserInteropService>();
 builder.Services.AddScoped<ThemeService>();
 builder.Services.AddRazorPages();
+
+var keyPath = builder.Configuration["DataProtection:KeyPath"];
+if (string.IsNullOrWhiteSpace(keyPath))
+    keyPath = Path.Combine(builder.Environment.ContentRootPath, "dp-keys");
+Directory.CreateDirectory(keyPath);
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(keyPath))
+    .SetApplicationName("Predictorator");
 
 var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ docker compose up --build
 ```
 
 This will start both the web application and a SQL Server container.
+
+Data Protection keys are persisted to `./dp-keys` by default. When running in Docker,
+the keys are stored in `/var/dp-keys` which is backed by the `dp-keys` volume.
+You can override the location by setting the `DataProtection__KeyPath` environment
+variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,14 @@ services:
       ConnectionStrings__DefaultConnection: Server=db;Database=Predictorator;User Id=sa;Password=Your_password123;Encrypt=False
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWORD: Admin123!
+      DataProtection__KeyPath: /var/dp-keys
     depends_on:
       - db
     ports:
       - "8080:8080"
+    volumes:
+      - dp-keys:/var/dp-keys
 
 volumes:
   mssql-data:
+  dp-keys:


### PR DESCRIPTION
## Summary
- persist ASP.NET DataProtection keys to a configurable path
- mount dp-keys volume in docker compose
- document the key storage location
- ignore local dp-keys directory

## Testing
- `dotnet build Predictorator.sln`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68712bd5aefc832888cdba1413c5cffd