### PR TITLE
Fix dark theme

### DIFF
--- a/Predictorator.Tests/DarkModeBUnitTests.cs
+++ b/Predictorator.Tests/DarkModeBUnitTests.cs
@@ -112,4 +112,11 @@ public class DarkModeBUnitTests
             Assert.True(service.IsDarkMode);
         }, timeout: TimeSpan.FromSeconds(1));
     }
+
+    [Fact]
+    public void FootballTheme_Defines_DarkPalette()
+    {
+        Assert.Equal("#121212", Themes.FootballPredictorTheme.PaletteDark!.Background);
+        Assert.Equal("#1E5F3E", Themes.FootballPredictorTheme.PaletteDark.Primary);
+    }
 }

--- a/Predictorator/Themes/Themes.cs
+++ b/Predictorator/Themes/Themes.cs
@@ -44,6 +44,28 @@ public static class Themes
             // Transparency
             OverlayDark = "rgba(0, 0, 0, 0.6)"
         },
+        PaletteDark = new PaletteDark()
+        {
+            Primary = "#1E5F3E",
+            PrimaryContrastText = "#FFFFFF",
+            Secondary = "#FFB300",
+            SecondaryContrastText = "#212121",
+            Background = "#121212",
+            Surface = "#1E1E1E",
+            AppbarBackground = "#1E5F3E",
+            DrawerBackground = "#1E1E1E",
+            DrawerText = "#FFFFFF",
+            TextPrimary = "#FFFFFF",
+            TextSecondary = "#BBBBBB",
+            TextDisabled = "#777777",
+            Success = "#4CAF50",
+            Info = "#2196F3",
+            Warning = "#FB8C00",
+            Error = "#E53935",
+            Divider = "#424242",
+            TableLines = "#616161",
+            OverlayDark = "rgba(0, 0, 0, 0.6)"
+        },
         Typography = new Typography()
         {
             Default = new Default()


### PR DESCRIPTION
## Summary
- add `PaletteDark` to `FootballPredictorTheme`
- verify dark palette in unit tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687a619caeac832880cb09df92ce5379