### PR TITLE
Fix login httpclient URI

### DIFF
--- a/Predictorator/Components/Pages/Login.razor
+++ b/Predictorator/Components/Pages/Login.razor
@@ -41,7 +41,8 @@
         _error = null;
         try
         {
-            var response = await Http.PostAsJsonAsync("/login", _input);
+            var absoluteUrl = NavigationManager.ToAbsoluteUri("/login");
+            var response = await Http.PostAsJsonAsync(absoluteUrl, _input);
             if (response.IsSuccessStatusCode)
             {
                 NavigationManager.NavigateTo("/");


### PR DESCRIPTION
## Summary
- fix login page to call Login endpoint using an absolute URL

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a286a66c4832898aa500d38d40552