### PR TITLE
Add admin dashboard and adjust login

### DIFF
--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Predictorator.Data;
+using Predictorator.Models;
+using Predictorator.Services;
+using Resend;
+
+namespace Predictorator.Tests;
+
+public class AdminServiceTests
+{
+    private static AdminService CreateService(out ApplicationDbContext db)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        db = new ApplicationDbContext(options);
+        var resend = Substitute.For<IResend>();
+        var sms = Substitute.For<ITwilioSmsSender>();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Resend:From"] = "from@example.com" })
+            .Build();
+        return new AdminService(db, resend, sms, config);
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_marks_subscriber_verified()
+    {
+        var service = CreateService(out var db);
+        var subscriber = new Subscriber { Email = "a", IsVerified = false, VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
+        db.Subscribers.Add(subscriber);
+        await db.SaveChangesAsync();
+
+        await service.ConfirmAsync("Email", subscriber.Id);
+
+        Assert.True(subscriber.IsVerified);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_removes_sms_subscriber()
+    {
+        var service = CreateService(out var db);
+        var smsSub = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
+        db.SmsSubscribers.Add(smsSub);
+        await db.SaveChangesAsync();
+
+        await service.DeleteAsync("SMS", smsSub.Id);
+
+        Assert.Empty(db.SmsSubscribers);
+    }
+}

--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -103,9 +103,9 @@ public class HomePageTests
     }
 
     [Test]
-    public async Task Admin_Route_Should_Display_Login_Page()
+    public async Task Login_Route_Should_Display_Login_Page()
     {
-        await NavigateWithRetriesAsync(_page!, $"{BaseUrl}/admin");
+        await NavigateWithRetriesAsync(_page!, $"{BaseUrl}/login");
         await _page!.Locator("h1").WaitForAsync();
         var header = await _page!.TextContentAsync("h1");
         Assert.That(header, Does.Contain("Log in"));

--- a/Predictorator/Components/Layout/LoginDisplay.razor
+++ b/Predictorator/Components/Layout/LoginDisplay.razor
@@ -7,7 +7,7 @@
 }
 else
 {
-    <MudButton Variant="Variant.Text" Href="/admin">Login</MudButton>
+    <MudButton Variant="Variant.Text" Href="/login">Login</MudButton>
 }
 
 @code {

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -1,0 +1,89 @@
+@page "/admin"
+@rendermode InteractiveServer
+@using Predictorator.Services
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles="Admin")]
+@inject AdminService AdminService
+
+<h2>Subscribers</h2>
+@if (_items == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <EditForm OnValidSubmit="SendTestAsync">
+        <MudTable Items="_items" Hover="true">
+            <HeaderContent>
+                <MudTh></MudTh>
+                <MudTh>Contact</MudTh>
+                <MudTh>Status</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate Context="row">
+                <MudTd><MudCheckBox T="bool" @bind-Value="row.Selected" /></MudTd>
+                <MudTd>@row.Contact</MudTd>
+                <MudTd>
+                    @if (row.IsVerified)
+                    {
+                        <MudChip T="string" Color="Color.Success" Variant="Variant.Filled">Verified</MudChip>
+                    }
+                    else
+                    {
+                        <MudChip T="string" Color="Color.Warning" Variant="Variant.Filled">Pending</MudChip>
+                    }
+                </MudTd>
+                <MudTd>
+                    @if (!row.IsVerified)
+                    {
+                        <MudButton Size="Size.Small" Color="Color.Success" OnClick="@(()=>ConfirmAsync(row))">Confirm</MudButton>
+                    }
+                    <MudButton Size="Size.Small" Color="Color.Error" OnClick="@(()=>DeleteAsync(row))">Delete</MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+        <MudStack Row="true" Spacing="2" Class="mt-2">
+            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Send Test</MudButton>
+        </MudStack>
+    </EditForm>
+}
+
+@code {
+    private class Item : AdminSubscriberDto
+    {
+        public Item(int id, string contact, bool verified, string type) : base(id, contact, verified, type)
+        {
+        }
+
+        public bool Selected { get; set; }
+    }
+
+    private List<Item>? _items;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var data = await AdminService.GetSubscribersAsync();
+        _items = data.Select(d => new Item(d.Id, d.Contact, d.IsVerified, d.Type)).ToList();
+    }
+
+    private async Task ConfirmAsync(Item item)
+    {
+        await AdminService.ConfirmAsync(item.Type, item.Id);
+        item.IsVerified = true;
+    }
+
+    private async Task DeleteAsync(Item item)
+    {
+        await AdminService.DeleteAsync(item.Type, item.Id);
+        _items!.Remove(item);
+    }
+
+    private async Task SendTestAsync()
+    {
+        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
+        if (selected.Any())
+        {
+            await AdminService.SendTestAsync(selected);
+        }
+    }
+}

--- a/Predictorator/Components/Pages/Login.razor
+++ b/Predictorator/Components/Pages/Login.razor
@@ -1,4 +1,4 @@
-@page "/admin"
+@page "/login"
 @rendermode InteractiveServer
 @inject NavigationManager NavigationManager
 @inject ILogger<Login> Logger
@@ -45,7 +45,7 @@
             var response = await Http.PostAsJsonAsync(absoluteUrl, _input);
             if (response.IsSuccessStatusCode)
             {
-                NavigationManager.NavigateTo("/");
+                NavigationManager.NavigateTo("/admin");
                 return;
             }
 

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -77,6 +77,7 @@ builder.Services.Configure<TwilioOptions>(builder.Configuration.GetSection(Twili
 builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();
+builder.Services.AddTransient<AdminService>();
 builder.Services.AddSingleton<NotificationFeatureService>();
 builder.Services.Configure<AdminUserOptions>(options =>
 {
@@ -104,7 +105,7 @@ builder.Services.AddIdentity<IdentityUser, IdentityRole>()
 
 builder.Services.ConfigureApplicationCookie(options =>
 {
-    options.LoginPath = "/admin";
+    options.LoginPath = "/login";
 });
 
 // Add services to the container.
@@ -122,6 +123,7 @@ builder.Services.AddScoped<IBrowserStorage, ProtectedLocalStorageBrowserStorage>
 builder.Services.AddScoped<ToastInterop>();
 builder.Services.AddScoped<UiModeService>();
 builder.Services.AddScoped<ISignInService, SignInManagerSignInService>();
+builder.Services.AddAuthorization();
 builder.Services.AddRazorPages();
 
 if (!builder.Environment.IsEnvironment("Testing"))

--- a/Predictorator/Services/AdminService.cs
+++ b/Predictorator/Services/AdminService.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Data;
+using Predictorator.Models;
+using Resend;
+
+namespace Predictorator.Services;
+
+public class AdminSubscriberDto
+{
+    public int Id { get; init; }
+    public string Contact { get; init; } = string.Empty;
+    public bool IsVerified { get; set; }
+    public string Type { get; init; } = string.Empty;
+
+    public AdminSubscriberDto(int id, string contact, bool isVerified, string type)
+    {
+        Id = id;
+        Contact = contact;
+        IsVerified = isVerified;
+        Type = type;
+    }
+}
+
+public class AdminService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IResend _resend;
+    private readonly ITwilioSmsSender _sms;
+    private readonly IConfiguration _config;
+
+    public AdminService(ApplicationDbContext db, IResend resend, ITwilioSmsSender sms, IConfiguration config)
+    {
+        _db = db;
+        _resend = resend;
+        _sms = sms;
+        _config = config;
+    }
+
+    public async Task<List<AdminSubscriberDto>> GetSubscribersAsync()
+    {
+        var emails = await _db.Subscribers
+            .Select(s => new AdminSubscriberDto(s.Id, s.Email, s.IsVerified, "Email"))
+            .ToListAsync();
+        var phones = await _db.SmsSubscribers
+            .Select(s => new AdminSubscriberDto(s.Id, s.PhoneNumber, s.IsVerified, "SMS"))
+            .ToListAsync();
+        return emails.Concat(phones).OrderBy(s => s.Contact).ToList();
+    }
+
+    public async Task ConfirmAsync(string type, int id)
+    {
+        if (type == "Email")
+        {
+            var entity = await _db.Subscribers.FindAsync(id);
+            if (entity != null) entity.IsVerified = true;
+        }
+        else
+        {
+            var entity = await _db.SmsSubscribers.FindAsync(id);
+            if (entity != null) entity.IsVerified = true;
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(string type, int id)
+    {
+        if (type == "Email")
+        {
+            var entity = await _db.Subscribers.FindAsync(id);
+            if (entity != null) _db.Subscribers.Remove(entity);
+        }
+        else
+        {
+            var entity = await _db.SmsSubscribers.FindAsync(id);
+            if (entity != null) _db.SmsSubscribers.Remove(entity);
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task SendTestAsync(IEnumerable<AdminSubscriberDto> recipients)
+    {
+        foreach (var s in recipients)
+        {
+            if (s.Type == "Email")
+            {
+                var message = new EmailMessage
+                {
+                    From = _config["Resend:From"] ?? "Predictorator <noreply@example.com>",
+                    Subject = "Test Notification",
+                    HtmlBody = "<p>This is a test notification.</p>"
+                };
+                message.To.Add(s.Contact);
+                await _resend.EmailSendAsync(message);
+            }
+            else
+            {
+                await _sms.SendSmsAsync(s.Contact, "Test notification");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move login page to `/login` and update cookie settings
- add admin dashboard at `/admin` to manage subscribers
- redirect to admin page after login
- update navigation login link
- expose AdminService
- test AdminService
- fix UI test for new login URL

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet format --no-restore`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a32de54f48328b4af22cc553791a0