### PR TITLE
Remove unused SendNotification page

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -46,7 +46,7 @@
             @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
                  HttpContextAccessor.HttpContext.User.IsInRole("Admin"))
             {
-                <MudButton Variant="Variant.Text" Href="/Admin/SendNotification">Admin</MudButton>
+                <MudButton Variant="Variant.Text" Href="/admin">Admin</MudButton>
             }
             <SubscribeButton/>
             <MudTooltip Text="Contribute to hosting costs">
@@ -73,7 +73,7 @@
                     @if (HttpContextAccessor.HttpContext?.User.Identity?.IsAuthenticated == true &&
                          HttpContextAccessor.HttpContext.User.IsInRole("Admin"))
                     {
-                        <MudMenuItem Href="/Admin/SendNotification">Admin</MudMenuItem>
+                        <MudMenuItem Href="/admin">Admin</MudMenuItem>
                     }
                     @if (NotificationFeatures.AnyEnabled)
                     {

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -12,7 +12,7 @@
 }
 else
 {
-    <EditForm OnValidSubmit="SendTestAsync">
+    <EditForm Model="this" OnValidSubmit="SendTestAsync">
         <MudTable Items="_items" Hover="true">
             <HeaderContent>
                 <MudTh></MudTh>

--- a/Predictorator/Components/Pages/Admin/SendNotification.razor
+++ b/Predictorator/Components/Pages/Admin/SendNotification.razor
@@ -1,8 +1,0 @@
-@page "/Admin/SendNotification"
-@rendermode InteractiveServer
-
-<h2>Send Notification</h2>
-<form method="post">
-    <p>Confirm sending notification?</p>
-    <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Send</MudButton>
-</form>


### PR DESCRIPTION
## Summary
- drop `Admin/SendNotification` page and update navigation
- fix admin page `EditForm` to include a model

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687a46a009588328b48c95eef912ed8d