### PR TITLE
Invoke copy via JS listener

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -127,4 +127,18 @@ public class IndexPageBUnitTests
         Assert.False(prev.HasAttribute("disabled"));
     }
 
+    [Fact]
+    public async Task CopyButton_Has_Expected_Id_And_No_OnClick()
+    {
+        await using var ctx = CreateContext();
+        RenderFragment body = b =>
+        {
+            b.OpenComponent<IndexPage>(0);
+            b.CloseComponent();
+        };
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        var btn = cut.Find("#copyBtn");
+        Assert.False(btn.HasAttribute("onclick"));
+    }
+
 }

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -3,7 +3,6 @@
 @inject NavigationManager NavigationManager
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
-
 <MudText Typo="Typo.h3" Class="my-4 pa-2" Align="Align.Center">Premier League Fixtures</MudText>
 
 <MudPaper Class="my-4 pa-2" Elevation="1">
@@ -71,7 +70,7 @@ else if (_fixtures.Response.Any())
     <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="@ClearScores"
                UserAttributes="@(new Dictionary<string, object>{{"id","clearBtn"}})">Clear Predictions</MudButton>
     <MudButton Color="Color.Success" Variant="Variant.Filled"
-               UserAttributes="@(new Dictionary<string, object>{{"id","copyBtn"}, {"onclick", "app.copyPredictions()"}})">Copy Predictions to Clipboard</MudButton>
+               UserAttributes="@(new Dictionary<string, object>{{"id","copyBtn"}})">Copy Predictions to Clipboard</MudButton>
 </MudStack>
 
 @code {

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -139,3 +139,10 @@ window.app = (() => {
         copyPredictions
     };
 })();
+
+// delegate click so the handler works regardless of render timing
+document.addEventListener('click', function (e) {
+    if (e.target && e.target.id === 'copyBtn') {
+        window.app.copyPredictions();
+    }
+});


### PR DESCRIPTION
## Summary
- remove BrowserInteropService from Index page
- hook copy button with a JavaScript event listener
- adjust bUnit test accordingly

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687766198f048328a1d3c871984a7a81