### PR TITLE
Use Hangfire for subscription queue

### DIFF
--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -39,9 +39,10 @@ public class SubscribeComponentBUnitTests
         var db = new ApplicationDbContext(options);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
+        var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time));
+        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs));
         return ctx;
     }
 

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -3,6 +3,10 @@ using Microsoft.Extensions.Configuration;
 using NSubstitute;
 using Predictorator.Data;
 using Predictorator.Models;
+using Hangfire;
+using System.Linq.Expressions;
+using Hangfire.Common;
+using Hangfire.States;
 using Predictorator.Services;
 using Predictorator.Tests.Helpers;
 using Resend;
@@ -11,7 +15,7 @@ namespace Predictorator.Tests;
 
 public class SubscriptionServiceTests
 {
-    private static SubscriptionService CreateService(out ApplicationDbContext db, out IResend resend, out ITwilioSmsSender sms, IDateTimeProvider? provider = null)
+    private static SubscriptionService CreateService(out ApplicationDbContext db, out IResend resend, out ITwilioSmsSender sms, out IBackgroundJobClient jobs, IDateTimeProvider? provider = null)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -19,18 +23,21 @@ public class SubscriptionServiceTests
         db = new ApplicationDbContext(options);
         resend = Substitute.For<IResend>();
         sms = Substitute.For<ITwilioSmsSender>();
+        jobs = Substitute.For<IBackgroundJobClient>();
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Resend:From"] = "from@example.com" })
             .Build();
         provider ??= new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
-        return new SubscriptionService(db, resend, config, sms, provider);
+        return new SubscriptionService(db, resend, config, sms, provider, jobs);
     }
 
     [Fact]
     public async Task SubscribeAsync_with_email_sends_email_with_links()
     {
-        var service = CreateService(out var db, out var resend, out _);
+        var service = CreateService(out var db, out var resend, out _, out var jobs);
         await service.SubscribeAsync("user@example.com", null, "http://localhost");
+        jobs.Received().Create(Arg.Is<Job>(j => j.Method.Name == nameof(SubscriptionService.AddEmailSubscriberAsync)), Arg.Any<IState>());
+        await service.AddEmailSubscriberAsync("user@example.com", "http://localhost");
 
         await resend.Received().EmailSendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
         var subscriber = await db.Subscribers.SingleAsync();
@@ -40,7 +47,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task VerifyAsync_marks_subscriber_verified()
     {
-        var service = CreateService(out var db, out _, out _);
+        var service = CreateService(out var db, out _, out _, out _);
         var subscriber = new Subscriber { Email = "a", VerificationToken = "token", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.Subscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -54,7 +61,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeAsync_removes_subscriber()
     {
-        var service = CreateService(out var db, out _, out _);
+        var service = CreateService(out var db, out _, out _, out _);
         var subscriber = new Subscriber { Email = "a", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.Subscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -68,8 +75,10 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task SubscribeAsync_with_phone_sends_sms()
     {
-        var service = CreateService(out var db, out _, out var sms);
+        var service = CreateService(out var db, out _, out var sms, out var jobs);
         await service.SubscribeAsync(null, "+123", "http://localhost");
+        jobs.Received().Create(Arg.Is<Job>(j => j.Method.Name == nameof(SubscriptionService.AddSmsSubscriberAsync)), Arg.Any<IState>());
+        await service.AddSmsSubscriberAsync("+123", "http://localhost");
 
         await sms.Received().SendSmsAsync("+123", Arg.Any<string>());
         var subscriber = await db.SmsSubscribers.SingleAsync();
@@ -79,14 +88,14 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task SubscribeAsync_throws_when_both_email_and_phone_provided()
     {
-        var service = CreateService(out _, out _, out _);
+        var service = CreateService(out _, out _, out _, out _);
         await Assert.ThrowsAsync<ArgumentException>(() => service.SubscribeAsync("e@example.com", "+1", "http://localhost"));
     }
 
     [Fact]
     public async Task VerifyAsync_marks_sms_subscriber_verified()
     {
-        var service = CreateService(out var db, out _, out _);
+        var service = CreateService(out var db, out _, out _, out _);
         var subscriber = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "t", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.SmsSubscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -100,7 +109,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeAsync_removes_sms_subscriber()
     {
-        var service = CreateService(out var db, out _, out _);
+        var service = CreateService(out var db, out _, out _, out _);
         var subscriber = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.SmsSubscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -115,7 +124,7 @@ public class SubscriptionServiceTests
     public async Task RemoveExpiredUnverifiedAsync_removes_old_records()
     {
         var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
-        var service = CreateService(out var db, out _, out _, provider);
+        var service = CreateService(out var db, out _, out _, out _, provider);
         db.Subscribers.Add(new Subscriber { Email = "old@example.com", CreatedAt = provider.UtcNow.AddHours(-2), VerificationToken = "a", UnsubscribeToken = "b" });
         db.SmsSubscribers.Add(new SmsSubscriber { PhoneNumber = "+1", CreatedAt = provider.UtcNow.AddHours(-2), VerificationToken = "c", UnsubscribeToken = "d" });
         await db.SaveChangesAsync();
@@ -130,7 +139,7 @@ public class SubscriptionServiceTests
     public async Task RemoveExpiredUnverifiedAsync_keeps_recent_or_verified()
     {
         var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
-        var service = CreateService(out var db, out _, out _, provider);
+        var service = CreateService(out var db, out _, out _, out _, provider);
         var recent = new Subscriber { Email = "new@example.com", CreatedAt = provider.UtcNow.AddMinutes(-30), VerificationToken = "a", UnsubscribeToken = "b" };
         var verified = new SmsSubscriber { PhoneNumber = "+1", CreatedAt = provider.UtcNow.AddHours(-2), IsVerified = true, VerificationToken = "c", UnsubscribeToken = "d" };
         db.Subscribers.Add(recent);


### PR DESCRIPTION
## Summary
- queue subscription tasks with Hangfire and add retry
- adjust unit tests for new async behavior

## Testing
- `dotnet build Predictorator.sln`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68763bbcb254832899aeac61ea479c4a