### PR TITLE
Add reset button for date range

### DIFF
--- a/Predictorator.Tests/HomePageTests.cs
+++ b/Predictorator.Tests/HomePageTests.cs
@@ -76,5 +76,6 @@ public class HomePageTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.NotNull(doc.QuerySelector("#copyBtn"));
         Assert.NotNull(doc.QuerySelector("#fillRandomBtn"));
         Assert.NotNull(doc.QuerySelector("#clearBtn"));
+        Assert.NotNull(doc.QuerySelector("#resetBtn"));
     }
 }

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -115,4 +115,32 @@ public class IndexPageBUnitTests
         Assert.False(next.HasAttribute("disabled"));
         Assert.False(prev.HasAttribute("disabled"));
     }
+
+    [Fact]
+    public async Task ResetButton_Removes_Date_Range_And_Reenables_Week_Navigation()
+    {
+        await using var ctx = CreateContext();
+        var navMan = (NavigationManager)ctx.Services.GetRequiredService<NavigationManager>();
+        navMan.NavigateTo("/?fromDate=2024-02-01&toDate=2024-02-07");
+
+        RenderFragment body = b =>
+        {
+            b.OpenComponent<IndexPage>(0);
+            b.CloseComponent();
+        };
+
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        var next = cut.Find("#nextWeekBtn");
+        var reset = cut.Find("#resetBtn");
+        Assert.True(next.HasAttribute("disabled"));
+        Assert.False(reset.HasAttribute("disabled"));
+
+        reset.Click();
+        Assert.DoesNotContain("fromDate", navMan.Uri);
+        Assert.DoesNotContain("toDate", navMan.Uri);
+
+        cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        next = cut.Find("#nextWeekBtn");
+        Assert.False(next.HasAttribute("disabled"));
+    }
 }

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -17,6 +17,8 @@
     </MudText>
     <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="!_autoWeek" OnClick="@(() => ChangeWeek(1))"
                    UserAttributes="@(new Dictionary<string, object>{{"id","nextWeekBtn"}})" />
+    <MudIconButton Icon="@Icons.Material.Filled.Refresh" Disabled="_autoWeek" OnClick="ResetRange"
+                   UserAttributes="@(new Dictionary<string, object>{{"id","resetBtn"}})" />
 </MudPaper>
 <MudCollapse Expanded="_showPicker">
     <MudDateRangePicker DateRange="_selectedRange" DateRangeChanged="RangeChanged" Class="my-2"
@@ -238,6 +240,11 @@ else if (_fixtures.Response.Any())
             await Browser.CopyToClipboardTextAsync(sbText.ToString());
         else
             await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+    }
+
+    private void ResetRange()
+    {
+        NavigationManager.NavigateTo("/");
     }
 
     private class PredictionInput


### PR DESCRIPTION
## Summary
- add a refresh icon button to reset the date range
- implement ResetRange handler
- verify reset logic in BUnit tests and update home page test

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6872407955408328a175b2a477ad9217