### PR TITLE
Add Ceefax themed mode

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -1,0 +1,97 @@
+using Bunit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+using Predictorator.Components;
+using Predictorator.Models.Fixtures;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+
+namespace Predictorator.Tests;
+
+public class CeefaxModeBUnitTests
+{
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        var jsRuntime = Substitute.For<IJSRuntime>();
+        ctx.Services.AddSingleton(jsRuntime);
+        var browser = new BrowserInteropService(jsRuntime);
+        ctx.Services.AddSingleton(browser);
+        var theme = new ThemeService(browser);
+        ctx.Services.AddSingleton(theme);
+        ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+        var fixtures = new FixturesResponse { Response = [] };
+        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        var provider = new FakeDateTimeProvider { Today = new DateTime(2024,1,1), UtcNow = new DateTime(2024,1,1) };
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task ToggleCeefax_UpdatesServiceState()
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<App>();
+        var toggle = cut.Find("#ceefaxToggle");
+        Assert.False(ctx.Services.GetRequiredService<ThemeService>().IsCeefax);
+        toggle.Click();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(ctx.Services.GetRequiredService<ThemeService>().IsCeefax);
+        }, timeout: TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Initialize_Uses_Existing_State()
+    {
+        await using var ctx = new BunitContext();
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        var jsRuntime = Substitute.For<IJSRuntime>();
+        ctx.Services.AddSingleton(jsRuntime);
+        jsRuntime.InvokeAsync<string?>("app.getLocalStorage", Arg.Any<object[]>()).Returns("true");
+        var browser = new BrowserInteropService(jsRuntime);
+        ctx.Services.AddSingleton(browser);
+        var theme = new ThemeService(browser);
+        ctx.Services.AddSingleton(theme);
+        ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024,1,1), UtcNow = new DateTime(2024,1,1) }));
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+
+        var cut = ctx.Render<App>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(ctx.Services.GetRequiredService<ThemeService>().IsCeefax);
+        }, timeout: TimeSpan.FromSeconds(1));
+    }
+}

--- a/Predictorator/Components/CeefaxDisplay.razor
+++ b/Predictorator/Components/CeefaxDisplay.razor
@@ -1,0 +1,32 @@
+@implements IDisposable
+@inject ThemeService ThemeService
+@using MudBlazor
+
+@if (ThemeService.IsCeefax)
+{
+    <MudPaper Class="pa-4 ceefax-font" Style="background-color:#000000; color:#FFFFFF;">
+        <MudText Typo="Typo.h5" Style="background-color:#0000FF; color:#FFFF00; padding:4px;">CEEFAX FOOTBALL</MudText>
+        <MudText Typo="Typo.subtitle2" Style="color:#FFFF00;">@_now.ToString("dd MMM yyyy HH:mm:ss")</MudText>
+        <MudDivider Class="my-2" />
+        <MudText Style="color:#00FF00;">Liverpool 3-0 Everton</MudText>
+        <MudText Style="color:#00FFFF;">Chelsea 1-1 Arsenal</MudText>
+        <MudText Style="color:#FF0000;">Next page 302</MudText>
+    </MudPaper>
+}
+
+@code {
+    private DateTime _now = DateTime.Now;
+    private System.Timers.Timer? _timer;
+
+    protected override void OnInitialized()
+    {
+        _timer = new System.Timers.Timer(1000);
+        _timer.Elapsed += (_, _) => InvokeAsync(() => { _now = DateTime.Now; StateHasChanged(); });
+        _timer.Start();
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+}

--- a/Predictorator/Components/Layout/CeefaxToggle.razor
+++ b/Predictorator/Components/Layout/CeefaxToggle.razor
@@ -1,0 +1,25 @@
+@implements IDisposable
+@rendermode InteractiveServer
+@inject ThemeService ThemeService
+@using MudBlazor
+
+<MudIconButton Icon="@Icons.Material.Outlined.Article" OnClick="ToggleCeefax" UserAttributes="@(new Dictionary<string, object>{{"id","ceefaxToggle"}})" />
+
+@code {
+    protected override void OnInitialized()
+    {
+        ThemeService.OnChange += OnThemeChanged;
+    }
+
+    private async Task ToggleCeefax()
+    {
+        await ThemeService.ToggleCeefaxAsync();
+    }
+
+    private void OnThemeChanged() => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ThemeService.OnChange -= OnThemeChanged;
+    }
+}

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -3,7 +3,8 @@
 @inject IHttpContextAccessor HttpContextAccessor
 @inject ThemeService ThemeService
 <MudLayout>
-    <MudThemeProvider @rendermode="InteractiveServer"
+<MudThemeProvider @rendermode="InteractiveServer"
+                      Theme="@ThemeService.CurrentTheme"
                       IsDarkMode="@ThemeService.IsDarkMode"
                       IsDarkModeChanged="@ThemeService.SetDarkModeAsync" />
 
@@ -21,6 +22,7 @@
         <SubscribeButton />
         <LoginDisplay />
         <DarkModeToggle />
+        <CeefaxToggle />
     </MudAppBar>
 
     <MudMainContent>

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -5,6 +5,9 @@
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
 @inject BrowserInteropService Browser
+@using Predictorator.Components
+
+<CeefaxDisplay />
 
 <h1>Premier League Fixtures</h1>
 

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -1,3 +1,5 @@
+using MudBlazor;
+
 namespace Predictorator.Services;
 
 public class ThemeService
@@ -10,6 +12,33 @@ public class ThemeService
     }
 
     public bool IsDarkMode { get; private set; }
+    public bool IsCeefax { get; private set; }
+
+    public MudTheme CeefaxTheme { get; } = new MudTheme()
+    {
+        PaletteDark = new PaletteDark()
+        {
+            Background = "#000000",
+            Surface = "#000000",
+            TextPrimary = "#FFFFFF",
+            TextSecondary = "#CCCCCC",
+            Primary = "#0000FF",
+            Secondary = "#00FF00",
+            Info = "#00FFFF",
+            Success = "#00FF00",
+            Warning = "#FFFF00",
+            Error = "#FF0000",
+            AppbarBackground = "#0000FF",
+            AppbarText = "#00FF00",
+            DrawerBackground = "#000000",
+            DrawerText = "#FFFFFF",
+            ActionDefault = "#FFFFFF",
+            ActionDisabled = "#555555",
+            ActionDisabledBackground = "#222222"
+        }
+    };
+
+    public MudTheme? CurrentTheme => IsCeefax ? CeefaxTheme : null;
 
     public event Action? OnChange;
 
@@ -19,6 +48,12 @@ public class ThemeService
         if (bool.TryParse(value, out var result))
         {
             IsDarkMode = result;
+        }
+
+        value = await _browser.GetLocalStorageAsync("ceefaxMode");
+        if (bool.TryParse(value, out result))
+        {
+            IsCeefax = result;
         }
     }
 
@@ -30,6 +65,18 @@ public class ThemeService
         {
             IsDarkMode = value;
             await _browser.SetLocalStorageAsync("darkMode", value.ToString().ToLowerInvariant());
+            OnChange?.Invoke();
+        }
+    }
+
+    public Task ToggleCeefaxAsync() => SetCeefaxAsync(!IsCeefax);
+
+    public async Task SetCeefaxAsync(bool value)
+    {
+        if (IsCeefax != value)
+        {
+            IsCeefax = value;
+            await _browser.SetLocalStorageAsync("ceefaxMode", value.ToString().ToLowerInvariant());
             OnChange?.Invoke();
         }
     }

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -57,3 +57,14 @@ html, body {
     color: inherit;
     text-decoration: none;
 }
+
+@font-face {
+    font-family: 'BBC-Ceefax';
+    src: url('../fonts/bbc-ceefax-logo.otf.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+}
+
+.ceefax-font {
+    font-family: 'BBC-Ceefax', monospace;
+}


### PR DESCRIPTION
## Summary
- create Ceefax style toggle in the header
- style the theme using the Ceefax palette
- show a Ceefax-style header on the index page when enabled
- persist the setting in local storage
- cover new behaviour with bUnit tests

## Testing
- `dotnet build Predictorator.sln -v minimal`
- `dotnet test Predictorator.sln --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68764d9e600483289728b67defd550f9