### PR TITLE
Trigger MudBlazor toast from JavaScript

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -136,6 +136,8 @@ builder.Services.AddDataProtection()
 
 var app = builder.Build();
 
+ToastInterop.Configure(app.Services);
+
 
 app.UseRateLimiter();
 

--- a/Predictorator/Services/ToastInterop.cs
+++ b/Predictorator/Services/ToastInterop.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using MudBlazor;
+
+namespace Predictorator.Services;
+
+public static class ToastInterop
+{
+    private static IServiceProvider? _provider;
+
+    public static void Configure(IServiceProvider provider)
+    {
+        _provider = provider;
+    }
+
+    [JSInvokable]
+    public static Task ShowToast(string message)
+    {
+        if (_provider == null)
+            return Task.CompletedTask;
+
+        using var scope = _provider.CreateScope();
+        var snackbar = scope.ServiceProvider.GetService<ISnackbar>();
+        snackbar?.Add(message, Severity.Normal);
+        return Task.CompletedTask;
+    }
+}

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -61,3 +61,4 @@ html, body {
     white-space: normal;
     padding: 0 0.5rem;
 }
+

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -74,10 +74,16 @@ window.app = (() => {
         return window.localStorage.getItem(key);
     }
 
+    function showToast(message) {
+        if (window.DotNet && DotNet.invokeMethodAsync) {
+            DotNet.invokeMethodAsync('Predictorator', 'ShowToast', message);
+        }
+    }
+
     function copyPredictions() {
         const groups = document.querySelectorAll('.fixture-group');
         if (groups.length === 0) {
-            alert('No predictions available to copy.');
+            showToast('No predictions available to copy.');
             return;
         }
 
@@ -115,7 +121,7 @@ window.app = (() => {
         html += '</table><br/>';
 
         if (missing) {
-            alert('Error: Please fill in all score predictions before copying.');
+            showToast('Error: Please fill in all score predictions before copying.');
             return;
         }
 
@@ -123,9 +129,9 @@ window.app = (() => {
         const copyPromise = mobile ? copyToClipboardText(text) : copyToClipboardHtml(html);
         Promise.resolve(copyPromise).then(copied => {
             if (copied) {
-                alert('Predictions copied to clipboard!');
+                showToast('Predictions copied to clipboard!');
             } else {
-                alert('Failed to copy predictions to clipboard.');
+                showToast('Failed to copy predictions to clipboard.');
             }
         });
     }
@@ -136,7 +142,8 @@ window.app = (() => {
         isMobileDevice,
         setLocalStorage,
         getLocalStorage,
-        copyPredictions
+        copyPredictions,
+        showToast
     };
 })();
 


### PR DESCRIPTION
## Summary
- remove custom toast styles
- call into .NET from JS to show MudBlazor toast
- wire up `ToastInterop` in Program startup

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68776a542e848328ba2435c8be39d81e