### PR TITLE
Initialize Ceefax theme before first render

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -154,6 +154,27 @@
 
     private MudTheme CurrentTheme => IsCeefax ? CeefaxTheme : Themes.FootballPredictorTheme;
 
+    protected override void OnInitialized()
+    {
+        var darkCookie = GetCookieBool("darkMode");
+        if (darkCookie.HasValue)
+            IsDarkMode = darkCookie.Value;
+
+        var ceefaxCookie = GetCookieBool("ceefaxMode");
+        if (ceefaxCookie.HasValue)
+            IsCeefax = ceefaxCookie.Value;
+
+        if (!darkCookie.HasValue && !ceefaxCookie.HasValue)
+        {
+            IsCeefax = true;
+            IsDarkMode = true;
+        }
+        else if (IsCeefax)
+        {
+            IsDarkMode = true;
+        }
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)


### PR DESCRIPTION
## Summary
- initialise the theme and dark mode in `MainLayout` before rendering

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687cbfcd8d108328bb3b288e68666851