### PR TITLE
Add responsive hamburger menu

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
+using AngleSharp.Dom;
 using Predictorator.Components;
 using Predictorator.Components.Layout;
 using Predictorator.Models.Fixtures;
@@ -51,7 +52,16 @@ public class CeefaxModeBUnitTests
         var cut = ctx.Render<App>();
         var layout = cut.FindComponent<MainLayout>();
         var service = ctx.Services.GetRequiredService<UiModeService>();
-        var toggle = cut.Find("#ceefaxToggle");
+        IElement toggle;
+        try
+        {
+            toggle = cut.Find("#ceefaxToggle");
+        }
+        catch (ElementNotFoundException)
+        {
+            cut.Find("#menuToggle").Click();
+            toggle = cut.Find("#ceefaxToggle");
+        }
         Assert.False(service.IsCeefax);
         toggle.Click();
         cut.WaitForAssertion(() =>
@@ -65,12 +75,29 @@ public class CeefaxModeBUnitTests
     {
         await using var ctx = CreateContext();
         var cut = ctx.Render<App>();
-        var toggle = cut.Find("#ceefaxToggle");
+        IElement toggle;
+        try
+        {
+            toggle = cut.Find("#ceefaxToggle");
+        }
+        catch (ElementNotFoundException)
+        {
+            cut.Find("#menuToggle").Click();
+            toggle = cut.Find("#ceefaxToggle");
+        }
         Assert.Contains("mud-dark-text", toggle.ClassName);
 
         toggle.Click();
         cut.WaitForAssertion(() =>
         {
+            try
+            {
+                cut.Find("#ceefaxToggle");
+            }
+            catch (ElementNotFoundException)
+            {
+                cut.Find("#menuToggle").Click();
+            }
             var t = cut.Find("#ceefaxToggle");
             Assert.Contains("mud-inherit-text", t.ClassName);
         }, timeout: TimeSpan.FromSeconds(1));

--- a/Predictorator.Tests/DarkModeBUnitTests.cs
+++ b/Predictorator.Tests/DarkModeBUnitTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
+using AngleSharp.Dom;
 using Predictorator.Components;
 using Predictorator.Components.Layout;
 using Predictorator.Models.Fixtures;
@@ -55,7 +56,16 @@ public class DarkModeBUnitTests
         var cut = ctx.Render<App>();
         var layout = cut.FindComponent<MainLayout>();
         var service = ctx.Services.GetRequiredService<UiModeService>();
-        var toggle = cut.Find("#darkModeToggle");
+        IElement toggle;
+        try
+        {
+            toggle = cut.Find("#darkModeToggle");
+        }
+        catch (ElementNotFoundException)
+        {
+            cut.Find("#menuToggle").Click();
+            toggle = cut.Find("#darkModeToggle");
+        }
         Assert.False(service.IsDarkMode);
 
         toggle.Click();

--- a/Predictorator.Tests/StartupValidatorTests.cs
+++ b/Predictorator.Tests/StartupValidatorTests.cs
@@ -14,6 +14,7 @@ public class StartupValidatorTests
         });
         builder.Configuration["ConnectionStrings:DefaultConnection"] = "Data Source=test.db";
         builder.Configuration["Resend:ApiToken"] = "token";
+        builder.Configuration["ApiSettings:RapidApiKey"] = null;
 
         var result = StartupValidator.Validate(builder);
 

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -4,6 +4,9 @@
 @inject IJSRuntime Js
 @inject IBrowserStorage Storage
 @inject UiModeService UiMode
+@inject IDialogService DialogService
+@inject NotificationFeatureService NotificationFeatures
+@using Predictorator.Components.Pages.Subscription
 
 <MudThemeProvider Theme="@CurrentTheme"
                   @bind-IsDarkMode="@IsDarkMode"/>
@@ -29,25 +32,49 @@
             </MudText>
         }
         <MudSpacer/>
-        @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
-             HttpContextAccessor.HttpContext.User.IsInRole("Admin"))
-        {
-            <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
-        }
-        <SubscribeButton/>
-        <MudTooltip Text="Contribute to hosting costs">
-            <MudIconButton Icon="@Icons.Material.Filled.VolunteerActivism"
-                           Href="https://paypal.me/tommcarrr?country.x=GB&locale.x=en_GB"
-                           Target="_blank" Rel="noopener"
-                           Color="Color.Inherit"
-                           UserAttributes="@(new Dictionary<string, object> { { "id", "donateLink" } })"/>
-        </MudTooltip>
-        <MudIconButton Icon="@(IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
-                       OnClick="@ToggleDarkModeAsync" Color="Color.Inherit"
-                       UserAttributes="@(new Dictionary<string, object> { { "id", "darkModeToggle" } })"/>
-        <MudIconButton Icon="@Icons.Material.Outlined.Article"
-                       OnClick="@ToggleCeefaxAsync" Color="@(IsCeefax ? Color.Inherit : Color.Dark)"
-                       UserAttributes="@(new Dictionary<string, object> { { "id", "ceefaxToggle" } })"/>
+        <MudHidden Breakpoint="Breakpoint.SmAndDown">
+            @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
+                 HttpContextAccessor.HttpContext.User.IsInRole("Admin"))
+            {
+                <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
+            }
+            <SubscribeButton/>
+            <MudTooltip Text="Contribute to hosting costs">
+                <MudIconButton Icon="@Icons.Material.Filled.VolunteerActivism"
+                               Href="https://paypal.me/tommcarrr?country.x=GB&locale.x=en_GB"
+                               Target="_blank" Rel="noopener"
+                               Color="Color.Inherit"
+                               UserAttributes="@(new Dictionary<string, object> { { "id", "donateLink" } })"/>
+            </MudTooltip>
+            <MudIconButton Icon="@(IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+                           OnClick="@ToggleDarkModeAsync" Color="Color.Inherit"
+                           UserAttributes="@(new Dictionary<string, object> { { "id", "darkModeToggle" } })"/>
+            <MudIconButton Icon="@Icons.Material.Outlined.Article"
+                           OnClick="@ToggleCeefaxAsync" Color="@(IsCeefax ? Color.Inherit : Color.Dark)"
+                           UserAttributes="@(new Dictionary<string, object> { { "id", "ceefaxToggle" } })"/>
+        </MudHidden>
+        <MudHidden Breakpoint="Breakpoint.MdAndUp">
+            <MudMenu>
+                <ActivatorContent>
+                    <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit"
+                                   UserAttributes="@(new Dictionary<string, object> { { "id", "menuToggle" } })" />
+                </ActivatorContent>
+                <ChildContent>
+                    @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
+                         HttpContextAccessor.HttpContext.User.IsInRole("Admin"))
+                    {
+                        <MudMenuItem Href="/Admin/SendNotification">Admin</MudMenuItem>
+                    }
+                    @if (NotificationFeatures.AnyEnabled)
+                    {
+                        <MudMenuItem OnClick="@OpenSubscribe" UserAttributes="@(new Dictionary<string, object> { { "id", "subscribeButton" } })">Subscribe</MudMenuItem>
+                    }
+                    <MudMenuItem Href="https://paypal.me/tommcarrr?country.x=GB&locale.x=en_GB" Target="_blank" UserAttributes="@(new Dictionary<string, object> { { "id", "donateLink" } })">Donate</MudMenuItem>
+                    <MudMenuItem OnClick="@ToggleDarkModeAsync" UserAttributes="@(new Dictionary<string, object> { { "id", "darkModeToggle" } })">@((IsDarkMode ? "Light Mode" : "Dark Mode"))</MudMenuItem>
+                    <MudMenuItem OnClick="@ToggleCeefaxAsync" Class="@(IsCeefax ? "mud-inherit-text" : "mud-dark-text")" UserAttributes="@(new Dictionary<string, object> { { "id", "ceefaxToggle" } })">Ceefax Mode</MudMenuItem>
+                </ChildContent>
+            </MudMenu>
+        </MudHidden>
     </MudAppBar>
 
     <MudMainContent>
@@ -147,6 +174,11 @@
         await Storage.SetAsync("ceefaxMode", IsCeefax);
         await Js.InvokeVoidAsync("app.setCeefax", IsCeefax);
         await InvokeAsync(StateHasChanged);
+    }
+
+    private void OpenSubscribe()
+    {
+        DialogService.Show<Subscribe>("Subscribe");
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- collapse top-right icons into a hamburger menu for small screens
- keep original buttons visible on larger displays
- ensure subscribe, donate and mode toggles are accessible from the menu
- update BUnit tests for new responsive layout
- clarify startup validator test setup

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build -nologo`

------
https://chatgpt.com/codex/tasks/task_e_687a04c555f08328bf30d9e41e93d170