### PR TITLE
Add UK mobile number validation

### DIFF
--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -51,7 +51,7 @@ public class SubscribeComponentBUnitTests
         await using var ctx = CreateContext(new Dictionary<string, string?> { ["Resend:ApiToken"] = "token" });
         var cut = ctx.Render<Subscribe>();
         Assert.Contains("Email address", cut.Markup);
-        Assert.DoesNotContain("Phone number", cut.Markup);
+        Assert.DoesNotContain("UK mobile number", cut.Markup);
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class SubscribeComponentBUnitTests
             ["Twilio:FromNumber"] = "+1"
         });
         var cut = ctx.Render<Subscribe>();
-        Assert.Contains("Phone number", cut.Markup);
+        Assert.Contains("UK mobile number", cut.Markup);
         Assert.DoesNotContain("Email address", cut.Markup);
     }
 

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -37,7 +37,7 @@
                         <MudStack Spacing="2">
                             <DataAnnotationsValidator />
                             <ValidationSummary />
-                            <MudTextField @bind-Value="_phoneModel.PhoneNumber" Label="Phone number" For="@(() => _phoneModel.PhoneNumber)" />
+                            <MudTextField @bind-Value="_phoneModel.PhoneNumber" Label="UK mobile number" HelperText="Format: 07xxxxxxxxx" For="@(() => _phoneModel.PhoneNumber)" />
                             <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Subscribe</MudButton>
                         </MudStack>
                     </EditForm>
@@ -56,7 +56,8 @@
 
     private class PhoneModel
     {
-        [Required, Phone]
+        [Required]
+        [RegularExpression("^07\\d{9}$", ErrorMessage = "UK mobile numbers must start with 07 and contain 11 digits.")]
         public string PhoneNumber { get; set; } = string.Empty;
     }
 


### PR DESCRIPTION
## Summary
- enforce UK mobile number pattern for SMS subscriptions
- show helper text explaining phone format
- update BUnit tests for new label

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687cab0e618083289b6d45981c160706