### PR TITLE
Add single channel subscription

### DIFF
--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -60,14 +60,14 @@
     private async Task HandleEmailSubmit()
     {
         var baseUrl = Navigation.BaseUri.TrimEnd('/');
-        await SubscriptionService.AddSubscriberAsync(Email, baseUrl);
+        await SubscriptionService.SubscribeAsync(Email, null, baseUrl);
         _emailSubmitted = true;
     }
 
     private async Task HandlePhoneSubmit()
     {
         var baseUrl = Navigation.BaseUri.TrimEnd('/');
-        await SubscriptionService.AddSmsSubscriberAsync(PhoneNumber, baseUrl);
+        await SubscriptionService.SubscribeAsync(null, PhoneNumber, baseUrl);
         _phoneSubmitted = true;
     }
 }

--- a/Predictorator/Services/SubscriptionService.cs
+++ b/Predictorator/Services/SubscriptionService.cs
@@ -20,7 +20,21 @@ public class SubscriptionService
         _smsSender = smsSender;
     }
 
-    public async Task AddSubscriberAsync(string email, string baseUrl)
+    public Task SubscribeAsync(string? email, string? phoneNumber, string baseUrl)
+    {
+        if (!string.IsNullOrWhiteSpace(email) && !string.IsNullOrWhiteSpace(phoneNumber))
+            throw new ArgumentException("Provide either an email or phone number, not both.");
+
+        if (!string.IsNullOrWhiteSpace(email))
+            return AddEmailSubscriberAsync(email, baseUrl);
+
+        if (!string.IsNullOrWhiteSpace(phoneNumber))
+            return AddSmsSubscriberAsync(phoneNumber, baseUrl);
+
+        throw new ArgumentException("An email or phone number is required.");
+    }
+
+    private async Task AddEmailSubscriberAsync(string email, string baseUrl)
     {
         if (await _db.Subscribers.AnyAsync(s => s.Email == email))
             return;
@@ -50,7 +64,7 @@ public class SubscriptionService
         await _resend.EmailSendAsync(message);
     }
 
-    public async Task AddSmsSubscriberAsync(string phoneNumber, string baseUrl)
+    private async Task AddSmsSubscriberAsync(string phoneNumber, string baseUrl)
     {
         if (await _db.SmsSubscribers.AnyAsync(s => s.PhoneNumber == phoneNumber))
             return;


### PR DESCRIPTION
## Summary
- add `SubscribeAsync` to enforce selecting either email or SMS
- use new method from the subscription page
- test new logic

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68762a9f9a78832881e746c8e1bb2be0