### PR TITLE
Add manual unsubscribe and links

### DIFF
--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -85,8 +85,8 @@ public class NotificationServiceTests
 
         await service.SendNewFixturesAvailableAsync("key", "http://localhost");
 
-        await resend.Received().EmailSendAsync(Arg.Any<EmailMessage>());
-        await sms.Received().SendSmsAsync("+1", Arg.Any<string>());
+        await resend.Received().EmailSendAsync(Arg.Is<EmailMessage>(m => m.HtmlBody != null && m.HtmlBody.Contains("Unsubscribe")));
+        await sms.Received().SendSmsAsync("+1", Arg.Is<string>(msg => msg.Contains("Unsubscribe:")));
         Assert.Equal(1, db.SentNotifications.Count());
     }
 }

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -150,4 +150,30 @@ public class SubscriptionServiceTests
         Assert.Contains(recent, db.Subscribers);
         Assert.Contains(verified, db.SmsSubscribers);
     }
+
+    [Fact]
+    public async Task UnsubscribeByContactAsync_email_case_insensitive()
+    {
+        var service = CreateService(out var db, out _, out _, out _);
+        db.Subscribers.Add(new Subscriber { Email = "User@Example.com", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await service.UnsubscribeByContactAsync("user@example.com");
+
+        Assert.True(result);
+        Assert.Empty(db.Subscribers);
+    }
+
+    [Fact]
+    public async Task UnsubscribeByContactAsync_matches_phone_formats()
+    {
+        var service = CreateService(out var db, out _, out _, out _);
+        db.SmsSubscribers.Add(new SmsSubscriber { PhoneNumber = "5551234567", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync();
+
+        var result = await service.UnsubscribeByContactAsync("(555) 123-4567");
+
+        Assert.True(result);
+        Assert.Empty(db.SmsSubscribers);
+    }
 }

--- a/Predictorator/Components/Pages/Subscription/Remove.razor
+++ b/Predictorator/Components/Pages/Subscription/Remove.razor
@@ -1,0 +1,38 @@
+@page "/Subscription/Remove"
+@rendermode InteractiveServer
+@inject SubscriptionService SubscriptionService
+
+<MudPaper Class="pa-4" Elevation="1">
+    <h2>Unsubscribe</h2>
+    @if (_result != null)
+    {
+        <p>You have been unsubscribed if a matching subscription was found.</p>
+    }
+    else
+    {
+        <EditForm Model="_model" OnValidSubmit="HandleSubmit">
+            <MudStack Spacing="2">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                <MudTextField @bind-Value="_model.Contact" Label="Email or phone" For="@(() => _model.Contact)" />
+                <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Unsubscribe</MudButton>
+            </MudStack>
+        </EditForm>
+    }
+</MudPaper>
+
+@code {
+    private class ContactModel
+    {
+        [Required]
+        public string Contact { get; set; } = string.Empty;
+    }
+
+    private readonly ContactModel _model = new();
+    private bool? _result;
+
+    private async Task HandleSubmit()
+    {
+        _result = await SubscriptionService.UnsubscribeByContactAsync(_model.Contact);
+    }
+}


### PR DESCRIPTION
## Summary
- add interactive page for manual unsubscribe
- support removing subscriptions by email or phone number
- include unsubscribe link in notification messages
- test new unsubscribe features

## Testing
- `dotnet format --no-restore`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687a6a00990c83288e819f32fa524785