### PR TITLE
Fix dark mode persistence

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -25,7 +25,7 @@ public class IndexPageBUnitTests
         ctx.Services.AddSingleton(jsRuntime);
         var browser = new BrowserInteropService(jsRuntime);
         ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService();
+        var theme = new ThemeService(browser);
         ctx.Services.AddSingleton(theme);
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));

--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -24,7 +24,7 @@ public class MainLayoutBUnitTests
         ctx.Services.AddSingleton(jsRuntime);
         var browser = new BrowserInteropService(jsRuntime);
         ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService();
+        var theme = new ThemeService(browser);
         ctx.Services.AddSingleton(theme);
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
 

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -16,15 +16,16 @@ namespace Predictorator.Tests;
 
 public class SubscribeComponentBUnitTests
 {
-    private BunitContext CreateContext(Dictionary<string,string?> settings)
+    private BunitContext CreateContext(Dictionary<string, string?> settings)
     {
         var ctx = new BunitContext();
         ctx.Services.AddMudServices();
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
         var jsRuntime = Substitute.For<IJSRuntime>();
         ctx.Services.AddSingleton(jsRuntime);
-        ctx.Services.AddSingleton(new BrowserInteropService(jsRuntime));
-        ctx.Services.AddSingleton(new ThemeService());
+        var browser = new BrowserInteropService(jsRuntime);
+        ctx.Services.AddSingleton(browser);
+        ctx.Services.AddSingleton(new ThemeService(browser));
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
 
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
@@ -44,7 +45,7 @@ public class SubscribeComponentBUnitTests
     [Fact]
     public async Task Renders_Email_Tab_When_Resend_Configured()
     {
-        await using var ctx = CreateContext(new Dictionary<string,string?> { ["Resend:ApiToken"] = "token" });
+        await using var ctx = CreateContext(new Dictionary<string, string?> { ["Resend:ApiToken"] = "token" });
         var cut = ctx.Render<Subscribe>();
         Assert.Contains("Email address", cut.Markup);
         Assert.DoesNotContain("Phone number", cut.Markup);
@@ -53,7 +54,7 @@ public class SubscribeComponentBUnitTests
     [Fact]
     public async Task Renders_Sms_Tab_When_Twilio_Configured()
     {
-        await using var ctx = CreateContext(new Dictionary<string,string?>
+        await using var ctx = CreateContext(new Dictionary<string, string?>
         {
             ["Twilio:AccountSid"] = "sid",
             ["Twilio:AuthToken"] = "token",

--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -27,6 +27,7 @@
         if (firstRender)
         {
             ThemeService.OnChange += OnThemeChanged;
+            await ThemeService.InitializeAsync();
             StateHasChanged();
         }
     }

--- a/Predictorator/Components/Layout/DarkModeToggle.razor
+++ b/Predictorator/Components/Layout/DarkModeToggle.razor
@@ -10,9 +10,9 @@
         ThemeService.OnChange += OnThemeChanged;
     }
 
-    private void ToggleDarkMode()
+    private async Task ToggleDarkMode()
     {
-        ThemeService.ToggleDarkMode();
+        await ThemeService.ToggleDarkModeAsync();
     }
 
     private void OnThemeChanged() => InvokeAsync(StateHasChanged);

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -5,7 +5,7 @@
 <MudLayout>
     <MudThemeProvider @rendermode="InteractiveServer"
                       IsDarkMode="@ThemeService.IsDarkMode"
-                      IsDarkModeChanged="@ThemeService.SetDarkMode" />
+                      IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
 
     <MudPopoverProvider  @rendermode="InteractiveServer" />
     <MudDialogProvider    @rendermode="InteractiveServer" />

--- a/Predictorator/Services/BrowserInteropService.cs
+++ b/Predictorator/Services/BrowserInteropService.cs
@@ -18,4 +18,10 @@ public class BrowserInteropService
     public ValueTask<bool> IsMobileDeviceAsync() => _js.InvokeAsync<bool>("app.isMobileDevice");
 
     public ValueTask AlertAsync(string message) => _js.InvokeVoidAsync("alert", message);
+
+    public ValueTask SetLocalStorageAsync(string key, string value) =>
+        _js.InvokeVoidAsync("app.setLocalStorage", key, value);
+
+    public ValueTask<string?> GetLocalStorageAsync(string key) =>
+        _js.InvokeAsync<string?>("app.getLocalStorage", key);
 }

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -2,20 +2,34 @@ namespace Predictorator.Services;
 
 public class ThemeService
 {
+    private readonly BrowserInteropService _browser;
+
+    public ThemeService(BrowserInteropService browser)
+    {
+        _browser = browser;
+    }
+
     public bool IsDarkMode { get; private set; }
 
     public event Action? OnChange;
 
-    public void ToggleDarkMode()
+    public async Task InitializeAsync()
     {
-        SetDarkMode(!IsDarkMode);
+        var value = await _browser.GetLocalStorageAsync("darkMode");
+        if (bool.TryParse(value, out var result))
+        {
+            IsDarkMode = result;
+        }
     }
 
-    public void SetDarkMode(bool value)
+    public Task ToggleDarkModeAsync() => SetDarkModeAsync(!IsDarkMode);
+
+    public async Task SetDarkModeAsync(bool value)
     {
         if (IsDarkMode != value)
         {
             IsDarkMode = value;
+            await _browser.SetLocalStorageAsync("darkMode", value.ToString().ToLowerInvariant());
             OnChange?.Invoke();
         }
     }

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -26,9 +26,19 @@ window.app = (() => {
             (window.innerWidth <= 800 && window.innerHeight <= 600);
     }
 
+    function setLocalStorage(key, value) {
+        window.localStorage.setItem(key, value);
+    }
+
+    function getLocalStorage(key) {
+        return window.localStorage.getItem(key);
+    }
+
     return {
         copyToClipboardText,
         copyToClipboardHtml,
-        isMobileDevice
+        isMobileDevice,
+        setLocalStorage,
+        getLocalStorage
     };
 })();


### PR DESCRIPTION
## Summary
- add localStorage helpers in site.js
- expose BrowserInteropService methods for local storage
- persist dark mode in ThemeService
- initialize theme on first render
- update DarkModeToggle and MainLayout to use async theme calls
- update tests for new ThemeService API

## Testing
- `dotnet test Predictorator.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6875715017848328bfa1ffd0338114dc