### PR TITLE
Fix score reset when switching modes

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -7,6 +7,7 @@ using MudBlazor.Services;
 using NSubstitute;
 using Microsoft.JSInterop;
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 using Predictorator.Components;
 using Predictorator.Components.Layout;
 using Predictorator.Models.Fixtures;
@@ -225,6 +226,82 @@ public class CeefaxModeBUnitTests
         cut.WaitForAssertion(() =>
         {
             Assert.True(service.IsDarkMode);
+        }, timeout: TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Scores_Persist_When_Toggling_Ceefax()
+    {
+        await using var ctx = new BunitContext();
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        var jsRuntime = Substitute.For<IJSRuntime>();
+        ctx.Services.AddSingleton(jsRuntime);
+        var storage = new FakeBrowserStorage();
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        ctx.Services.AddScoped<ToastInterop>();
+        ctx.Services.AddScoped<UiModeService>();
+        ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+        var fixtures = new FixturesResponse
+        {
+            Response = new List<FixtureData>
+            {
+                new()
+                {
+                    Fixture = new Fixture { Id = 1, Date = DateTime.UtcNow, Venue = new Venue { Name = "A", City = "B" } },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Home", Logo = string.Empty },
+                        Away = new Team { Name = "Away", Logo = string.Empty }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = null, Away = null } }
+                }
+            }
+        };
+        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        var provider = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+
+        var cut = ctx.Render<App>();
+        var inputs = cut.FindAll("[data-testid=score-input]");
+        var homeInput = (IHtmlInputElement)inputs[0];
+        var awayInput = (IHtmlInputElement)inputs[1];
+        homeInput.Change("1");
+        awayInput.Change("0");
+        var homeValue = homeInput.Value;
+        var awayValue = awayInput.Value;
+
+        IElement toggle;
+        try
+        {
+            toggle = cut.Find("#ceefaxToggle");
+        }
+        catch (ElementNotFoundException)
+        {
+            cut.Find("#menuToggle").Click();
+            toggle = cut.Find("#ceefaxToggle");
+        }
+
+        toggle.Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            var updated = cut.FindAll("[data-testid=score-input]");
+            var updatedHome = (IHtmlInputElement)updated[0];
+            var updatedAway = (IHtmlInputElement)updated[1];
+            Assert.Equal(homeValue, updatedHome.Value);
+            Assert.Equal(awayValue, updatedAway.Value);
         }, timeout: TimeSpan.FromSeconds(1));
     }
 }

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -123,8 +123,11 @@ else if (_fixtures.Response.Any())
                 if (!_predictions.ContainsKey(f.Fixture.Id))
                     _predictions[f.Fixture.Id] = new PredictionInput();
 
-                _predictions[f.Fixture.Id].Home = f.Score?.Fulltime.Home;
-                _predictions[f.Fixture.Id].Away = f.Score?.Fulltime.Away;
+                var pred = _predictions[f.Fixture.Id];
+                if (pred.Home == null)
+                    pred.Home = f.Score?.Fulltime.Home;
+                if (pred.Away == null)
+                    pred.Away = f.Score?.Fulltime.Away;
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid overwriting predictions during re-render
- test that scores remain when toggling Ceefax mode

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687a5c4cf9b883289a3e1f7ca1bb083b