### PR TITLE
Fix layout button handlers

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -31,11 +31,13 @@
                            Color="Color.Inherit"
                            UserAttributes="@(new Dictionary<string, object>{{"id","donateLink"}})" />
         </MudTooltip>
-        <MudIconButton Icon="@(IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
-                       OnClick="ToggleDarkModeAsync" Color="Color.Inherit"
+        <MudIconButton @rendermode="InteractiveServer"
+                       Icon="@(IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+                       OnClick="@ToggleDarkModeAsync" Color="Color.Inherit"
                        UserAttributes="@(new Dictionary<string, object>{{"id","darkModeToggle"}})" />
-        <MudIconButton Icon="@Icons.Material.Outlined.Article"
-                      OnClick="ToggleCeefaxAsync" Color="@(IsCeefax ? Color.Inherit : Color.Dark)"
+        <MudIconButton @rendermode="InteractiveServer"
+                      Icon="@Icons.Material.Outlined.Article"
+                      OnClick="@ToggleCeefaxAsync" Color="@(IsCeefax ? Color.Inherit : Color.Dark)"
                       UserAttributes="@(new Dictionary<string, object>{{"id","ceefaxToggle"}})" />
     </MudAppBar>
 


### PR DESCRIPTION
## Summary
- make dark mode and ceefax toggles interactive by applying `@rendermode` to the icon buttons
- use `@ToggleDarkModeAsync` and `@ToggleCeefaxAsync` as event handlers

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6878094f68248328854f184f835de0f9