### PR TITLE
Add color-coded toasts

### DIFF
--- a/Predictorator/Services/ToastInterop.cs
+++ b/Predictorator/Services/ToastInterop.cs
@@ -22,9 +22,16 @@ public sealed class ToastInterop : IAsyncDisposable
     }
 
     [JSInvokable]
-    public Task ShowToast(string message)
+    public Task ShowToast(string message, string? severity = null)
     {
-        _snackbar.Add(message, Severity.Normal);
+        var toastSeverity = severity?.ToLowerInvariant() switch
+        {
+            "success" => Severity.Success,
+            "error" => Severity.Error,
+            _ => Severity.Normal
+        };
+
+        _snackbar.Add(message, toastSeverity);
         return Task.CompletedTask;
     }
 

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -78,16 +78,16 @@ window.app = (() => {
         window.toastHelper = dotnetHelper;
     }
 
-    function showToast(message) {
+    function showToast(message, severity) {
         if (window.toastHelper) {
-            window.toastHelper.invokeMethodAsync('ShowToast', message);
+            window.toastHelper.invokeMethodAsync('ShowToast', message, severity);
         }
     }
     
     function copyPredictions() {
         const groups = document.querySelectorAll('.fixture-group');
         if (groups.length === 0) {
-            showToast('No predictions available to copy.');
+            showToast('No predictions available to copy.', 'error');
             return;
         }
 
@@ -125,7 +125,7 @@ window.app = (() => {
         html += '</table><br/>';
 
         if (missing) {
-            showToast('Error: Please fill in all score predictions before copying.');
+            showToast('Error: Please fill in all score predictions before copying.', 'error');
             return;
         }
 
@@ -133,9 +133,9 @@ window.app = (() => {
         const copyPromise = mobile ? copyToClipboardText(text) : copyToClipboardHtml(html);
         Promise.resolve(copyPromise).then(copied => {
             if (copied) {
-                showToast('Predictions copied to clipboard!');
+                showToast('Predictions copied to clipboard!', 'success');
             } else {
-                showToast('Failed to copy predictions to clipboard.');
+                showToast('Failed to copy predictions to clipboard.', 'error');
             }
         });
     }


### PR DESCRIPTION
## Summary
- allow JS to specify toast severity
- color toasts green for success and red for errors

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68778480d4348328a1efa0cb0463f38f