### PR TITLE
Fix Twilio build warning

### DIFF
--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.AzureApp" Version="3.1.0" />
-    <PackageReference Include="Twilio" Version="6.7.1" />
+    <PackageReference Include="Twilio" Version="6.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update Twilio package reference to version 6.8.0

## Testing
- `~/.dotnet/dotnet build Predictorator.sln -v minimal`
- `~/.dotnet/dotnet test Predictorator.sln --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_687638fcab6c8328ae00179e6c00a815