### PR TITLE
Fix email subscription requiring phone

### DIFF
--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -64,4 +64,19 @@ public class SubscribeComponentBUnitTests
         Assert.Contains("Phone number", cut.Markup);
         Assert.DoesNotContain("Email address", cut.Markup);
     }
+
+    [Fact]
+    public async Task Email_Submit_Does_Not_Require_Phone()
+    {
+        await using var ctx = CreateContext(new Dictionary<string, string?> { ["Resend:ApiToken"] = "token" });
+        var cut = ctx.Render<Subscribe>();
+        var input = cut.Find("input");
+        input.Change("user@example.com");
+        cut.Find("form").Submit();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Contains("verification link", cut.Markup, StringComparison.OrdinalIgnoreCase);
+        });
+    }
 }

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -16,11 +16,11 @@
             }
             else
             {
-                <EditForm Model="this" OnValidSubmit="HandleEmailSubmit">
+                <EditForm Model="_emailModel" OnValidSubmit="HandleEmailSubmit">
                     <MudStack Spacing="2">
                         <DataAnnotationsValidator />
                         <ValidationSummary />
-                        <MudTextField @bind-Value="Email" Label="Email address" For="@(() => Email)" />
+                        <MudTextField @bind-Value="_emailModel.Email" Label="Email address" For="@(() => _emailModel.Email)" />
                         <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
                     </MudStack>
                 </EditForm>
@@ -36,11 +36,11 @@
             }
             else
             {
-                <EditForm Model="this" OnValidSubmit="HandlePhoneSubmit">
+                <EditForm Model="_phoneModel" OnValidSubmit="HandlePhoneSubmit">
                     <MudStack Spacing="2">
                         <DataAnnotationsValidator />
                         <ValidationSummary />
-                        <MudTextField @bind-Value="PhoneNumber" Label="Phone number" For="@(() => PhoneNumber)" />
+                        <MudTextField @bind-Value="_phoneModel.PhoneNumber" Label="Phone number" For="@(() => _phoneModel.PhoneNumber)" />
                         <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
                     </MudStack>
                 </EditForm>
@@ -51,23 +51,34 @@
 </MudPaper>
 
 @code {
-    [Required, EmailAddress]
-    public string Email { get; set; } = string.Empty;
-    [Required, Phone]
-    public string PhoneNumber { get; set; } = string.Empty;
+    private class EmailModel
+    {
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+
+    private class PhoneModel
+    {
+        [Required, Phone]
+        public string PhoneNumber { get; set; } = string.Empty;
+    }
+
+    private readonly EmailModel _emailModel = new();
+    private readonly PhoneModel _phoneModel = new();
     private bool _emailSubmitted;
     private bool _phoneSubmitted;
+
     private async Task HandleEmailSubmit()
     {
         var baseUrl = Navigation.BaseUri.TrimEnd('/');
-        await SubscriptionService.SubscribeAsync(Email, null, baseUrl);
+        await SubscriptionService.SubscribeAsync(_emailModel.Email, null, baseUrl);
         _emailSubmitted = true;
     }
 
     private async Task HandlePhoneSubmit()
     {
         var baseUrl = Navigation.BaseUri.TrimEnd('/');
-        await SubscriptionService.SubscribeAsync(null, PhoneNumber, baseUrl);
+        await SubscriptionService.SubscribeAsync(null, _phoneModel.PhoneNumber, baseUrl);
         _phoneSubmitted = true;
     }
 }


### PR DESCRIPTION
## Summary
- prevent the SMS phone field from validating when only subscribing via email
- use separate form models per tab
- test that phone is not required when subscribing via email

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68762e772b508328a492ebaa4dd3ae69