### PR TITLE
Fix mobile orientation of bottom buttons

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -74,7 +74,7 @@ else if (_fixtures.Response.Any())
     }
 }
 
-<MudStack Class="py-4 bottom-buttons" Row="true" Spacing="2" Justify="Justify.Center">
+<MudStack Class="py-4 bottom-buttons" Spacing="2" Justify="Justify.Center">
     <MudButton Color="Color.Secondary" Variant="Variant.Filled" OnClick="@FillRandomScores"
                UserAttributes="@(new Dictionary<string, object>{{"id","fillRandomBtn"}})">Complete with Random Scores</MudButton>
     <MudButton Color="Color.Warning" Variant="Variant.Filled" OnClick="@ClearScores"

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -89,6 +89,10 @@ html, body {
     text-transform: inherit;
 }
 
+.bottom-buttons {
+    flex-direction: row;
+}
+
 @media (max-width: 600px) {
     .fixture-line {
         grid-template-columns: 1fr 20px 2rem 0.5rem 2rem 20px 1fr;


### PR DESCRIPTION
## Summary
- remove Row attribute from bottom button stack
- style buttons to use row layout by default and switch to column on small screens

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a17a2c3288328b8b3a593676096d2