### PR TITLE
Fix fixture row width

### DIFF
--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -21,6 +21,12 @@ html, body {
     width: 100%;
 }
 
+/* Ensure table rows stretch the full table width */
+.fixture-row td {
+    padding: 0;
+    width: 100%;
+}
+
 .home-name {
     text-align: left;
 }


### PR DESCRIPTION
## Summary
- ensure table rows fill the MudTable width so fixtures render correctly

## Testing
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68751314cd1c8328a0d83f6c77fa182a