### PR TITLE
Reduce artifact retention to 1 day

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           name: app
           path: publish
+          retention-days: 1
 
   deploy_prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- limit uploaded artifact retention to a single day in cd workflow

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6871456e0bfc83288e3f05e8351835f1