### PR TITLE
Move seeding before Hangfire initialization

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -177,8 +177,8 @@ app.MapGet("/logout", async (SignInManager<IdentityUser> sm) =>
 
 if (!app.Environment.IsEnvironment("Testing"))
 {
-    app.UseHangfireDashboard();
     await ApplicationDbInitializer.SeedAdminUserAsync(app.Services);
+    app.UseHangfireDashboard();
     RecurringJob.AddOrUpdate<NotificationService>(
         "fixture-notifications",
         s => s.CheckFixturesAsync(),


### PR DESCRIPTION
## Summary
- call `ApplicationDbInitializer.SeedAdminUserAsync` before `UseHangfireDashboard`

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687ca1259aec8328a4f1a95243e46094