### PR TITLE
Add PayPal donation link

### DIFF
--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -64,6 +64,17 @@ public class MainLayoutBUnitTests
     }
 
     [Fact]
+    public async Task LayoutRendersSupportLink()
+    {
+        await using var ctx = CreateContext();
+        RenderFragment body = b => b.AddMarkupContent(0, "<p>child</p>");
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        var link = cut.Find("#donateLink");
+        Assert.NotNull(link);
+        Assert.Equal("_blank", link.GetAttribute("target"));
+    }
+
+    [Fact]
     public async Task DarkModeToggleUpdatesState()
     {
         await using var ctx = CreateContext();

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -20,6 +20,7 @@
             <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
         }
         <SubscribeButton />
+        <SupportLink />
         <LoginDisplay />
         <DarkModeToggle />
         <CeefaxToggle />

--- a/Predictorator/Components/Layout/SupportLink.razor
+++ b/Predictorator/Components/Layout/SupportLink.razor
@@ -1,0 +1,9 @@
+@rendermode InteractiveServer
+<MudTooltip Text="Contribute to hosting costs">
+    <MudIconButton Icon="@Icons.Material.Filled.VolunteerActivism"
+                   Href="https://paypal.me/tommcarrr?country.x=GB&locale.x=en_GB"
+                   Target="_blank" Rel="noopener"
+                   Color="Color.Inherit"
+                   UserAttributes="@(new Dictionary<string, object>{{"id","donateLink"}})" />
+</MudTooltip>
+


### PR DESCRIPTION
## Summary
- add a `SupportLink` component with PayPal URL and tooltip
- place the link in `MainLayout` app bar
- test that the link renders and opens in a new tab

## Testing
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68765abee9608328827fabece4a7d113