### PR TITLE
Improve environment handling in Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Database SA password
+MSSQL_SA_PASSWORD=Your_password123
+
+# Admin credentials
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=Admin123!
+
+# Twilio
+TWILIO_ACCOUNT_SID=your_sid
+TWILIO_AUTH_TOKEN=your_token
+TWILIO_FROM_NUMBER=+10000000000
+
+# Resend email service
+RESEND_API_TOKEN=your_resend_token
+RESEND_FROM="Prediction Fairy <no-reply@predictotronix.com>"
+
+# Rapid API key for fixture data
+RAPID_API_KEY=your_rapid_api_key
+
+# Base URL used in notifications
+BASE_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 Set `BASE_URL` to the public address of the site so scheduled notifications
 contain valid links.
 
+All variables used by Docker Compose can be placed in a `.env` file. A sample
+is provided at `.env.example`. Copy this file to `.env` and update the values
+as needed before running the containers.
+
 Verification links sent to subscribers are valid for one hour. A background job
 runs every 15 minutes to remove unverified subscriptions that have expired.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "Your_password123"
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
     ports:
       - "1433:1433"
     volumes:
@@ -15,12 +15,16 @@ services:
       dockerfile: Dockerfile
     environment:
       ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__DefaultConnection: Server=db;Database=Predictorator;User Id=sa;Password=Your_password123;Encrypt=False
-      ADMIN_EMAIL: admin@example.com
-      ADMIN_PASSWORD: Admin123!
-      Twilio__AccountSid: your_sid
-      Twilio__AuthToken: your_token
-      Twilio__FromNumber: +10000000000
+      ConnectionStrings__DefaultConnection: Server=db;Database=Predictorator;User Id=sa;Password=${MSSQL_SA_PASSWORD};Encrypt=False
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+      Twilio__AccountSid: ${TWILIO_ACCOUNT_SID}
+      Twilio__AuthToken: ${TWILIO_AUTH_TOKEN}
+      Twilio__FromNumber: ${TWILIO_FROM_NUMBER}
+      Resend__ApiToken: ${RESEND_API_TOKEN}
+      Resend__From: ${RESEND_FROM}
+      ApiSettings__RapidApiKey: ${RAPID_API_KEY}
+      BASE_URL: ${BASE_URL}
       DataProtection__KeyPath: /var/dp-keys
     depends_on:
       - db


### PR DESCRIPTION
## Summary
- parameterize Docker Compose env vars
- document `.env` file usage
- add `.env.example`

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`
- ❌ `docker compose -f docker-compose.yml build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a51cfb5e483289a8b354b92e1d2fd