### PR TITLE
Enable optional email and SMS subscriptions

### DIFF
--- a/Predictorator.Tests/DarkModeBUnitTests.cs
+++ b/Predictorator.Tests/DarkModeBUnitTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.JSInterop;
 using MudBlazor;
 using MudBlazor.Services;
@@ -34,6 +35,17 @@ public class DarkModeBUnitTests
         };
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
         return ctx;
     }
 
@@ -69,6 +81,17 @@ public class DarkModeBUnitTests
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
 
         var cut = ctx.Render<App>();
 

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -2,6 +2,7 @@ using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.JSInterop;
 using MudBlazor.Services;
 using NSubstitute;
@@ -34,6 +35,17 @@ public class IndexPageBUnitTests
             UtcNow = new DateTime(2024, 1, 1)
         };
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
         return ctx;
     }
 

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -1,0 +1,66 @@
+using Bunit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using MudBlazor.Services;
+using MudBlazor;
+using NSubstitute;
+using Predictorator.Components.Pages.Subscription;
+using Predictorator.Data;
+using Predictorator.Services;
+using Resend;
+
+namespace Predictorator.Tests;
+
+public class SubscribeComponentBUnitTests
+{
+    private BunitContext CreateContext(Dictionary<string,string?> settings)
+    {
+        var ctx = new BunitContext();
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        var jsRuntime = Substitute.For<IJSRuntime>();
+        ctx.Services.AddSingleton(jsRuntime);
+        ctx.Services.AddSingleton(new BrowserInteropService(jsRuntime));
+        ctx.Services.AddSingleton(new ThemeService());
+        ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var db = new ApplicationDbContext(options);
+        var resend = Substitute.For<IResend>();
+        var sms = Substitute.For<ITwilioSmsSender>();
+        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms));
+        return ctx;
+    }
+
+    [Fact]
+    public async Task Renders_Email_Tab_When_Resend_Configured()
+    {
+        await using var ctx = CreateContext(new Dictionary<string,string?> { ["Resend:ApiToken"] = "token" });
+        var cut = ctx.Render<Subscribe>();
+        Assert.Contains("Email address", cut.Markup);
+        Assert.DoesNotContain("Phone number", cut.Markup);
+    }
+
+    [Fact]
+    public async Task Renders_Sms_Tab_When_Twilio_Configured()
+    {
+        await using var ctx = CreateContext(new Dictionary<string,string?>
+        {
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        });
+        var cut = ctx.Render<Subscribe>();
+        Assert.Contains("Phone number", cut.Markup);
+        Assert.DoesNotContain("Email address", cut.Markup);
+    }
+}

--- a/Predictorator/Components/Layout/SubscribeButton.razor
+++ b/Predictorator/Components/Layout/SubscribeButton.razor
@@ -1,7 +1,11 @@
 @rendermode InteractiveServer
 @using Predictorator.Components.Pages.Subscription
 @inject IDialogService DialogService
-<MudButton Variant="Variant.Text" OnClick="@OpenSubscribe">Subscribe</MudButton>
+@inject NotificationFeatureService Features
+@if (Features.AnyEnabled)
+{
+    <MudButton Variant="Variant.Text" OnClick="@OpenSubscribe">Subscribe</MudButton>
+}
 @code {
     private void OpenSubscribe()
     {

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -2,11 +2,14 @@
 @rendermode InteractiveServer
 @inject SubscriptionService SubscriptionService
 @inject NavigationManager Navigation
+@inject NotificationFeatureService Features
 
 <MudPaper Class="pa-4" Elevation="1">
     <h2>Subscribe to Notifications</h2>
     <MudTabs>
-        <MudTabPanel Text="Email">
+        @if (Features.EmailEnabled)
+        {
+            <MudTabPanel Text="Email">
             @if (_emailSubmitted)
             {
                 <p>A verification link has been sent to your email address.</p>
@@ -22,8 +25,11 @@
                     </MudStack>
                 </EditForm>
             }
-        </MudTabPanel>
-        <MudTabPanel Text="SMS">
+            </MudTabPanel>
+        }
+        @if (Features.SmsEnabled)
+        {
+            <MudTabPanel Text="SMS">
             @if (_phoneSubmitted)
             {
                 <p>A verification link has been sent to your phone.</p>
@@ -39,7 +45,8 @@
                     </MudStack>
                 </EditForm>
             }
-        </MudTabPanel>
+            </MudTabPanel>
+        }
     </MudTabs>
 </MudPaper>
 

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -73,6 +73,7 @@ builder.Services.AddTransient<IResend, ResendClient>();
 builder.Services.Configure<TwilioOptions>(builder.Configuration.GetSection(TwilioOptions.SectionName));
 builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
+builder.Services.AddSingleton<NotificationFeatureService>();
 builder.Services.Configure<AdminUserOptions>(options =>
 {
     builder.Configuration.GetSection(AdminUserOptions.SectionName).Bind(options);

--- a/Predictorator/Services/NotificationFeatureService.cs
+++ b/Predictorator/Services/NotificationFeatureService.cs
@@ -1,0 +1,20 @@
+namespace Predictorator.Services;
+
+public class NotificationFeatureService
+{
+    private readonly IConfiguration _config;
+
+    public NotificationFeatureService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public bool EmailEnabled => !string.IsNullOrWhiteSpace(_config["Resend:ApiToken"]);
+
+    public bool SmsEnabled =>
+        !string.IsNullOrWhiteSpace(_config["Twilio:AccountSid"]) &&
+        !string.IsNullOrWhiteSpace(_config["Twilio:AuthToken"]) &&
+        !string.IsNullOrWhiteSpace(_config["Twilio:FromNumber"]);
+
+    public bool AnyEnabled => EmailEnabled || SmsEnabled;
+}

--- a/Predictorator/Startup/StartupExitCode.cs
+++ b/Predictorator/Startup/StartupExitCode.cs
@@ -3,6 +3,5 @@ namespace Predictorator.Startup;
 public enum StartupExitCode
 {
     MissingRapidApiKey = 1,
-    MissingResendApiToken = 2,
-    MissingConnectionString = 3
+    MissingConnectionString = 2
 }

--- a/Predictorator/Startup/StartupValidator.cs
+++ b/Predictorator/Startup/StartupValidator.cs
@@ -10,9 +10,6 @@ public static class StartupValidator
         if (string.IsNullOrWhiteSpace(builder.Configuration["ApiSettings:RapidApiKey"]))
             return StartupExitCode.MissingRapidApiKey;
 
-        if (string.IsNullOrWhiteSpace(builder.Configuration["Resend:ApiToken"]))
-            return StartupExitCode.MissingResendApiToken;
-
         var connection = builder.Configuration.GetConnectionString("DefaultConnection");
         if (string.IsNullOrWhiteSpace(connection))
             return StartupExitCode.MissingConnectionString;


### PR DESCRIPTION
## Summary
- add `NotificationFeatureService` for checking Resend and Twilio credentials
- hide Subscribe button and tabs when credentials are missing
- treat Resend API token as optional during startup
- update tests for new feature flags

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687561f1035c8328afa81d5ef9c93816