### PR TITLE
Enable Ceefax theme by default

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -65,11 +65,11 @@ public class CeefaxModeBUnitTests
             cut.Find("#menuToggle").Click();
             toggle = cut.Find("#ceefaxToggle");
         }
-        Assert.False(service.IsCeefax);
+        Assert.True(service.IsCeefax);
         toggle.Click();
         cut.WaitForAssertion(() =>
         {
-            Assert.True(service.IsCeefax);
+            Assert.False(service.IsCeefax);
         }, timeout: TimeSpan.FromSeconds(1));
     }
 
@@ -77,6 +77,9 @@ public class CeefaxModeBUnitTests
     public async Task ToggleCeefax_Enables_DarkMode()
     {
         await using var ctx = CreateContext();
+        var storage = (FakeBrowserStorage)ctx.Services.GetRequiredService<IBrowserStorage>();
+        await storage.SetAsync("ceefaxMode", false);
+        await storage.SetAsync("darkMode", false);
         var cut = ctx.Render<App>();
         var service = ctx.Services.GetRequiredService<UiModeService>();
         IElement toggle;
@@ -101,6 +104,8 @@ public class CeefaxModeBUnitTests
     public async Task CeefaxToggle_Uses_Dark_Color_When_Off()
     {
         await using var ctx = CreateContext();
+        var storage = (FakeBrowserStorage)ctx.Services.GetRequiredService<IBrowserStorage>();
+        await storage.SetAsync("ceefaxMode", false);
         var cut = ctx.Render<App>();
         IElement toggle;
         try
@@ -135,6 +140,8 @@ public class CeefaxModeBUnitTests
     {
         await using var ctx = CreateContext();
         var js = ctx.Services.GetRequiredService<IJSRuntime>();
+        var storage = (FakeBrowserStorage)ctx.Services.GetRequiredService<IBrowserStorage>();
+        await storage.SetAsync("ceefaxMode", false);
         var cut = ctx.Render<App>();
         IElement toggle;
         try

--- a/Predictorator.Tests/DarkModeBUnitTests.cs
+++ b/Predictorator.Tests/DarkModeBUnitTests.cs
@@ -66,13 +66,13 @@ public class DarkModeBUnitTests
             cut.Find("#menuToggle").Click();
             toggle = cut.Find("#darkModeToggle");
         }
-        Assert.False(service.IsDarkMode);
+        Assert.True(service.IsDarkMode);
 
         toggle.Click();
 
         cut.WaitForAssertion(() =>
         {
-            Assert.True(service.IsDarkMode);
+            Assert.False(service.IsDarkMode);
         }, timeout: TimeSpan.FromSeconds(1));
     }
 

--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -49,6 +49,8 @@ public class MainLayoutBUnitTests
     public async Task LayoutRendersHeaderWithCorrectFont()
     {
         await using var ctx = CreateContext();
+        var storage = (FakeBrowserStorage)ctx.Services.GetRequiredService<IBrowserStorage>();
+        await storage.SetAsync("ceefaxMode", false);
         RenderFragment body = b => b.AddMarkupContent(0, "<p>child</p>");
         var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
         var header = cut.Find("h5.mud-typography-h5");
@@ -112,7 +114,7 @@ public class MainLayoutBUnitTests
         toggle.Click();
         cut.WaitForAssertion(() =>
         {
-            Assert.True(cut.Instance.IsDarkMode);
+            Assert.False(cut.Instance.IsDarkMode);
         });
     }
 

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -159,30 +159,47 @@
         if (firstRender)
         {
             var dark = await Storage.GetAsync("darkMode");
-            if (!dark.HasValue)
+            bool darkSet = false;
+            if (dark.HasValue)
+            {
+                IsDarkMode = dark.Value;
+                darkSet = true;
+            }
+            else
             {
                 var darkCookie = GetCookieBool("darkMode");
                 if (darkCookie.HasValue)
+                {
                     IsDarkMode = darkCookie.Value;
-            }
-            else
-            {
-                IsDarkMode = dark.Value;
+                    darkSet = true;
+                }
             }
 
             var ceefax = await Storage.GetAsync("ceefaxMode");
-            if (!ceefax.HasValue)
+            bool ceefaxSet = false;
+            if (ceefax.HasValue)
             {
-                var ceefaxCookie = GetCookieBool("ceefaxMode");
-                if (ceefaxCookie.HasValue)
-                    IsCeefax = ceefaxCookie.Value;
+                IsCeefax = ceefax.Value;
+                ceefaxSet = true;
             }
             else
             {
-                IsCeefax = ceefax.Value;
+                var ceefaxCookie = GetCookieBool("ceefaxMode");
+                if (ceefaxCookie.HasValue)
+                {
+                    IsCeefax = ceefaxCookie.Value;
+                    ceefaxSet = true;
+                }
             }
 
-            if (IsCeefax)
+            if (!darkSet && !ceefaxSet)
+            {
+                IsCeefax = true;
+                IsDarkMode = true;
+                await Storage.SetAsync("ceefaxMode", IsCeefax);
+                await Storage.SetAsync("darkMode", IsDarkMode);
+            }
+            else if (IsCeefax)
             {
                 IsDarkMode = true;
                 await Storage.SetAsync("darkMode", IsDarkMode);

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Verification links sent to subscribers are valid for one hour. A background job
 runs every 15 minutes to remove unverified subscriptions that have expired.
 
 Ceefax mode provides a retro Teletext-inspired theme. When enabled, dark mode is
-also automatically activated for optimal contrast.
+also automatically activated for optimal contrast. If no prior preference is
+stored in the browser, the site defaults to Ceefax mode with dark mode enabled.
 
 To run the application in Docker using the latest Compose Specification:
 


### PR DESCRIPTION
## Summary
- default to Ceefax mode with dark theme when no preference is stored
- document the new default behaviour
- update tests for Ceefax and dark mode toggling

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687cbbbdb9b88328840e81fef690c61b