### PR TITLE
Fix week navigation query handling

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -87,4 +87,32 @@ public class IndexPageBUnitTests
         Assert.NotNull(home);
         Assert.NotNull(away);
     }
+
+    [Fact]
+    public async Task WeekNavigation_Uses_WeekOffset_And_Buttons_Remain_Enabled()
+    {
+        await using var ctx = CreateContext();
+        var navMan = (NavigationManager)ctx.Services.GetRequiredService<NavigationManager>();
+        RenderFragment body = b =>
+        {
+            b.OpenComponent<IndexPage>(0);
+            b.CloseComponent();
+        };
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        var next = cut.Find("#nextWeekBtn");
+        var prev = cut.Find("#prevWeekBtn");
+        Assert.False(next.HasAttribute("disabled"));
+        Assert.False(prev.HasAttribute("disabled"));
+
+        next.Click();
+        Assert.Contains("weekOffset=1", navMan.Uri);
+        Assert.DoesNotContain("fromDate", navMan.Uri);
+        Assert.DoesNotContain("toDate", navMan.Uri);
+
+        cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        next = cut.Find("#nextWeekBtn");
+        prev = cut.Find("#prevWeekBtn");
+        Assert.False(next.HasAttribute("disabled"));
+        Assert.False(prev.HasAttribute("disabled"));
+    }
 }

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -133,9 +133,14 @@ else if (_fixtures.Response.Any())
     {
         if (range.Start.HasValue && range.End.HasValue)
         {
+            var newFrom = range.Start.Value.Date;
+            var newTo = range.End.Value.Date;
+            if (newFrom == _fromDate && newTo == _toDate)
+                return;
+
             _selectedRange = range;
-            _fromDate = range.Start.Value.Date;
-            _toDate = range.End.Value.Date;
+            _fromDate = newFrom;
+            _toDate = newTo;
             Reload();
         }
     }


### PR DESCRIPTION
## Summary
- prevent range picker events from firing when navigating by week
- verify navigation uses weekOffset and buttons stay enabled

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6871327097348328a783833823aa70e1