### PR TITLE
Fix theme init timing and Ceefax toggle color

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -70,7 +70,7 @@ public class CeefaxModeBUnitTests
         cut.WaitForAssertion(() =>
         {
             var t = cut.Find("#ceefaxToggle");
-            Assert.Contains("mud-primary-text", t.ClassName);
+            Assert.Contains("mud-inherit-text", t.ClassName);
         }, timeout: TimeSpan.FromSeconds(1));
     }
 

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -34,10 +34,13 @@
 </MudLayout>
 
 @code {
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await ThemeService.InitializeAsync();
-        ThemeService.OnChange += OnThemeChanged;
+        if (firstRender)
+        {
+            await ThemeService.InitializeAsync();
+            ThemeService.OnChange += OnThemeChanged;
+        }
     }
 
     private void OnThemeChanged() => InvokeAsync(StateHasChanged);


### PR DESCRIPTION
## Summary
- delay theme initialization until after first render
- keep Ceefax toggle color inherit when active
- update test expectations

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6877a93e67f883289bf2ab610ce2d1c9