### PR TITLE
Implement auto-week increment

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -138,4 +138,80 @@ public class IndexPageBUnitTests
         Assert.False(btn.HasAttribute("onclick"));
     }
 
+    [Fact]
+    public async Task AutoWeek_Increments_Offset_When_No_Fixtures()
+    {
+        await using var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        ctx.Services.AddSingleton<IBrowserStorage>(new FakeBrowserStorage());
+        ctx.Services.AddScoped<ToastInterop>();
+        ctx.Services.AddScoped<UiModeService>();
+
+        var provider = new FakeDateTimeProvider
+        {
+            Today = new DateTime(2024, 1, 1),
+            UtcNow = new DateTime(2024, 1, 1)
+        };
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
+        var fixtureService = new AutoWeekFixtureService();
+        ctx.Services.AddSingleton<IFixtureService>(fixtureService);
+
+        var settings = new Dictionary<string, string?>
+        {
+            ["Resend:ApiToken"] = "token",
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+1"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+
+        var navMan = (NavigationManager)ctx.Services.GetRequiredService<NavigationManager>();
+        RenderFragment body = b => { b.OpenComponent<IndexPage>(0); b.CloseComponent(); };
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.True(fixtureService.RequestedFromDates.Count >= 2);
+            Assert.Equal(new DateTime(2023, 12, 29), fixtureService.RequestedFromDates[0]);
+            Assert.Equal(new DateTime(2024, 1, 5), fixtureService.RequestedFromDates[1]);
+            cut.Find("[data-testid=fixture-row]");
+        }, timeout: TimeSpan.FromSeconds(1));
+
+        cut.Find("#nextWeekBtn").Click();
+        Assert.Contains("weekOffset=2", navMan.Uri);
+    }
+
+    private class AutoWeekFixtureService : IFixtureService
+    {
+        public List<DateTime> RequestedFromDates { get; } = new();
+
+        public Task<FixturesResponse> GetFixturesAsync(DateTime fromDate, DateTime toDate)
+        {
+            RequestedFromDates.Add(fromDate.Date);
+            if (fromDate.Date == new DateTime(2023, 12, 29))
+            {
+                return Task.FromResult(new FixturesResponse { FromDate = fromDate, ToDate = toDate });
+            }
+
+            return Task.FromResult(new FixturesResponse
+            {
+                FromDate = fromDate,
+                ToDate = toDate,
+                Response = new List<FixtureData>
+                {
+                    new()
+                    {
+                        Fixture = new Fixture { Id = 1, Date = fromDate, Venue = new Venue { Name = "A", City = "B" } },
+                        Teams = new Teams { Home = new Team { Name = "Home", Logo = string.Empty }, Away = new Team { Name = "Away", Logo = string.Empty } },
+                        Score = new Score { Fulltime = new ScoreHomeAway() }
+                    }
+                }
+            });
+        }
+    }
+
 }

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -116,6 +116,30 @@ else if (_fixtures.Response.Any())
         _autoWeek = FromDate == null && ToDate == null;
         _fixtures = await FixtureService.GetFixturesAsync(from, to);
 
+        if (_autoWeek && WeekOffset == null && (_fixtures?.Response.Count ?? 0) == 0)
+        {
+            var offset = 1;
+            FixturesResponse? response = null;
+            do
+            {
+                var (nFrom, nTo) = DateRangeCalculator.GetDates(null, null, offset);
+                response = await FixtureService.GetFixturesAsync(nFrom, nTo);
+                if (response.Response.Count > 0)
+                {
+                    _fixtures = response;
+                    _fromDate = nFrom;
+                    _toDate = nTo;
+                    _selectedRange = new DateRange(nFrom, nTo);
+                    _currentWeekOffset = offset;
+                    WeekOffset = offset;
+                }
+                else
+                {
+                    offset++;
+                }
+            } while ((_fixtures?.Response.Count ?? 0) == 0 && offset < 52);
+        }
+
         if (_fixtures?.Response != null)
         {
             foreach (var f in _fixtures.Response)


### PR DESCRIPTION
## Summary
- adjust Index page to auto-increment week offset if no fixtures found
- cover auto-week logic in BUnit tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687ccce824148328bcf38f9a7611eccd