### PR TITLE
Fix missing login partial for Identity

### DIFF
--- a/Predictorator/Pages/Shared/_LoginPartial.cshtml
+++ b/Predictorator/Pages/Shared/_LoginPartial.cshtml
@@ -1,0 +1,24 @@
+@using Microsoft.AspNetCore.Identity
+@inject SignInManager<IdentityUser> SignInManager
+@inject UserManager<IdentityUser> UserManager
+@if (SignInManager.IsSignedIn(User))
+{
+    <form id="logoutForm" class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="/" method="post">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index">Hello @UserManager.GetUserName(User)!</a>
+            </li>
+            <li class="nav-item">
+                <button type="submit" class="nav-link btn btn-link text-dark">Logout</button>
+            </li>
+        </ul>
+    </form>
+}
+else
+{
+    <ul class="navbar-nav">
+        <li class="nav-item">
+            <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Login">Login</a>
+        </li>
+    </ul>
+}


### PR DESCRIPTION
## Summary
- create a `_LoginPartial` view so the default Identity pages can render

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6876363356388328a2bf54efbfbef5e7