### PR TITLE
Fix login cookie error

### DIFF
--- a/Predictorator.Tests/AuthenticationTests.cs
+++ b/Predictorator.Tests/AuthenticationTests.cs
@@ -1,6 +1,15 @@
 using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Predictorator.Data;
+using Predictorator.Options;
+using System.Net.Http.Json;
+using Predictorator.Models;
 
 namespace Predictorator.Tests;
 
@@ -22,5 +31,14 @@ public class AuthenticationTests : IClassFixture<WebApplicationFactory<Program>>
         var client = _factory.CreateClient();
         var response = await client.GetAsync("/Identity/Account/Register");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_Endpoint_Returns_BadRequest_When_Body_Missing()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync("/login", null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/Predictorator.Tests/LoginEndpointsTests.cs
+++ b/Predictorator.Tests/LoginEndpointsTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Predictorator.Endpoints;
+using Predictorator.Models;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class LoginEndpointsTests
+{
+    [Fact]
+    public async Task Returns_Ok_when_signin_succeeds()
+    {
+        var service = Substitute.For<ISignInService>();
+        service.PasswordSignInAsync("user", "pass", false).Returns(SignInResult.Success);
+
+        var result = await LoginEndpoints.LoginAsync(new LoginRequest("user", "pass", false), service);
+
+        var typed = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        Assert.Equal(StatusCodes.Status200OK, typed.StatusCode);
+    }
+
+    [Fact]
+    public async Task Returns_BadRequest_when_request_is_null()
+    {
+        var service = Substitute.For<ISignInService>();
+
+        var result = await LoginEndpoints.LoginAsync(null, service);
+
+        var typed = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, typed.StatusCode);
+    }
+}

--- a/Predictorator/Components/Pages/Login.razor
+++ b/Predictorator/Components/Pages/Login.razor
@@ -1,9 +1,8 @@
 @page "/admin"
 @rendermode InteractiveServer
-@using Microsoft.AspNetCore.Identity
-@inject SignInManager<IdentityUser> SignInManager
 @inject NavigationManager NavigationManager
 @inject ILogger<Login> Logger
+@inject HttpClient Http
 
 <h1>Log in</h1>
 <EditForm Model="_input" OnValidSubmit="HandleLogin">
@@ -40,18 +39,25 @@
     private async Task HandleLogin()
     {
         _error = null;
-        var result = await SignInManager.PasswordSignInAsync(_input.Email, _input.Password, _input.RememberMe, lockoutOnFailure: false);
-        if (result.Succeeded)
+        try
         {
-            NavigationManager.NavigateTo("/");
+            var response = await Http.PostAsJsonAsync("/login", _input);
+            if (response.IsSuccessStatusCode)
+            {
+                NavigationManager.NavigateTo("/");
+                return;
+            }
+
+            _error = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(_error))
+            {
+                _error = "Invalid login attempt.";
+            }
         }
-        else if (result.IsLockedOut)
+        catch (Exception ex)
         {
-            _error = "User locked out.";
-        }
-        else
-        {
-            _error = "Invalid login attempt.";
+            Logger.LogError(ex, "Login failed");
+            _error = "An error occurred.";
         }
     }
 }

--- a/Predictorator/Endpoints/LoginEndpoints.cs
+++ b/Predictorator/Endpoints/LoginEndpoints.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Http;
+using Predictorator.Models;
+using Predictorator.Services;
+
+namespace Predictorator.Endpoints;
+
+public static class LoginEndpoints
+{
+    public static async Task<IResult> LoginAsync(LoginRequest? request, ISignInService signIn)
+    {
+        if (request is null)
+        {
+            return Results.BadRequest("Invalid request");
+        }
+
+        var result = await signIn.PasswordSignInAsync(request.Email, request.Password, request.RememberMe);
+        if (result.Succeeded)
+        {
+            return Results.Ok();
+        }
+        if (result.IsLockedOut)
+        {
+            return Results.BadRequest("User locked out.");
+        }
+        return Results.BadRequest("Invalid login attempt.");
+    }
+}

--- a/Predictorator/Models/LoginRequest.cs
+++ b/Predictorator/Models/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace Predictorator.Models;
+
+public record LoginRequest(string Email, string Password, bool RememberMe);

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -8,6 +8,8 @@ using Predictorator.Data;
 using Predictorator.Options;
 using Predictorator.Services;
 using Predictorator.Startup;
+using Predictorator.Models;
+using Predictorator.Endpoints;
 using Resend;
 using Serilog;
 using Serilog.Events;
@@ -112,8 +114,10 @@ razorComponentsBuilder.AddInteractiveServerComponents(options =>
     options.DetailedErrors = true;
 });
 builder.Services.AddMudServices();
+builder.Services.AddHttpClient();
 builder.Services.AddScoped<BrowserInteropService>();
 builder.Services.AddScoped<ThemeService>();
+builder.Services.AddScoped<ISignInService, SignInManagerSignInService>();
 builder.Services.AddRazorPages();
 
 if (!builder.Environment.IsEnvironment("Testing"))
@@ -156,6 +160,7 @@ var razorComponents = app.MapRazorComponents<App>();
 razorComponents.AddInteractiveServerRenderMode();
 
 app.MapRazorPages();
+app.MapPost("/login", LoginEndpoints.LoginAsync);
 app.MapGet("/Identity/Account/Register", () => Results.NotFound());
 app.MapPost("/Identity/Account/Register", () => Results.NotFound());
 app.MapGet("/logout", async (SignInManager<IdentityUser> sm) =>

--- a/Predictorator/Services/ISignInService.cs
+++ b/Predictorator/Services/ISignInService.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Predictorator.Services;
+
+public interface ISignInService
+{
+    Task<SignInResult> PasswordSignInAsync(string email, string password, bool rememberMe);
+}

--- a/Predictorator/Services/SignInManagerSignInService.cs
+++ b/Predictorator/Services/SignInManagerSignInService.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Predictorator.Services;
+
+public class SignInManagerSignInService : ISignInService
+{
+    private readonly SignInManager<IdentityUser> _signInManager;
+
+    public SignInManagerSignInService(SignInManager<IdentityUser> signInManager)
+    {
+        _signInManager = signInManager;
+    }
+
+    public Task<SignInResult> PasswordSignInAsync(string email, string password, bool rememberMe)
+    {
+        return _signInManager.PasswordSignInAsync(email, password, rememberMe, lockoutOnFailure: false);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ISignInService` abstraction and adapter for `SignInManager`
- create `LoginEndpoints` with testable login logic
- update Program to register sign-in service and map login endpoint
- update login page to call the new `/login` API
- add unit tests for `LoginEndpoints`
- cover `/login` missing body with a test

## Testing
- `dotnet build Predictorator.sln`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68764ea3390c8328bc8073134f4f70a6