### PR TITLE
Refactor theme service to use ProtectedLocalStorage

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -2,7 +2,6 @@ using Bunit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.JSInterop;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
@@ -18,13 +17,12 @@ public class CeefaxModeBUnitTests
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
-        var jsRuntime = Substitute.For<IJSRuntime>();
-        ctx.Services.AddSingleton(jsRuntime);
-        var browser = new BrowserInteropService(jsRuntime);
-        ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService(browser);
+        var storage = new FakeBrowserStorage();
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        var theme = new ThemeService(storage);
         ctx.Services.AddSingleton(theme);
         ctx.Services.AddScoped<ToastInterop>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
@@ -64,14 +62,13 @@ public class CeefaxModeBUnitTests
     public async Task Initialize_Uses_Existing_State()
     {
         await using var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
-        var jsRuntime = Substitute.For<IJSRuntime>();
-        ctx.Services.AddSingleton(jsRuntime);
-        jsRuntime.InvokeAsync<string?>("app.getLocalStorage", Arg.Any<object[]>()).Returns("true");
-        var browser = new BrowserInteropService(jsRuntime);
-        ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService(browser);
+        var storage = new FakeBrowserStorage();
+        await storage.SetAsync("ceefaxMode", true);
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        var theme = new ThemeService(storage);
         ctx.Services.AddSingleton(theme);
         ctx.Services.AddScoped<ToastInterop>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());

--- a/Predictorator.Tests/Helpers/FakeBrowserStorage.cs
+++ b/Predictorator.Tests/Helpers/FakeBrowserStorage.cs
@@ -1,0 +1,19 @@
+using Predictorator.Services;
+
+namespace Predictorator.Tests.Helpers;
+
+public class FakeBrowserStorage : IBrowserStorage
+{
+    private readonly Dictionary<string, bool> _storage = new();
+
+    public Task SetAsync(string key, bool value)
+    {
+        _storage[key] = value;
+        return Task.CompletedTask;
+    }
+
+    public Task<bool?> GetAsync(string key)
+    {
+        return Task.FromResult(_storage.TryGetValue(key, out var value) ? (bool?)value : null);
+    }
+}

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
-using Microsoft.JSInterop;
 using MudBlazor.Services;
 using NSubstitute;
 using Predictorator.Components.Layout;
@@ -19,13 +18,12 @@ public class IndexPageBUnitTests
     private BunitContext CreateContext()
     {
         var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
-        var jsRuntime = Substitute.For<IJSRuntime>();
-        ctx.Services.AddSingleton(jsRuntime);
-        var browser = new BrowserInteropService(jsRuntime);
-        ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService(browser);
+        var storage = new FakeBrowserStorage();
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        var theme = new ThemeService(storage);
         ctx.Services.AddSingleton(theme);
         ctx.Services.AddScoped<ToastInterop>();
         var fixtures = new FixturesResponse { Response = [] };

--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -8,6 +8,7 @@ using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
 using Predictorator.Components.Layout;
+using Predictorator.Tests.Helpers;
 using Predictorator.Components.Pages.Subscription;
 using Predictorator.Services;
 
@@ -22,9 +23,9 @@ public class MainLayoutBUnitTests
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
         var jsRuntime = Substitute.For<IJSRuntime>();
         ctx.Services.AddSingleton(jsRuntime);
-        var browser = new BrowserInteropService(jsRuntime);
-        ctx.Services.AddSingleton(browser);
-        var theme = new ThemeService(browser);
+        var storage = new FakeBrowserStorage();
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        var theme = new ThemeService(storage);
         ctx.Services.AddSingleton(theme);
         ctx.Services.AddScoped<ToastInterop>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.JSInterop;
 using MudBlazor.Services;
 using MudBlazor;
 using NSubstitute;
@@ -20,13 +19,12 @@ public class SubscribeComponentBUnitTests
     private BunitContext CreateContext(Dictionary<string, string?> settings)
     {
         var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
         ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
-        var jsRuntime = Substitute.For<IJSRuntime>();
-        ctx.Services.AddSingleton(jsRuntime);
-        var browser = new BrowserInteropService(jsRuntime);
-        ctx.Services.AddSingleton(browser);
-        ctx.Services.AddSingleton(new ThemeService(browser));
+        var storage = new FakeBrowserStorage();
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        ctx.Services.AddSingleton(new ThemeService(storage));
         ctx.Services.AddScoped<ToastInterop>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
 

--- a/Predictorator.Tests/ThemeServiceTests.cs
+++ b/Predictorator.Tests/ThemeServiceTests.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 using Predictorator.Services;
-using Microsoft.JSInterop;
+using Predictorator.Tests.Helpers;
 
 namespace Predictorator.Tests;
 
@@ -11,10 +11,9 @@ public class ThemeServiceTests
     [Fact]
     public async Task InitializeAsync_Raises_OnChange()
     {
-        var jsRuntime = Substitute.For<IJSRuntime>();
-        jsRuntime.InvokeAsync<string?>("app.getLocalStorage", Arg.Any<object[]>()).Returns("true");
-        var browser = new BrowserInteropService(jsRuntime);
-        var service = new ThemeService(browser);
+        var storage = new FakeBrowserStorage();
+        await storage.SetAsync("darkMode", true);
+        var service = new ThemeService(storage);
         bool raised = false;
         service.OnChange += () => raised = true;
         await service.InitializeAsync();

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -13,6 +13,7 @@ using Resend;
 using Serilog;
 using Serilog.Events;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -116,6 +117,8 @@ razorComponentsBuilder.AddInteractiveServerComponents(options =>
 builder.Services.AddMudServices();
 builder.Services.AddHttpClient();
 builder.Services.AddScoped<BrowserInteropService>();
+builder.Services.AddScoped<ProtectedLocalStorage>();
+builder.Services.AddScoped<IBrowserStorage, ProtectedLocalStorageBrowserStorage>();
 builder.Services.AddScoped<ThemeService>();
 builder.Services.AddScoped<ToastInterop>();
 builder.Services.AddScoped<ISignInService, SignInManagerSignInService>();

--- a/Predictorator/Services/BrowserInteropService.cs
+++ b/Predictorator/Services/BrowserInteropService.cs
@@ -21,9 +21,4 @@ public class BrowserInteropService
 
     public ValueTask AlertAsync(string message) => _js.InvokeVoidAsync("alert", message);
 
-    public ValueTask SetLocalStorageAsync(string key, string value) =>
-        _js.InvokeVoidAsync("app.setLocalStorage", key, value);
-
-    public ValueTask<string?> GetLocalStorageAsync(string key) =>
-        _js.InvokeAsync<string?>("app.getLocalStorage", key);
 }

--- a/Predictorator/Services/IBrowserStorage.cs
+++ b/Predictorator/Services/IBrowserStorage.cs
@@ -1,0 +1,7 @@
+namespace Predictorator.Services;
+
+public interface IBrowserStorage
+{
+    Task SetAsync(string key, bool value);
+    Task<bool?> GetAsync(string key);
+}

--- a/Predictorator/Services/ProtectedLocalStorageBrowserStorage.cs
+++ b/Predictorator/Services/ProtectedLocalStorageBrowserStorage.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Predictorator.Services;
+
+public class ProtectedLocalStorageBrowserStorage : IBrowserStorage
+{
+    private readonly ProtectedLocalStorage _storage;
+
+    public ProtectedLocalStorageBrowserStorage(ProtectedLocalStorage storage)
+    {
+        _storage = storage;
+    }
+
+    public async Task SetAsync(string key, bool value)
+    {
+        await _storage.SetAsync(key, value);
+    }
+
+    public async Task<bool?> GetAsync(string key)
+    {
+        var result = await _storage.GetAsync<bool>(key);
+        return result.Success ? result.Value : null;
+    }
+}

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -1,14 +1,15 @@
+using System.Threading.Tasks;
 using MudBlazor;
 
 namespace Predictorator.Services;
 
 public class ThemeService
 {
-    private readonly BrowserInteropService _browser;
+    private readonly IBrowserStorage _storage;
 
-    public ThemeService(BrowserInteropService browser)
+    public ThemeService(IBrowserStorage storage)
     {
-        _browser = browser;
+        _storage = storage;
     }
 
     public bool IsDarkMode { get; private set; }
@@ -44,16 +45,16 @@ public class ThemeService
 
     public async Task InitializeAsync()
     {
-        var value = await _browser.GetLocalStorageAsync("darkMode");
-        if (bool.TryParse(value, out var result))
+        var stored = await _storage.GetAsync("darkMode");
+        if (stored.HasValue)
         {
-            IsDarkMode = result;
+            IsDarkMode = stored.Value;
         }
 
-        value = await _browser.GetLocalStorageAsync("ceefaxMode");
-        if (bool.TryParse(value, out result))
+        stored = await _storage.GetAsync("ceefaxMode");
+        if (stored.HasValue)
         {
-            IsCeefax = result;
+            IsCeefax = stored.Value;
         }
 
         OnChange?.Invoke();
@@ -66,7 +67,7 @@ public class ThemeService
         if (IsDarkMode != value)
         {
             IsDarkMode = value;
-            await _browser.SetLocalStorageAsync("darkMode", value.ToString().ToLowerInvariant());
+            await _storage.SetAsync("darkMode", value);
             OnChange?.Invoke();
         }
     }
@@ -78,7 +79,7 @@ public class ThemeService
         if (IsCeefax != value)
         {
             IsCeefax = value;
-            await _browser.SetLocalStorageAsync("ceefaxMode", value.ToString().ToLowerInvariant());
+            await _storage.SetAsync("ceefaxMode", value);
             OnChange?.Invoke();
         }
     }

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -66,14 +66,6 @@ window.app = (() => {
             (window.innerWidth <= 800 && window.innerHeight <= 600);
     }
 
-    function setLocalStorage(key, value) {
-        window.localStorage.setItem(key, value);
-    }
-
-    function getLocalStorage(key) {
-        return window.localStorage.getItem(key);
-    }
-    
     function registerToastHandler(dotnetHelper) {
         window.toastHelper = dotnetHelper;
     }
@@ -142,9 +134,7 @@ window.app = (() => {
 
     return {
         copyPredictions,
-        registerToastHandler,
-        setLocalStorage,
-        getLocalStorage
+        registerToastHandler
     };
 })();
 


### PR DESCRIPTION
## Summary
- add `IBrowserStorage` abstraction with a ProtectedLocalStorage-based implementation
- update `ThemeService` to use `IBrowserStorage`
- remove localStorage JS functions
- adjust tests with a fake storage and loose JS interop

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6877849dece08328857bc7ab231a33c6