### PR TITLE
Fix title link color

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -11,7 +11,7 @@
     <MudDialogProvider    @rendermode="InteractiveServer" />
     <MudSnackbarProvider  @rendermode="InteractiveServer" />
     <MudAppBar Elevation="1" Color="Color.Primary">
-        <MudText Typo="Typo.h5" Class="ml-2"><a href="/">Predictotronix</a></MudText>
+        <MudText Typo="Typo.h5" Class="ml-2"><a href="/" class="app-title-link">Predictotronix</a></MudText>
         <MudSpacer />
         @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
             HttpContextAccessor.HttpContext.User.IsInRole("Admin"))

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -51,3 +51,9 @@ html, body {
 .team-name {
     white-space: normal;
 }
+
+/* Style the main title link to match surrounding text */
+.app-title-link {
+    color: inherit;
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- make the page title link use `color: inherit`
- add CSS rule for `.app-title-link`

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68763b5a2ad88328b4264d39b9c3e011