### PR TITLE
Fix login flow and logout

### DIFF
--- a/Predictorator.Tests/AuthenticationTests.cs
+++ b/Predictorator.Tests/AuthenticationTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Predictorator.Tests;
+
+public class AuthenticationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AuthenticationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Testing");
+        });
+    }
+
+    [Fact]
+    public async Task Register_Page_Should_Return_NotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/Identity/Account/Register");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/Predictorator/Components/Layout/LoginDisplay.razor
+++ b/Predictorator/Components/Layout/LoginDisplay.razor
@@ -1,0 +1,18 @@
+@inject IHttpContextAccessor HttpContextAccessor
+@inject NavigationManager NavigationManager
+@rendermode InteractiveServer
+@if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true)
+{
+    <MudButton Variant="Variant.Text" OnClick="@Logout">Logout</MudButton>
+}
+else
+{
+    <MudButton Variant="Variant.Text" Href="/admin">Login</MudButton>
+}
+
+@code {
+    private void Logout()
+    {
+        NavigationManager.NavigateTo("/logout", true);
+    }
+}

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -19,6 +19,7 @@
             <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
         }
         <SubscribeButton />
+        <LoginDisplay />
         <DarkModeToggle />
     </MudAppBar>
 

--- a/Predictorator/Components/Pages/Login.razor
+++ b/Predictorator/Components/Pages/Login.razor
@@ -1,0 +1,57 @@
+@page "/admin"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.Identity
+@inject SignInManager<IdentityUser> SignInManager
+@inject NavigationManager NavigationManager
+@inject ILogger<Login> Logger
+
+<h1>Log in</h1>
+<EditForm Model="_input" OnValidSubmit="HandleLogin">
+    <DataAnnotationsValidator />
+    <MudStack Spacing="2">
+        <MudTextField @bind-Value="_input.Email" Label="Email" Required="true" />
+        <MudTextField @bind-Value="_input.Password" Label="Password" InputType="InputType.Password" Required="true" />
+        <MudCheckBox T="bool" @bind-Checked="_input.RememberMe" Label="Remember me" />
+        <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary">Log in</MudButton>
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudAlert Severity="Severity.Error">@_error</MudAlert>
+        }
+    </MudStack>
+</EditForm>
+
+@code {
+    private readonly InputModel _input = new();
+    private string? _error;
+
+    private class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        public bool RememberMe { get; set; }
+    }
+
+    private async Task HandleLogin()
+    {
+        _error = null;
+        var result = await SignInManager.PasswordSignInAsync(_input.Email, _input.Password, _input.RememberMe, lockoutOnFailure: false);
+        if (result.Succeeded)
+        {
+            NavigationManager.NavigateTo("/");
+        }
+        else if (result.IsLockedOut)
+        {
+            _error = "User locked out.";
+        }
+        else
+        {
+            _error = "Invalid login attempt.";
+        }
+    }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -156,7 +156,13 @@ var razorComponents = app.MapRazorComponents<App>();
 razorComponents.AddInteractiveServerRenderMode();
 
 app.MapRazorPages();
-app.MapGet("/admin", () => Results.Redirect("/Identity/Account/Login"));
+app.MapGet("/Identity/Account/Register", () => Results.NotFound());
+app.MapPost("/Identity/Account/Register", () => Results.NotFound());
+app.MapGet("/logout", async (SignInManager<IdentityUser> sm) =>
+{
+    await sm.SignOutAsync();
+    return Results.Redirect("/");
+});
 
 if (!app.Environment.IsEnvironment("Testing"))
 {


### PR DESCRIPTION
## Summary
- add LoginDisplay component to render Login/Logout buttons
- create custom `/admin` login page using MudBlazor
- block access to registration and add logout endpoint
- test registration route returns 404

## Testing
- `dotnet build Predictorator.sln`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68763b1feb448328b4ade6ab34f6b11e