### PR TITLE
Add cleanup for unverified subscribers

### DIFF
--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -10,6 +10,7 @@ using NSubstitute;
 using Predictorator.Components.Pages.Subscription;
 using Predictorator.Data;
 using Predictorator.Services;
+using Predictorator.Tests.Helpers;
 using Resend;
 
 namespace Predictorator.Tests;
@@ -38,7 +39,9 @@ public class SubscribeComponentBUnitTests
         var db = new ApplicationDbContext(options);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms));
+        var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
+        ctx.Services.AddSingleton<IDateTimeProvider>(time);
+        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time));
         return ctx;
     }
 

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -11,7 +11,7 @@
     <MudDialogProvider    @rendermode="InteractiveServer" />
     <MudSnackbarProvider  @rendermode="InteractiveServer" />
     <MudAppBar Elevation="1" Color="Color.Primary">
-        <MudText Typo="Typo.h5" Class="ml-2">Predictotronix</MudText>
+        <MudText Typo="Typo.h5" Class="ml-2"><a href="/">Predictotronix</a></MudText>
         <MudSpacer />
         @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
             HttpContextAccessor.HttpContext.User.IsInRole("Admin"))

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -6,48 +6,45 @@
 
 <MudPaper Class="pa-4" Elevation="1">
     <h2>Subscribe to Notifications</h2>
-    <MudTabs>
-        @if (Features.EmailEnabled)
-        {
-            <MudTabPanel Text="Email">
-            @if (_emailSubmitted)
+    @if (_emailSubmitted)
+    {
+        <p>A verification link has been sent to your email address. It will be valid for one hour.</p>
+    }
+    else if (_phoneSubmitted)
+    {
+        <p>A verification link has been sent to your phone. It will be valid for one hour.</p>
+    }
+    else
+    {
+        <MudTabs>
+            @if (Features.EmailEnabled)
             {
-                <p>A verification link has been sent to your email address.</p>
+                <MudTabPanel Text="Email">
+                    <EditForm Model="_emailModel" OnValidSubmit="HandleEmailSubmit">
+                        <MudStack Spacing="2">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+                            <MudTextField @bind-Value="_emailModel.Email" Label="Email address" For="@(() => _emailModel.Email)" />
+                            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
+                        </MudStack>
+                    </EditForm>
+                </MudTabPanel>
             }
-            else
+            @if (Features.SmsEnabled)
             {
-                <EditForm Model="_emailModel" OnValidSubmit="HandleEmailSubmit">
-                    <MudStack Spacing="2">
-                        <DataAnnotationsValidator />
-                        <ValidationSummary />
-                        <MudTextField @bind-Value="_emailModel.Email" Label="Email address" For="@(() => _emailModel.Email)" />
-                        <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
-                    </MudStack>
-                </EditForm>
+                <MudTabPanel Text="SMS">
+                    <EditForm Model="_phoneModel" OnValidSubmit="HandlePhoneSubmit">
+                        <MudStack Spacing="2">
+                            <DataAnnotationsValidator />
+                            <ValidationSummary />
+                            <MudTextField @bind-Value="_phoneModel.PhoneNumber" Label="Phone number" For="@(() => _phoneModel.PhoneNumber)" />
+                            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
+                        </MudStack>
+                    </EditForm>
+                </MudTabPanel>
             }
-            </MudTabPanel>
-        }
-        @if (Features.SmsEnabled)
-        {
-            <MudTabPanel Text="SMS">
-            @if (_phoneSubmitted)
-            {
-                <p>A verification link has been sent to your phone.</p>
-            }
-            else
-            {
-                <EditForm Model="_phoneModel" OnValidSubmit="HandlePhoneSubmit">
-                    <MudStack Spacing="2">
-                        <DataAnnotationsValidator />
-                        <ValidationSummary />
-                        <MudTextField @bind-Value="_phoneModel.PhoneNumber" Label="Phone number" For="@(() => _phoneModel.PhoneNumber)" />
-                        <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
-                    </MudStack>
-                </EditForm>
-            }
-            </MudTabPanel>
-        }
-    </MudTabs>
+        </MudTabs>
+    }
 </MudPaper>
 
 @code {

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -20,6 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.20" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7" PrivateAssets="all" />

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ You can override these values by setting the `ADMIN_EMAIL` and
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 
+Verification links sent to subscribers are valid for one hour. A background job
+runs every 15 minutes to remove unverified subscriptions that have expired.
+
 To run the application in Docker using the latest Compose Specification:
 
 ```bash


### PR DESCRIPTION
## Summary
- add Hangfire background job to purge stale unverified subscribers
- note link expiry on subscribe page and hide tabs after submission
- make app header link back to home
- update README with info about link expiration
- add tests for cleanup logic

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687636bff5448328a93d4969ce42cdee