### PR TITLE
Ensure seeding before Hangfire jobs

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -178,6 +178,7 @@ app.MapGet("/logout", async (SignInManager<IdentityUser> sm) =>
 if (!app.Environment.IsEnvironment("Testing"))
 {
     app.UseHangfireDashboard();
+    await ApplicationDbInitializer.SeedAdminUserAsync(app.Services);
     RecurringJob.AddOrUpdate<NotificationService>(
         "fixture-notifications",
         s => s.CheckFixturesAsync(),
@@ -191,7 +192,6 @@ if (!app.Environment.IsEnvironment("Testing"))
         service => service.RemoveExpiredUnverifiedAsync(),
         "*/15 * * * *",
         new RecurringJobOptions());
-    await ApplicationDbInitializer.SeedAdminUserAsync(app.Services);
 }
 
 app.Run();


### PR DESCRIPTION
## Summary
- move admin user seeding before recurring job scheduling

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`
- `dotnet run --project Predictorator/Predictorator.csproj` *(fails: MissingRapidApiKey)*

------
https://chatgpt.com/codex/tasks/task_e_687bff96c1548328bcb3ebfa8a950865