### PR TITLE
Add Prediction Fairy display name to from address

### DIFF
--- a/Predictorator/Services/NotificationService.cs
+++ b/Predictorator/Services/NotificationService.cs
@@ -116,7 +116,7 @@ public class NotificationService
         {
             var emailMessage = new EmailMessage
             {
-                From = _config["Resend:From"] ?? "no-reply@example.com",
+                From = _config["Resend:From"] ?? "Prediction Fairy <no-reply@example.com>",
                 Subject = "Predictorator Notification",
                 HtmlBody = $"<p>{message} <a href=\"{baseUrl}\">View fixtures</a>.</p>"
             };

--- a/Predictorator/Services/SubscriptionService.cs
+++ b/Predictorator/Services/SubscriptionService.cs
@@ -71,7 +71,7 @@ public class SubscriptionService
 
         var message = new EmailMessage
         {
-            From = _config["Resend:From"] ?? "no-reply@example.com",
+            From = _config["Resend:From"] ?? "Prediction Fairy <no-reply@example.com>",
             Subject = "Verify your email",
             HtmlBody = $"<p>Please <a href=\"{verifyLink}\">verify your email</a>.</p><p>If you did not request this, you can <a href=\"{unsubscribeLink}\">unsubscribe</a>.</p>"
         };

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -14,7 +14,7 @@
   },
   "Resend": {
     "ApiToken": "",
-    "From": "no-reply@example.com"
+    "From": "Prediction Fairy <no-reply@example.com>"
   },
   "AdminUser": {
     "Email": "admin@example.com",


### PR DESCRIPTION
## Summary
- add display name to Resend From setting
- default email from address now includes display name

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6876ad8481a08328bb69a22ffa782711