### PR TITLE
Fix dark mode and subscribe buttons

### DIFF
--- a/Predictorator/Components/Layout/DarkModeToggle.razor
+++ b/Predictorator/Components/Layout/DarkModeToggle.razor
@@ -1,0 +1,24 @@
+@implements IDisposable
+@rendermode InteractiveServer
+@inject ThemeService ThemeService
+<MudIconButton Icon="@(ThemeService.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+               OnClick="@ToggleDarkMode"
+               UserAttributes="@(new Dictionary<string, object>{{"id","darkModeToggle"}})" />
+@code {
+    protected override void OnInitialized()
+    {
+        ThemeService.OnChange += OnThemeChanged;
+    }
+
+    private async Task ToggleDarkMode()
+    {
+        await ThemeService.ToggleDarkModeAsync();
+    }
+
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ThemeService.OnChange -= OnThemeChanged;
+    }
+}

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -1,9 +1,7 @@
 @implements IDisposable
-@using Predictorator.Components.Pages.Subscription
 @inherits LayoutComponentBase
 @inject IHttpContextAccessor HttpContextAccessor
 @inject ThemeService ThemeService
-@inject IDialogService DialogService
 <MudLayout>
     <MudThemeProvider @rendermode="InteractiveServer"
                       IsDarkMode="@ThemeService.IsDarkMode"
@@ -20,10 +18,8 @@
         {
             <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
         }
-        <MudButton Variant="Variant.Text" OnClick="@OpenSubscribe">Subscribe</MudButton>
-        <MudIconButton Icon="@(ThemeService.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
-                       OnClick="@ToggleDarkMode"
-                       UserAttributes="@(new Dictionary<string, object>{{"id","darkModeToggle"}})" />
+        <SubscribeButton />
+        <DarkModeToggle />
     </MudAppBar>
 
     <MudMainContent>
@@ -38,16 +34,6 @@
     protected override void OnInitialized()
     {
         ThemeService.OnChange += OnThemeChanged;
-    }
-
-    private async Task ToggleDarkMode()
-    {
-        await ThemeService.ToggleDarkModeAsync();
-    }
-
-    private void OpenSubscribe()
-    {
-        DialogService.Show<Subscribe>("Subscribe");
     }
 
     private void OnThemeChanged() => InvokeAsync(StateHasChanged);

--- a/Predictorator/Components/Layout/SubscribeButton.razor
+++ b/Predictorator/Components/Layout/SubscribeButton.razor
@@ -1,0 +1,10 @@
+@rendermode InteractiveServer
+@using Predictorator.Components.Pages.Subscription
+@inject IDialogService DialogService
+<MudButton Variant="Variant.Text" OnClick="@OpenSubscribe">Subscribe</MudButton>
+@code {
+    private void OpenSubscribe()
+    {
+        DialogService.Show<Subscribe>("Subscribe");
+    }
+}


### PR DESCRIPTION
## Summary
- make standalone interactive components for dark mode toggle and subscribe dialog
- use these components in `MainLayout`
- remove unused event handlers

## Testing
- `dotnet build Predictorator.sln -c Debug`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6871355768f48328a61af6c25939884d