### PR TITLE
Remove Ceefax header

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -165,37 +165,6 @@ public class CeefaxModeBUnitTests
     }
 
     [Fact]
-    public async Task CeefaxHeader_Renders_When_Enabled()
-    {
-        await using var ctx = CreateContext();
-        var cut = ctx.Render<App>();
-        IElement toggle;
-        try
-        {
-            toggle = cut.Find("#ceefaxToggle");
-        }
-        catch (ElementNotFoundException)
-        {
-            cut.Find("#menuToggle").Click();
-            toggle = cut.Find("#ceefaxToggle");
-        }
-
-        toggle.Click();
-
-        cut.WaitForAssertion(() =>
-        {
-            Assert.NotNull(cut.Find("#ceefaxHeader"));
-        }, timeout: TimeSpan.FromSeconds(1));
-    }
-
-    [Fact]
-    public async Task CeefaxHeader_NotRendered_When_Disabled()
-    {
-        await using var ctx = CreateContext();
-        var cut = ctx.Render<App>();
-
-        Assert.Empty(cut.FindAll("#ceefaxHeader"));
-    }
     public async Task Initialize_Ceefax_Enables_DarkMode()
     {
         await using var ctx = new BunitContext();

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -16,13 +16,7 @@
 <CascadingValue Value="this">
 <MudLayout>
     <ToastInit/>
-    @if (IsCeefax)
-    {
-        <div id="ceefaxHeader" class="ceefax-header d-flex px-2">
-            <span>Ceefax 1 303</span>
-            <span class="ms-auto"><span id="ceefaxDate"></span> <span id="ceefaxTime"></span></span>
-        </div>
-    }
+    @* Ceefax header removed *@
     <MudAppBar Elevation="1" Color="Color.Primary">
         @if (IsCeefax)
         {

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -93,13 +93,7 @@ html, body {
     flex-direction: row;
 }
 
-.ceefax-header {
-    display: flex;
-    justify-content: space-between;
-    background-color: #000;
-    color: #00FF00;
-    font-family: 'BBC-Ceefax', monospace;
-}
+
 
 @media (max-width: 600px) {
     .fixture-line {


### PR DESCRIPTION
## Summary
- drop the Ceefax header markup and style
- remove tests that looked for the header
- keep Ceefax initialisation test and mark with `[Fact]`

## Testing
- `~/.dotnet/dotnet build Predictorator.sln -warnaserror`
- `~/.dotnet/dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687a21fc16cc8328876d09a00ec1295b