### PR TITLE
Sync Ceefax mode with dark mode

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -71,6 +71,30 @@ public class CeefaxModeBUnitTests
     }
 
     [Fact]
+    public async Task ToggleCeefax_Enables_DarkMode()
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<App>();
+        var service = ctx.Services.GetRequiredService<UiModeService>();
+        IElement toggle;
+        try
+        {
+            toggle = cut.Find("#ceefaxToggle");
+        }
+        catch (ElementNotFoundException)
+        {
+            cut.Find("#menuToggle").Click();
+            toggle = cut.Find("#ceefaxToggle");
+        }
+        Assert.False(service.IsDarkMode);
+        toggle.Click();
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(service.IsDarkMode);
+        }, timeout: TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
     public async Task CeefaxToggle_Uses_Dark_Color_When_Off()
     {
         await using var ctx = CreateContext();
@@ -137,6 +161,43 @@ public class CeefaxModeBUnitTests
         cut.WaitForAssertion(() =>
         {
             Assert.True(service.IsCeefax);
+        }, timeout: TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Initialize_Ceefax_Enables_DarkMode()
+    {
+        await using var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        var storage = new FakeBrowserStorage();
+        await storage.SetAsync("ceefaxMode", true);
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        ctx.Services.AddScoped<ToastInterop>();
+        ctx.Services.AddScoped<UiModeService>();
+        ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+
+        var cut = ctx.Render<App>();
+        var layout = cut.FindComponent<MainLayout>();
+        var service = ctx.Services.GetRequiredService<UiModeService>();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(service.IsDarkMode);
         }, timeout: TimeSpan.FromSeconds(1));
     }
 }

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -163,7 +163,14 @@
 
             var ceefax = await Storage.GetAsync("ceefaxMode");
             if (ceefax.HasValue)
+            {
                 IsCeefax = ceefax.Value;
+                if (IsCeefax)
+                {
+                    IsDarkMode = true;
+                    await Storage.SetAsync("darkMode", IsDarkMode);
+                }
+            }
 
             await Js.InvokeVoidAsync("app.setCeefax", IsCeefax);
             await InvokeAsync(StateHasChanged);
@@ -181,6 +188,11 @@
     {
         IsCeefax = !IsCeefax;
         await Storage.SetAsync("ceefaxMode", IsCeefax);
+        if (IsCeefax)
+        {
+            IsDarkMode = true;
+            await Storage.SetAsync("darkMode", IsDarkMode);
+        }
         await Js.InvokeVoidAsync("app.setCeefax", IsCeefax);
         await InvokeAsync(StateHasChanged);
     }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ contain valid links.
 Verification links sent to subscribers are valid for one hour. A background job
 runs every 15 minutes to remove unverified subscriptions that have expired.
 
+Ceefax mode provides a retro Teletext-inspired theme. When enabled, dark mode is
+also automatically activated for optimal contrast.
+
 To run the application in Docker using the latest Compose Specification:
 
 ```bash


### PR DESCRIPTION
## Summary
- enable dark mode whenever Ceefax mode is activated or loaded from storage
- update tests for new Ceefax behaviour
- document this behaviour in README

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687a1e315fe4832885f36d6f0dc6fdac