### PR TITLE
Fix dark mode with MudThemeProvider

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -24,8 +24,7 @@ public class IndexPageBUnitTests
         ctx.Services.AddSingleton(jsRuntime);
         var browser = new BrowserInteropService(jsRuntime);
         ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService(browser);
-        theme.InitializeAsync().GetAwaiter().GetResult();
+        var theme = new ThemeService();
         ctx.Services.AddSingleton(theme);
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));

--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -27,7 +27,6 @@
         if (firstRender)
         {
             ThemeService.OnChange += OnThemeChanged;
-            await ThemeService.InitializeAsync();
             StateHasChanged();
         }
     }

--- a/Predictorator/Components/Layout/DarkModeToggle.razor
+++ b/Predictorator/Components/Layout/DarkModeToggle.razor
@@ -10,9 +10,9 @@
         ThemeService.OnChange += OnThemeChanged;
     }
 
-    private async Task ToggleDarkMode()
+    private void ToggleDarkMode()
     {
-        await ThemeService.ToggleDarkModeAsync();
+        ThemeService.ToggleDarkMode();
     }
 
     private void OnThemeChanged() => InvokeAsync(StateHasChanged);

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
 <MudLayout>
     <MudThemeProvider @rendermode="InteractiveServer"
                       IsDarkMode="@ThemeService.IsDarkMode"
-                      IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
+                      IsDarkModeChanged="@ThemeService.SetDarkMode" />
 
     <MudPopoverProvider  @rendermode="InteractiveServer" />
     <MudDialogProvider    @rendermode="InteractiveServer" />

--- a/Predictorator/Services/BrowserInteropService.cs
+++ b/Predictorator/Services/BrowserInteropService.cs
@@ -11,10 +11,6 @@ public class BrowserInteropService
         _js = js;
     }
 
-    public ValueTask<bool> GetDarkModeAsync() => _js.InvokeAsync<bool>("app.getDarkMode");
-
-    public ValueTask SaveDarkModeAsync(bool enable) => _js.InvokeVoidAsync("app.saveDarkMode", enable);
-
     public ValueTask CopyToClipboardTextAsync(string text) => _js.InvokeVoidAsync("app.copyToClipboardText", text);
 
     public ValueTask CopyToClipboardHtmlAsync(string html) => _js.InvokeVoidAsync("app.copyToClipboardHtml", html);

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -2,36 +2,20 @@ namespace Predictorator.Services;
 
 public class ThemeService
 {
-    private readonly BrowserInteropService _browser;
-
     public bool IsDarkMode { get; private set; }
 
     public event Action? OnChange;
 
-    public ThemeService(BrowserInteropService browser)
+    public void ToggleDarkMode()
     {
-        _browser = browser;
+        SetDarkMode(!IsDarkMode);
     }
 
-    public async Task InitializeAsync()
-    {
-        IsDarkMode = await _browser.GetDarkModeAsync();
-        OnChange?.Invoke();
-    }
-
-    public async Task ToggleDarkModeAsync()
-    {
-        IsDarkMode = !IsDarkMode;
-        await _browser.SaveDarkModeAsync(IsDarkMode);
-        OnChange?.Invoke();
-    }
-
-    public async Task SetDarkModeAsync(bool value)
+    public void SetDarkMode(bool value)
     {
         if (IsDarkMode != value)
         {
             IsDarkMode = value;
-            await _browser.SaveDarkModeAsync(value);
             OnChange?.Invoke();
         }
     }

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -1,13 +1,5 @@
 window.app = (() => {
 
-    function saveDarkMode(enable) {
-        localStorage.setItem('dark-mode', enable ? 'enabled' : 'disabled');
-    }
-
-    function getDarkMode() {
-        const enabled = localStorage.getItem('dark-mode') === 'enabled';
-        return enabled;
-    }
 
     function copyToClipboardText(text) {
         navigator.clipboard.writeText(text).then(() => {
@@ -35,8 +27,6 @@ window.app = (() => {
     }
 
     return {
-        saveDarkMode,
-        getDarkMode,
         copyToClipboardText,
         copyToClipboardHtml,
         isMobileDevice


### PR DESCRIPTION
## Summary
- rely entirely on `MudThemeProvider` for dark mode
- drop manual JS persistence helpers
- simplify `ThemeService` and update consumers
- adjust unit tests to check service state only

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68751e2056fc8328892080e1e3c29992