### PR TITLE
Fix clipboard copy and switch alerts to toasts

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -5,6 +5,7 @@
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
 @inject BrowserInteropService Browser
+@inject ISnackbar Snackbar
 
 <MudText Typo="Typo.h3" Class="my-4 pa-2" Align="Align.Center">Premier League Fixtures</MudText>
 
@@ -230,15 +231,19 @@ else if (_fixtures.Response.Any())
 
         if (missing)
         {
-            await Browser.AlertAsync("Error: Please fill in all score predictions before copying.");
+            Snackbar.Add("Error: Please fill in all score predictions before copying.", Severity.Error);
             return;
         }
 
         var mobile = await Browser.IsMobileDeviceAsync();
-        if (mobile)
-            await Browser.CopyToClipboardTextAsync(sbText.ToString());
+        bool copied = mobile
+            ? await Browser.CopyToClipboardTextAsync(sbText.ToString())
+            : await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+
+        if (copied)
+            Snackbar.Add("Predictions copied to clipboard!", Severity.Success);
         else
-            await Browser.CopyToClipboardHtmlAsync(sbHtml.ToString());
+            Snackbar.Add("Failed to copy predictions to clipboard.", Severity.Error);
     }
 
     private void ResetRange()

--- a/Predictorator/Services/BrowserInteropService.cs
+++ b/Predictorator/Services/BrowserInteropService.cs
@@ -11,9 +11,11 @@ public class BrowserInteropService
         _js = js;
     }
 
-    public ValueTask CopyToClipboardTextAsync(string text) => _js.InvokeVoidAsync("app.copyToClipboardText", text);
+    public ValueTask<bool> CopyToClipboardTextAsync(string text) =>
+        _js.InvokeAsync<bool>("app.copyToClipboardText", text);
 
-    public ValueTask CopyToClipboardHtmlAsync(string html) => _js.InvokeVoidAsync("app.copyToClipboardHtml", html);
+    public ValueTask<bool> CopyToClipboardHtmlAsync(string html) =>
+        _js.InvokeAsync<bool>("app.copyToClipboardHtml", html);
 
     public ValueTask<bool> IsMobileDeviceAsync() => _js.InvokeAsync<bool>("app.isMobileDevice");
 


### PR DESCRIPTION
## Summary
- handle clipboard copy in JS with fallbacks and return success boolean
- return success from browser interop methods
- show toast notifications instead of JS alerts when copying predictions

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6876a4dc41c083289dfb60ecd0c95b8e