### PR TITLE
Fix clipboard copy and show toast notifications

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -5,6 +5,7 @@
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
 @inject BrowserInteropService Browser
+@inject ISnackbar Snackbar
 
 <MudText Typo="Typo.h3" Class="my-4 pa-2" Align="Align.Center">Premier League Fixtures</MudText>
 
@@ -18,6 +19,8 @@
         </MudText>
         <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="!_autoWeek" OnClick="@(() => ChangeWeek(1))"
                        UserAttributes="@(new Dictionary<string, object>{{"id","nextWeekBtn"}})" />
+        <MudIconButton Icon="@Icons.Material.Filled.Close" Disabled="_autoWeek" OnClick="ResetRange"
+                       UserAttributes="@(new Dictionary<string, object>{{"id","resetBtn"}})" />
     </MudStack>
     <MudCollapse Expanded="_showPicker">
         <MudDateRangePicker DateRange="_selectedRange" DateRangeChanged="RangeChanged" Class="my-2"
@@ -159,6 +162,11 @@ else if (_fixtures.Response.Any())
         NavigationManager.NavigateTo(uri);
     }
 
+    private void ResetRange()
+    {
+        NavigationManager.NavigateTo("/");
+    }
+
     private void FillRandomScores()
     {
         var possible = new[] { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,4,4,5 };
@@ -228,15 +236,19 @@ else if (_fixtures.Response.Any())
 
         if (missing)
         {
-            await Browser.AlertAsync("Error: Please fill in all score predictions before copying.");
+            Snackbar.Add("Error: Please fill in all score predictions before copying.", Severity.Error);
             return;
         }
 
         var mobile = await Browser.IsMobileDeviceAsync();
-        if (mobile)
-            await Browser.CopyToClipboardTextAsync(sbText.ToString());
+        bool copied = mobile
+            ? await Browser.CopyToClipboardTextAsync(sbText.ToString())
+            : await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+
+        if (copied)
+            Snackbar.Add("Predictions copied to clipboard!", Severity.Success);
         else
-            await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+            Snackbar.Add("Could not copy predictions to clipboard.", Severity.Error);
     }
 
     private class PredictionInput

--- a/Predictorator/Services/BrowserInteropService.cs
+++ b/Predictorator/Services/BrowserInteropService.cs
@@ -11,9 +11,11 @@ public class BrowserInteropService
         _js = js;
     }
 
-    public ValueTask CopyToClipboardTextAsync(string text) => _js.InvokeVoidAsync("app.copyToClipboardText", text);
+    public ValueTask<bool> CopyToClipboardTextAsync(string text) =>
+        _js.InvokeAsync<bool>("app.copyToClipboardText", text);
 
-    public ValueTask CopyToClipboardHtmlAsync(string html) => _js.InvokeVoidAsync("app.copyToClipboardHtml", html);
+    public ValueTask<bool> CopyToClipboardHtmlAsync(string html) =>
+        _js.InvokeAsync<bool>("app.copyToClipboardHtml", html);
 
     public ValueTask<bool> IsMobileDeviceAsync() => _js.InvokeAsync<bool>("app.isMobileDevice");
 

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -1,24 +1,72 @@
 window.app = (() => {
 
 
-    function copyToClipboardText(text) {
-        navigator.clipboard.writeText(text).then(() => {
-            alert('Predictions copied to clipboard!');
-        }).catch(err => {
-            console.error('Could not copy text: ', err);
-        });
+    async function copyToClipboardText(text) {
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                return true;
+            }
+        } catch (err) {
+            console.error('Could not use clipboard API: ', err);
+        }
+
+        try {
+            const textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            textarea.style.top = '0';
+            textarea.style.left = '0';
+            textarea.style.width = '1px';
+            textarea.style.height = '1px';
+            textarea.style.padding = '0';
+            textarea.style.border = 'none';
+            textarea.style.outline = 'none';
+            textarea.style.boxShadow = 'none';
+            textarea.style.background = 'transparent';
+            document.body.appendChild(textarea);
+            textarea.focus();
+            textarea.select();
+            const successful = document.execCommand('copy');
+            document.body.removeChild(textarea);
+            return successful;
+        } catch (err) {
+            console.error('Fallback copy failed: ', err);
+            return false;
+        }
     }
 
-    function copyToClipboardHtml(html) {
-        navigator.clipboard.write([
-            new ClipboardItem({
-                'text/html': new Blob([html], { type: 'text/html' })
-            })
-        ]).then(() => {
-            alert('Predictions copied to clipboard!');
-        }).catch(err => {
-            console.error('Could not copy text: ', err);
-        });
+    async function copyToClipboardHtml(html) {
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.write([
+                    new ClipboardItem({
+                        'text/html': new Blob([html], { type: 'text/html' })
+                    })
+                ]);
+                return true;
+            }
+        } catch (err) {
+            console.error('Could not use clipboard API: ', err);
+        }
+
+        try {
+            const container = document.createElement('div');
+            container.innerHTML = html;
+            document.body.appendChild(container);
+            const range = document.createRange();
+            range.selectNodeContents(container);
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            const successful = document.execCommand('copy');
+            selection.removeAllRanges();
+            document.body.removeChild(container);
+            return successful;
+        } catch (err) {
+            console.error('Fallback copy failed: ', err);
+            return false;
+        }
     }
 
     function isMobileDevice() {


### PR DESCRIPTION
## Summary
- ensure clipboard copy falls back when the Clipboard API isn't available
- return boolean results from JS interop calls
- show MudBlazor snackbar messages instead of alerts
- add reset date range button for week navigation

## Testing
- `dotnet build Predictorator.sln`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68767788e774832897883266ca182184