### PR TITLE
Fix theme initialization

### DIFF
--- a/Predictorator.Tests/HomePageTests.cs
+++ b/Predictorator.Tests/HomePageTests.cs
@@ -59,6 +59,11 @@ public class HomePageTests : IClassFixture<WebApplicationFactory<Program>>
                             }
                         }
                     }));
+
+                services.RemoveAll(typeof(IBrowserStorage));
+                services.AddSingleton<IBrowserStorage>(new FakeBrowserStorage());
+                services.RemoveAll(typeof(ThemeService));
+                services.AddSingleton<ThemeService>();
             });
         });
     }

--- a/Predictorator.Tests/RateLimitingTests.cs
+++ b/Predictorator.Tests/RateLimitingTests.cs
@@ -47,6 +47,11 @@ public class RateLimitingTests : IClassFixture<WebApplicationFactory<Program>>
                 });
                 services.AddTransient<IFixtureService>(_ => new FakeFixtureService(
                     new FixturesResponse { Response = new List<FixtureData>() }));
+
+                services.RemoveAll(typeof(IBrowserStorage));
+                services.AddSingleton<IBrowserStorage>(new FakeBrowserStorage());
+                services.RemoveAll(typeof(ThemeService));
+                services.AddSingleton<ThemeService>();
             });
         });
     }

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -34,8 +34,9 @@
 </MudLayout>
 
 @code {
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        await ThemeService.InitializeAsync();
         ThemeService.OnChange += OnThemeChanged;
     }
 

--- a/Predictorator/Services/ThemeService.cs
+++ b/Predictorator/Services/ThemeService.cs
@@ -15,6 +15,11 @@ public class ThemeService
     public bool IsDarkMode { get; private set; }
     public bool IsCeefax { get; private set; }
 
+    public MudTheme DefaultTheme { get; } = new MudTheme()
+    {
+        // Light mode palette overrides can be specified here
+    };
+
     public MudTheme CeefaxTheme { get; } = new MudTheme()
     {
         PaletteDark = new PaletteDark()
@@ -39,7 +44,7 @@ public class ThemeService
         }
     };
 
-    public MudTheme? CurrentTheme => IsCeefax ? CeefaxTheme : null;
+    public MudTheme CurrentTheme => IsCeefax ? CeefaxTheme : DefaultTheme;
 
     public event Action? OnChange;
 


### PR DESCRIPTION
## Summary
- add default theme fallback to `ThemeService`
- trigger theme initialization in `MainLayout`
- ensure local tests don't hit JS interop in server tests by using `FakeBrowserStorage`

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6877a62b8e3483289f3aebec98304d59