### PR TITLE
Fix dark mode init

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -29,7 +29,7 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
-        var provider = new FakeDateTimeProvider { Today = new DateTime(2024,1,1), UtcNow = new DateTime(2024,1,1) };
+        var provider = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
 
         var settings = new Dictionary<string, string?>
@@ -74,7 +74,7 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddSingleton(theme);
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
-        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024,1,1), UtcNow = new DateTime(2024,1,1) }));
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
 
         var settings = new Dictionary<string, string?>
         {

--- a/Predictorator.Tests/ThemeServiceTests.cs
+++ b/Predictorator.Tests/ThemeServiceTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+using Predictorator.Services;
+using Microsoft.JSInterop;
+
+namespace Predictorator.Tests;
+
+public class ThemeServiceTests
+{
+    [Fact]
+    public async Task InitializeAsync_Raises_OnChange()
+    {
+        var jsRuntime = Substitute.For<IJSRuntime>();
+        jsRuntime.InvokeAsync<string?>("app.getLocalStorage", Arg.Any<object[]>()).Returns("true");
+        var browser = new BrowserInteropService(jsRuntime);
+        var service = new ThemeService(browser);
+        bool raised = false;
+        service.OnChange += () => raised = true;
+        await service.InitializeAsync();
+        Assert.True(raised);
+    }
+}

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -55,6 +55,8 @@ public class ThemeService
         {
             IsCeefax = result;
         }
+
+        OnChange?.Invoke();
     }
 
     public Task ToggleDarkModeAsync() => SetDarkModeAsync(!IsDarkMode);


### PR DESCRIPTION
## Summary
- trigger theme update when `ThemeService.InitializeAsync` runs
- add regression test for theme initialization

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6876621c0ffc8328b27ae56bddba8ba9