### PR TITLE
Darken Ceefax toggle when off

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -61,6 +61,22 @@ public class CeefaxModeBUnitTests
     }
 
     [Fact]
+    public async Task CeefaxToggle_Uses_Dark_Color_When_Off()
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<App>();
+        var toggle = cut.Find("#ceefaxToggle");
+        Assert.Contains("mud-dark-text", toggle.ClassName);
+
+        toggle.Click();
+        cut.WaitForAssertion(() =>
+        {
+            var t = cut.Find("#ceefaxToggle");
+            Assert.Contains("mud-primary-text", t.ClassName);
+        }, timeout: TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
     public async Task Initialize_Uses_Existing_State()
     {
         await using var ctx = new BunitContext();

--- a/Predictorator/Components/Layout/CeefaxToggle.razor
+++ b/Predictorator/Components/Layout/CeefaxToggle.razor
@@ -2,7 +2,10 @@
 @rendermode InteractiveServer
 @inject ThemeService ThemeService
 
-<MudIconButton Icon="@Icons.Material.Outlined.Article" OnClick="ToggleCeefax" Color="Color.Inherit" UserAttributes="@(new Dictionary<string, object>{{"id","ceefaxToggle"}})" />
+<MudIconButton Icon="@Icons.Material.Outlined.Article"
+              OnClick="ToggleCeefax"
+              Color="@(ThemeService.IsCeefax ? Color.Primary : Color.Dark)"
+              UserAttributes="@(new Dictionary<string, object>{{"id","ceefaxToggle"}})" />
 
 @code {
     protected override void OnInitialized()


### PR DESCRIPTION
## Summary
- revert Ceefax theme palette change
- dim Ceefax mode toggle when inactive using MudBlazor color
- verify button colours in BUnit test

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68778fe1ac48832888a3139e407b9f89