### PR TITLE
Remove reset button, update toggle colors

### DIFF
--- a/Predictorator.Tests/HomePageTests.cs
+++ b/Predictorator.Tests/HomePageTests.cs
@@ -76,6 +76,5 @@ public class HomePageTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.NotNull(doc.QuerySelector("#copyBtn"));
         Assert.NotNull(doc.QuerySelector("#fillRandomBtn"));
         Assert.NotNull(doc.QuerySelector("#clearBtn"));
-        Assert.NotNull(doc.QuerySelector("#resetBtn"));
     }
 }

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -127,31 +127,4 @@ public class IndexPageBUnitTests
         Assert.False(prev.HasAttribute("disabled"));
     }
 
-    [Fact]
-    public async Task ResetButton_Removes_Date_Range_And_Reenables_Week_Navigation()
-    {
-        await using var ctx = CreateContext();
-        var navMan = (NavigationManager)ctx.Services.GetRequiredService<NavigationManager>();
-        navMan.NavigateTo("/?fromDate=2024-02-01&toDate=2024-02-07");
-
-        RenderFragment body = b =>
-        {
-            b.OpenComponent<IndexPage>(0);
-            b.CloseComponent();
-        };
-
-        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
-        var next = cut.Find("#nextWeekBtn");
-        var reset = cut.Find("#resetBtn");
-        Assert.True(next.HasAttribute("disabled"));
-        Assert.False(reset.HasAttribute("disabled"));
-
-        reset.Click();
-        Assert.DoesNotContain("fromDate", navMan.Uri);
-        Assert.DoesNotContain("toDate", navMan.Uri);
-
-        cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
-        next = cut.Find("#nextWeekBtn");
-        Assert.False(next.HasAttribute("disabled"));
-    }
 }

--- a/Predictorator/Components/Layout/CeefaxToggle.razor
+++ b/Predictorator/Components/Layout/CeefaxToggle.razor
@@ -2,7 +2,7 @@
 @rendermode InteractiveServer
 @inject ThemeService ThemeService
 
-<MudIconButton Icon="@Icons.Material.Outlined.Article" OnClick="ToggleCeefax" UserAttributes="@(new Dictionary<string, object>{{"id","ceefaxToggle"}})" />
+<MudIconButton Icon="@Icons.Material.Outlined.Article" OnClick="ToggleCeefax" Color="Color.Inherit" UserAttributes="@(new Dictionary<string, object>{{"id","ceefaxToggle"}})" />
 
 @code {
     protected override void OnInitialized()

--- a/Predictorator/Components/Layout/DarkModeToggle.razor
+++ b/Predictorator/Components/Layout/DarkModeToggle.razor
@@ -2,7 +2,7 @@
 @rendermode InteractiveServer
 @inject ThemeService ThemeService
 <MudIconButton Icon="@(ThemeService.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
-               OnClick="@ToggleDarkMode"
+               OnClick="@ToggleDarkMode" Color="Color.Inherit"
                UserAttributes="@(new Dictionary<string, object>{{"id","darkModeToggle"}})" />
 @code {
     protected override void OnInitialized()

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -19,8 +19,6 @@
         </MudText>
         <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="!_autoWeek" OnClick="@(() => ChangeWeek(1))"
                        UserAttributes="@(new Dictionary<string, object>{{"id","nextWeekBtn"}})" />
-        <MudIconButton Icon="@Icons.Material.Filled.Refresh" Disabled="_autoWeek" OnClick="ResetRange"
-                       UserAttributes="@(new Dictionary<string, object>{{"id","resetBtn"}})" />
     </MudStack>
     <MudCollapse Expanded="_showPicker">
         <MudDateRangePicker DateRange="_selectedRange" DateRangeChanged="RangeChanged" Class="my-2"
@@ -246,10 +244,6 @@ else if (_fixtures.Response.Any())
             Snackbar.Add("Failed to copy predictions to clipboard.", Severity.Error);
     }
 
-    private void ResetRange()
-    {
-        NavigationManager.NavigateTo("/");
-    }
 
     private class PredictionInput
     {


### PR DESCRIPTION
## Summary
- remove reset icon button from index page
- drop unused method and tests for removed button
- adjust dark mode and Ceefax toggles to use `Color.Inherit`

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6876ae6ebcc08328b7022a41d8235374