### PR TITLE
Fix toast initialization

### DIFF
--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -102,6 +102,19 @@ public class MainLayoutBUnitTests
     }
 
     [Fact]
+    public async Task LayoutRegistersToastHandler()
+    {
+        await using var ctx = CreateContext();
+        var js = ctx.Services.GetRequiredService<IJSRuntime>();
+        RenderFragment body = b => b.AddMarkupContent(0, "<p>child</p>");
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        cut.WaitForAssertion(() =>
+        {
+            js.Received().InvokeAsync<Microsoft.JSInterop.Infrastructure.IJSVoidResult>("app.registerToastHandler", Arg.Any<object[]>());
+        });
+    }
+
+    [Fact]
     public async Task SubscribeButtonNotRendered_When_Features_Disabled()
     {
         await using var ctx = CreateContext(enableEmail: false, enableSms: false);

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -2,7 +2,6 @@
 @inherits LayoutComponentBase
 @inject IHttpContextAccessor HttpContextAccessor
 @inject ThemeService ThemeService
-@inject ToastInterop ToastInterop
 <MudLayout>
 <MudThemeProvider @rendermode="InteractiveServer"
                       Theme="@ThemeService.CurrentTheme"
@@ -11,6 +10,7 @@
     <MudPopoverProvider  @rendermode="InteractiveServer" />
     <MudDialogProvider    @rendermode="InteractiveServer" />
     <MudSnackbarProvider  @rendermode="InteractiveServer" />
+    <ToastInit />
     <MudAppBar Elevation="1" Color="Color.Primary">
         <MudText Typo="Typo.h5" Class="ml-2"><a href="/" style="color:inherit;text-decoration:none">Predictotronix</a></MudText>
         <MudSpacer />
@@ -39,19 +39,10 @@
         ThemeService.OnChange += OnThemeChanged;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            await ToastInterop.InitializeAsync();
-        }
-    }
-
     private void OnThemeChanged() => InvokeAsync(StateHasChanged);
 
     public void Dispose()
     {
         ThemeService.OnChange -= OnThemeChanged;
-        ToastInterop.DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 }

--- a/Predictorator/Components/Layout/ToastInit.razor
+++ b/Predictorator/Components/Layout/ToastInit.razor
@@ -1,0 +1,18 @@
+@implements IDisposable
+@rendermode InteractiveServer
+@inject ToastInterop ToastInterop
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await ToastInterop.InitializeAsync();
+        }
+    }
+
+    public void Dispose()
+    {
+        ToastInterop.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure toast helper initializes via new `ToastInit` component
- test that layout registers the toast handler

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68777ec6f1b08328af5274f513d11d03