### PR TITLE
Fix toast handler registration

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -12,9 +12,9 @@
 </head>
 <body class="@BodyClass">
     <Routes />
+    <script src="js/site.js"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-    <script src="js/site.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- load site.js before blazor.web.js so registerToastHandler is available before Blazor initializes

## Testing
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687779255a44832891559afd91c05976