### PR TITLE
Apply ceefax theme before rendering

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -10,10 +10,24 @@
     <link href="css/site.css" rel="stylesheet" />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
-<body>
+<body class="@BodyClass">
     <Routes @rendermode="InteractiveServer" />
     <script src="js/site.js"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 </html>
+
+@code {
+    [Inject]
+    private IHttpContextAccessor HttpContextAccessor { get; set; } = default!;
+
+    private string BodyClass => _isCeefax ? "ceefax" : string.Empty;
+    private bool _isCeefax;
+
+    protected override void OnInitialized()
+    {
+        var cookie = HttpContextAccessor.HttpContext?.Request.Cookies["ceefaxMode"];
+        _isCeefax = bool.TryParse(cookie, out var v) && v;
+    }
+}

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -159,19 +159,37 @@
         if (firstRender)
         {
             var dark = await Storage.GetAsync("darkMode");
-            if (dark.HasValue)
+            if (!dark.HasValue)
+            {
+                var darkCookie = GetCookieBool("darkMode");
+                if (darkCookie.HasValue)
+                    IsDarkMode = darkCookie.Value;
+            }
+            else
+            {
                 IsDarkMode = dark.Value;
+            }
 
             var ceefax = await Storage.GetAsync("ceefaxMode");
-            if (ceefax.HasValue)
+            if (!ceefax.HasValue)
+            {
+                var ceefaxCookie = GetCookieBool("ceefaxMode");
+                if (ceefaxCookie.HasValue)
+                    IsCeefax = ceefaxCookie.Value;
+            }
+            else
             {
                 IsCeefax = ceefax.Value;
-                if (IsCeefax)
-                {
-                    IsDarkMode = true;
-                    await Storage.SetAsync("darkMode", IsDarkMode);
-                }
             }
+
+            if (IsCeefax)
+            {
+                IsDarkMode = true;
+                await Storage.SetAsync("darkMode", IsDarkMode);
+            }
+
+            await SetCookie("darkMode", IsDarkMode);
+            await SetCookie("ceefaxMode", IsCeefax);
 
             await Js.InvokeVoidAsync("app.setCeefax", IsCeefax);
             await InvokeAsync(StateHasChanged);
@@ -182,6 +200,7 @@
     {
         IsDarkMode = !IsDarkMode;
         await Storage.SetAsync("darkMode", IsDarkMode);
+        await SetCookie("darkMode", IsDarkMode);
         await InvokeAsync(StateHasChanged);
     }
 
@@ -189,10 +208,12 @@
     {
         IsCeefax = !IsCeefax;
         await Storage.SetAsync("ceefaxMode", IsCeefax);
+        await SetCookie("ceefaxMode", IsCeefax);
         if (IsCeefax)
         {
             IsDarkMode = true;
             await Storage.SetAsync("darkMode", IsDarkMode);
+            await SetCookie("darkMode", IsDarkMode);
         }
         await Js.InvokeVoidAsync("app.setCeefax", IsCeefax);
         await InvokeAsync(StateHasChanged);
@@ -201,6 +222,20 @@
     private void OpenSubscribe()
     {
         DialogService.Show<Subscribe>("Subscribe");
+    }
+
+    private bool? GetCookieBool(string key)
+    {
+        var cookies = HttpContextAccessor.HttpContext?.Request.Cookies;
+        if (cookies != null && cookies.TryGetValue(key, out var value) && bool.TryParse(value, out var result))
+            return result;
+        return null;
+    }
+
+    private async Task SetCookie(string key, bool value)
+    {
+        // Use JS interop to update cookies after initial render
+        await Js.InvokeVoidAsync("eval", $"document.cookie='{key}={value};path=/;max-age=31536000'");
     }
 
     public void Dispose()

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -77,6 +77,7 @@ window.app = (() => {
 
     function setCeefax(enabled) {
         document.body.classList.toggle('ceefax', enabled);
+        document.cookie = `ceefaxMode=${enabled};path=/;max-age=31536000`;
         if (enabled) {
             updateCeefaxClock();
             ceefaxTimer = setInterval(updateCeefaxClock, 1000);


### PR DESCRIPTION
## Summary
- use an HttpContext cookie to apply the ceefax theme class in App.razor
- store theme preference via JS so the cookie persists across requests
- sync cookies during initialization and when toggling themes

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687cab4d0b8883288373690ac5edf540