### PR TITLE
Fix score inputs on mobile

### DIFF
--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -115,4 +115,15 @@ html, body {
     body.ceefax .fixture-line img {
         display: none;
     }
+
+    /* Hide numeric input arrows on small screens */
+    .score-input input {
+        -moz-appearance: textfield;
+    }
+
+    .score-input input::-webkit-inner-spin-button,
+    .score-input input::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
 }


### PR DESCRIPTION
## Summary
- hide spin buttons for score inputs on small screens

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687a1d0e2a3c83289ef6e6d870c93037