### PR TITLE
Implement automated fixture notifications

### DIFF
--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -1,0 +1,90 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Predictorator.Data;
+using Predictorator.Models;
+using Predictorator.Models.Fixtures;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+using Resend;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+
+namespace Predictorator.Tests;
+
+public class NotificationServiceTests
+{
+    private static NotificationService CreateService(DateTime nowUtc, DateTime fixtureTimeUtc,
+        out ApplicationDbContext db, out IBackgroundJobClient jobs,
+        out IResend resend, out ITwilioSmsSender sms)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        db = new ApplicationDbContext(options);
+        jobs = Substitute.For<IBackgroundJobClient>();
+        resend = Substitute.For<IResend>();
+        sms = Substitute.For<ITwilioSmsSender>();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Resend:ApiToken"] = "t",
+                ["Resend:From"] = "from@example.com",
+                ["Twilio:AccountSid"] = "sid",
+                ["Twilio:AuthToken"] = "tok",
+                ["Twilio:FromNumber"] = "+1",
+                ["BASE_URL"] = "http://localhost"
+            })
+            .Build();
+        var features = new NotificationFeatureService(config);
+        var provider = new FakeDateTimeProvider { UtcNow = nowUtc, Today = nowUtc.Date };
+        var calculator = new DateRangeCalculator(provider);
+        var fixtures = new FakeFixtureService(new FixturesResponse
+        {
+            FromDate = nowUtc.Date,
+            ToDate = nowUtc.Date.AddDays(6),
+            Response = new List<FixtureData>
+            {
+                new()
+                {
+                    Fixture = new Fixture { Id = 1, Date = fixtureTimeUtc, Venue = new Venue { Name = "A", City = "B" } },
+                    Teams = new Teams { Home = new Team { Name = "H" }, Away = new Team { Name = "A" } },
+                    Score = new Score { Fulltime = new ScoreHomeAway() }
+                }
+            }
+        });
+
+        return new NotificationService(db, resend, sms, config, fixtures, calculator, features, provider, jobs);
+    }
+
+    [Fact]
+    public async Task CheckFixturesAsync_enqueues_new_fixture_job()
+    {
+        var now = new DateTime(2024, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+        var fixture = now.AddDays(2);
+        var service = CreateService(now, fixture, out var db, out var jobs, out _, out _);
+
+        await service.CheckFixturesAsync();
+
+        jobs.Received().Create(Arg.Any<Job>(), Arg.Any<IState>());
+    }
+
+    [Fact]
+    public async Task SendNewFixturesAvailableAsync_sends_and_records()
+    {
+        var now = DateTime.UtcNow;
+        var service = CreateService(now, now.AddDays(1), out var db, out _, out var resend, out var sms);
+        db.Subscribers.Add(new Subscriber { Email = "u@example.com", IsVerified = true, VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = now });
+        db.SmsSubscribers.Add(new SmsSubscriber { PhoneNumber = "+1", IsVerified = true, VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = now });
+        await db.SaveChangesAsync();
+
+        await service.SendNewFixturesAvailableAsync("key", "http://localhost");
+
+        await resend.Received().EmailSendAsync(Arg.Any<EmailMessage>());
+        await sms.Received().SendSmsAsync("+1", Arg.Any<string>());
+        Assert.Equal(1, db.SentNotifications.Count());
+    }
+}

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -14,4 +14,5 @@ public class ApplicationDbContext : IdentityDbContext<IdentityUser>
 
     public DbSet<Subscriber> Subscribers => Set<Subscriber>();
     public DbSet<SmsSubscriber> SmsSubscribers => Set<SmsSubscriber>();
+    public DbSet<SentNotification> SentNotifications => Set<SentNotification>();
 }

--- a/Predictorator/Models/SentNotification.cs
+++ b/Predictorator/Models/SentNotification.cs
@@ -1,0 +1,9 @@
+namespace Predictorator.Models;
+
+public class SentNotification
+{
+    public int Id { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public DateTime SentAt { get; set; }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -76,6 +76,7 @@ builder.Services.AddTransient<IResend, ResendClient>();
 builder.Services.Configure<TwilioOptions>(builder.Configuration.GetSection(TwilioOptions.SectionName));
 builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
+builder.Services.AddTransient<NotificationService>();
 builder.Services.AddSingleton<NotificationFeatureService>();
 builder.Services.Configure<AdminUserOptions>(options =>
 {
@@ -172,6 +173,11 @@ app.MapGet("/logout", async (SignInManager<IdentityUser> sm) =>
 if (!app.Environment.IsEnvironment("Testing"))
 {
     app.UseHangfireDashboard();
+    RecurringJob.AddOrUpdate<NotificationService>(
+        "fixture-notifications",
+        s => s.CheckFixturesAsync(),
+        "0 10 * * *",
+        TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time"));
     RecurringJob.AddOrUpdate<SubscriptionService>(
         "cleanup-unverified",
         service => service.RemoveExpiredUnverifiedAsync(),

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
+Set `BASE_URL` to the public address of the site so scheduled notifications
+contain valid links.
 
 Verification links sent to subscribers are valid for one hour. A background job
 runs every 15 minutes to remove unverified subscriptions that have expired.


### PR DESCRIPTION
## Summary
- add a `SentNotification` entity
- create `NotificationService` for sending emails/SMS
- schedule a Hangfire recurring job to check fixtures daily
- add unit tests for new notification service
- document required `BASE_URL` setting

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68765900d7f88328a1bff1368f3125aa