### PR TITLE
Fix warnings and enforce warn-as-error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Codex must be proficient in the following technologies and frameworks, which are
 
 - Codex must ensure that the app builds and passes tests via GitHub Actions or another CI system.
 - Linting and formatting checks (e.g., `dotnet format`) should be used to enforce consistency.
+- Run `dotnet build Predictorator.sln -warnaserror` to confirm there are no compiler warnings before completing any task.
 - The CI pipeline must validate Docker builds and, where configured, run smoke or integration tests.
 
 ### Running the Application

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -18,6 +18,8 @@
         </MudText>
         <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="!_autoWeek" OnClick="@(() => ChangeWeek(1))"
                        UserAttributes="@(new Dictionary<string, object>{{"id","nextWeekBtn"}})" />
+        <MudIconButton Icon="@Icons.Material.Filled.Refresh" Disabled="_autoWeek" OnClick="ResetRange"
+                       UserAttributes="@(new Dictionary<string, object>{{"id","resetBtn"}})" />
     </MudStack>
     <MudCollapse Expanded="_showPicker">
         <MudDateRangePicker DateRange="_selectedRange" DateRangeChanged="RangeChanged" Class="my-2"
@@ -237,6 +239,11 @@ else if (_fixtures.Response.Any())
             await Browser.CopyToClipboardTextAsync(sbText.ToString());
         else
             await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+    }
+
+    private void ResetRange()
+    {
+        NavigationManager.NavigateTo("/");
     }
 
     private class PredictionInput

--- a/Predictorator/Components/Pages/Login.razor
+++ b/Predictorator/Components/Pages/Login.razor
@@ -10,7 +10,7 @@
     <MudStack Spacing="2">
         <MudTextField @bind-Value="_input.Email" Label="Email" Required="true" />
         <MudTextField @bind-Value="_input.Password" Label="Password" InputType="InputType.Password" Required="true" />
-        <MudCheckBox T="bool" @bind-Checked="_input.RememberMe" Label="Remember me" />
+        <MudCheckBox T="bool" @bind-Value="_input.RememberMe" Label="Remember me" />
         <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary">Log in</MudButton>
         @if (!string.IsNullOrEmpty(_error))
         {

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -176,11 +176,15 @@ if (!app.Environment.IsEnvironment("Testing"))
         "fixture-notifications",
         s => s.CheckFixturesAsync(),
         "0 10 * * *",
-        TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time"));
+        new RecurringJobOptions
+        {
+            TimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")
+        });
     RecurringJob.AddOrUpdate<SubscriptionService>(
         "cleanup-unverified",
         service => service.RemoveExpiredUnverifiedAsync(),
-        "*/15 * * * *");
+        "*/15 * * * *",
+        new RecurringJobOptions());
     await ApplicationDbInitializer.SeedAdminUserAsync(app.Services);
 }
 


### PR DESCRIPTION
## Summary
- fix Hangfire AddOrUpdate API usage
- fix MudCheckBox binding
- restore reset button in index page
- document warn-as-error build step in AGENTS.md

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687676f023f08328bc7d3b839b0e8ccd