### PR TITLE
Refactor subscription service to reduce duplication

### DIFF
--- a/Predictorator/Models/ISubscriber.cs
+++ b/Predictorator/Models/ISubscriber.cs
@@ -1,0 +1,9 @@
+namespace Predictorator.Models;
+
+public interface ISubscriber
+{
+    bool IsVerified { get; set; }
+    string VerificationToken { get; set; }
+    string UnsubscribeToken { get; set; }
+    DateTime CreatedAt { get; set; }
+}

--- a/Predictorator/Models/SmsSubscriber.cs
+++ b/Predictorator/Models/SmsSubscriber.cs
@@ -1,6 +1,6 @@
 namespace Predictorator.Models;
 
-public class SmsSubscriber
+public class SmsSubscriber : ISubscriber
 {
     public int Id { get; set; }
     public string PhoneNumber { get; set; } = string.Empty;

--- a/Predictorator/Models/Subscriber.cs
+++ b/Predictorator/Models/Subscriber.cs
@@ -1,6 +1,6 @@
 namespace Predictorator.Models;
 
-public class Subscriber
+public class Subscriber : ISubscriber
 {
     public int Id { get; set; }
     public string Email { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- add `ISubscriber` interface for common properties
- implement `ISubscriber` in `Subscriber` and `SmsSubscriber`
- refactor `SubscriptionService` with generic helper methods

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`
- `dotnet format Predictorator.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6878af35d35883289457eb00dbe3b90b