### PR TITLE
Improve Ceefax mobile view

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -19,11 +19,20 @@
     <MudAppBar Elevation="1" Color="Color.Primary">
         @if (IsCeefax)
         {
-            <MudText Typo="Typo.h5" Class="ml-2 ceefax-logo">
-                <a href="/" style="color:inherit;text-decoration:none">
-                    <span>P</span><span>r</span><span>e</span><span>d</span><span>i</span><span>c</span><span>t</span><span>o</span><span>t</span><span>r</span><span>o</span><span>n</span><span>i</span><span>x</span>
-                </a>
-            </MudText>
+            <MudHidden Breakpoint="Breakpoint.SmAndDown">
+                <MudText Typo="Typo.h5" Class="ml-2 ceefax-logo">
+                    <a href="/" style="color:inherit;text-decoration:none">
+                        <span>P</span><span>r</span><span>e</span><span>d</span><span>i</span><span>c</span><span>t</span><span>o</span><span>t</span><span>r</span><span>o</span><span>n</span><span>i</span><span>x</span>
+                    </a>
+                </MudText>
+            </MudHidden>
+            <MudHidden Breakpoint="Breakpoint.MdAndUp">
+                <MudText Typo="Typo.h6" Class="ml-2 ceefax-logo">
+                    <a href="/" style="color:inherit;text-decoration:none">
+                        <span>P</span><span>R</span><span>D</span><span>C</span><span>T</span>
+                    </a>
+                </MudText>
+            </MudHidden>
         }
         else
         {

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -8,7 +8,7 @@
 
 @if (UiModeService.IsCeefax)
 {
-    <MudText Typo="Typo.h3" Class="my-4 pa-2" Align="Align.Left" Color="Color.Success">Premiership Results/Fixtures</MudText>
+    <MudText Typo="Typo.h3" Class="my-4 pa-2 ceefax-title" Align="Align.Left" Color="Color.Success">Premiership Results/Fixtures</MudText>
 }
 else
 {
@@ -74,7 +74,7 @@ else if (_fixtures.Response.Any())
     }
 }
 
-<MudStack Class="py-4" Row="true" Spacing="2" Justify="Justify.Center">
+<MudStack Class="py-4 bottom-buttons" Row="true" Spacing="2" Justify="Justify.Center">
     <MudButton Color="Color.Secondary" Variant="Variant.Filled" OnClick="@FillRandomScores"
                UserAttributes="@(new Dictionary<string, object>{{"id","fillRandomBtn"}})">Complete with Random Scores</MudButton>
     <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="@ClearScores"

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -88,3 +88,27 @@ html, body {
     /* ensure the spans inherit the uppercase */
     text-transform: inherit;
 }
+
+@media (max-width: 600px) {
+    .fixture-line {
+        grid-template-columns: 1fr 20px 2rem 0.5rem 2rem 20px 1fr;
+        gap: 0.25rem;
+    }
+
+    .bottom-buttons {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    body.ceefax .ceefax-title {
+        font-size: 1.25rem;
+    }
+
+    body.ceefax .fixture-line {
+        grid-template-columns: 1fr 2rem 0.5rem 2rem 1fr;
+    }
+
+    body.ceefax .fixture-line img {
+        display: none;
+    }
+}

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -62,7 +62,7 @@ window.app = (() => {
     }
 
     function setCeefax(enabled) {
-        // font handled by MudTheme
+        document.body.classList.toggle('ceefax', enabled);
     }
 
     function isMobileDevice() {


### PR DESCRIPTION
## Summary
- adjust Ceefax header for mobile view
- shrink title text in Ceefax mode on small screens
- stack action buttons vertically on mobile
- tweak fixture grid for small screens and hide images in Ceefax mobile
- toggle `ceefax` CSS class from JavaScript

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687a10e7a51483288f343ffaa37f8aa4