### PR TITLE
Add phone subscription support with Twilio

### DIFF
--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -10,23 +10,24 @@ namespace Predictorator.Tests;
 
 public class SubscriptionServiceTests
 {
-    private static SubscriptionService CreateService(out ApplicationDbContext db, out IResend resend)
+    private static SubscriptionService CreateService(out ApplicationDbContext db, out IResend resend, out ITwilioSmsSender sms)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         db = new ApplicationDbContext(options);
         resend = Substitute.For<IResend>();
+        sms = Substitute.For<ITwilioSmsSender>();
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Resend:From"] = "from@example.com" })
             .Build();
-        return new SubscriptionService(db, resend, config);
+        return new SubscriptionService(db, resend, config, sms);
     }
 
     [Fact]
     public async Task AddSubscriberAsync_sends_email_with_links()
     {
-        var service = CreateService(out var db, out var resend);
+        var service = CreateService(out var db, out var resend, out _);
         await service.AddSubscriberAsync("user@example.com", "http://localhost");
 
         await resend.Received().EmailSendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
@@ -37,7 +38,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task VerifyAsync_marks_subscriber_verified()
     {
-        var service = CreateService(out var db, out _);
+        var service = CreateService(out var db, out _, out _);
         var subscriber = new Subscriber { Email = "a", VerificationToken = "token", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.Subscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -51,7 +52,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeAsync_removes_subscriber()
     {
-        var service = CreateService(out var db, out _);
+        var service = CreateService(out var db, out _, out _);
         var subscriber = new Subscriber { Email = "a", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.Subscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -60,5 +61,44 @@ public class SubscriptionServiceTests
 
         Assert.True(result);
         Assert.Empty(db.Subscribers);
+    }
+
+    [Fact]
+    public async Task AddSmsSubscriberAsync_sends_sms()
+    {
+        var service = CreateService(out var db, out _, out var sms);
+        await service.AddSmsSubscriberAsync("+123", "http://localhost");
+
+        await sms.Received().SendSmsAsync("+123", Arg.Any<string>());
+        var subscriber = await db.SmsSubscribers.SingleAsync();
+        Assert.False(subscriber.IsVerified);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_marks_sms_subscriber_verified()
+    {
+        var service = CreateService(out var db, out _, out _);
+        var subscriber = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "t", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
+        db.SmsSubscribers.Add(subscriber);
+        await db.SaveChangesAsync();
+
+        var result = await service.VerifyAsync("t");
+
+        Assert.True(result);
+        Assert.True(subscriber.IsVerified);
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_removes_sms_subscriber()
+    {
+        var service = CreateService(out var db, out _, out _);
+        var subscriber = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
+        db.SmsSubscribers.Add(subscriber);
+        await db.SaveChangesAsync();
+
+        var result = await service.UnsubscribeAsync("u");
+
+        Assert.True(result);
+        Assert.Empty(db.SmsSubscribers);
     }
 }

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -5,33 +5,62 @@
 
 <MudPaper Class="pa-4" Elevation="1">
     <h2>Subscribe to Notifications</h2>
-
-    @if (_submitted)
-    {
-        <p>A verification link has been sent to your email address.</p>
-    }
-    else
-    {
-        <EditForm Model="this" OnValidSubmit="HandleSubmit">
-            <MudStack Spacing="2">
-                <DataAnnotationsValidator />
-                <ValidationSummary />
-                <MudTextField @bind-Value="Email" Label="Email address" For="@(() => Email)" />
-                <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
-            </MudStack>
-        </EditForm>
-    }
+    <MudTabs>
+        <MudTabPanel Text="Email">
+            @if (_emailSubmitted)
+            {
+                <p>A verification link has been sent to your email address.</p>
+            }
+            else
+            {
+                <EditForm Model="this" OnValidSubmit="HandleEmailSubmit">
+                    <MudStack Spacing="2">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        <MudTextField @bind-Value="Email" Label="Email address" For="@(() => Email)" />
+                        <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
+                    </MudStack>
+                </EditForm>
+            }
+        </MudTabPanel>
+        <MudTabPanel Text="SMS">
+            @if (_phoneSubmitted)
+            {
+                <p>A verification link has been sent to your phone.</p>
+            }
+            else
+            {
+                <EditForm Model="this" OnValidSubmit="HandlePhoneSubmit">
+                    <MudStack Spacing="2">
+                        <DataAnnotationsValidator />
+                        <ValidationSummary />
+                        <MudTextField @bind-Value="PhoneNumber" Label="Phone number" For="@(() => PhoneNumber)" />
+                        <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
+                    </MudStack>
+                </EditForm>
+            }
+        </MudTabPanel>
+    </MudTabs>
 </MudPaper>
 
 @code {
     [Required, EmailAddress]
     public string Email { get; set; } = string.Empty;
-    private bool _submitted;
-
-    private async Task HandleSubmit()
+    [Required, Phone]
+    public string PhoneNumber { get; set; } = string.Empty;
+    private bool _emailSubmitted;
+    private bool _phoneSubmitted;
+    private async Task HandleEmailSubmit()
     {
         var baseUrl = Navigation.BaseUri.TrimEnd('/');
         await SubscriptionService.AddSubscriberAsync(Email, baseUrl);
-        _submitted = true;
+        _emailSubmitted = true;
+    }
+
+    private async Task HandlePhoneSubmit()
+    {
+        var baseUrl = Navigation.BaseUri.TrimEnd('/');
+        await SubscriptionService.AddSmsSubscriberAsync(PhoneNumber, baseUrl);
+        _phoneSubmitted = true;
     }
 }

--- a/Predictorator/Components/Pages/Subscription/Verify.razor
+++ b/Predictorator/Components/Pages/Subscription/Verify.razor
@@ -9,7 +9,7 @@
 }
 else if (_result == true)
 {
-    <p>Your email has been verified.</p>
+    <p>Your subscription has been verified.</p>
 }
 else
 {

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -13,4 +13,5 @@ public class ApplicationDbContext : IdentityDbContext<IdentityUser>
     }
 
     public DbSet<Subscriber> Subscribers => Set<Subscriber>();
+    public DbSet<SmsSubscriber> SmsSubscribers => Set<SmsSubscriber>();
 }

--- a/Predictorator/Models/SmsSubscriber.cs
+++ b/Predictorator/Models/SmsSubscriber.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Predictorator.Models;
+
+public class SmsSubscriber
+{
+    public int Id { get; set; }
+    public string PhoneNumber { get; set; } = string.Empty;
+    public bool IsVerified { get; set; }
+    public string VerificationToken { get; set; } = string.Empty;
+    public string UnsubscribeToken { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/Predictorator/Options/TwilioOptions.cs
+++ b/Predictorator/Options/TwilioOptions.cs
@@ -1,0 +1,10 @@
+namespace Predictorator.Options;
+
+public class TwilioOptions
+{
+    public const string SectionName = "Twilio";
+
+    public string AccountSid { get; set; } = string.Empty;
+    public string AuthToken { get; set; } = string.Empty;
+    public string FromNumber { get; set; } = string.Empty;
+}

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.AzureApp" Version="3.1.0" />
+    <PackageReference Include="Twilio" Version="6.7.1" />
   </ItemGroup>
 
 </Project>

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -70,6 +70,8 @@ builder.Services.Configure<ResendClientOptions>(o =>
     o.ApiToken = builder.Configuration["Resend:ApiToken"]!;
 });
 builder.Services.AddTransient<IResend, ResendClient>();
+builder.Services.Configure<TwilioOptions>(builder.Configuration.GetSection(TwilioOptions.SectionName));
+builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.Configure<AdminUserOptions>(options =>
 {

--- a/Predictorator/Services/ITwilioSmsSender.cs
+++ b/Predictorator/Services/ITwilioSmsSender.cs
@@ -1,0 +1,6 @@
+namespace Predictorator.Services;
+
+public interface ITwilioSmsSender
+{
+    Task SendSmsAsync(string to, string message);
+}

--- a/Predictorator/Services/TwilioSmsSender.cs
+++ b/Predictorator/Services/TwilioSmsSender.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Options;
+using Predictorator.Options;
+using Twilio;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Types;
+
+namespace Predictorator.Services;
+
+public class TwilioSmsSender : ITwilioSmsSender
+{
+    private readonly TwilioOptions _options;
+
+    public TwilioSmsSender(IOptions<TwilioOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public Task SendSmsAsync(string to, string message)
+    {
+        TwilioClient.Init(_options.AccountSid, _options.AuthToken);
+        return MessageResource.CreateAsync(
+            to: new PhoneNumber(to),
+            from: new PhoneNumber(_options.FromNumber),
+            body: message);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ dotnet test Predictorator.sln
 The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application.
+SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
+`Twilio__FromNumber` environment variables with your Twilio credentials.
 
 To run the application in Docker using the latest Compose Specification:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       ConnectionStrings__DefaultConnection: Server=db;Database=Predictorator;User Id=sa;Password=Your_password123;Encrypt=False
       ADMIN_EMAIL: admin@example.com
       ADMIN_PASSWORD: Admin123!
+      Twilio__AccountSid: your_sid
+      Twilio__AuthToken: your_token
+      Twilio__FromNumber: +10000000000
       DataProtection__KeyPath: /var/dp-keys
     depends_on:
       - db

--- a/flyway/sql/V3__AddSmsSubscribers.sql
+++ b/flyway/sql/V3__AddSmsSubscribers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "SmsSubscribers" (
+    "Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "PhoneNumber" TEXT NOT NULL,
+    "IsVerified" INTEGER NOT NULL,
+    "VerificationToken" TEXT NOT NULL,
+    "UnsubscribeToken" TEXT NOT NULL,
+    "CreatedAt" TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- allow subscribing via SMS in Subscribe popup
- store phone subscriptions in new `SmsSubscriber` table
- send verification messages through Twilio
- support Twilio configuration and containers
- extend tests for SMS subscription

## Testing
- `dotnet test Predictorator.sln`
- `dotnet format --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_687530007db88328a95795fa177b474c