### PR TITLE
Restore Facebook share metadata

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -8,6 +8,10 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
+    <meta property="og:title" content="Predictotronix" />
+    <meta property="og:description" content="A predicting robot from the future." />
+    <meta property="og:image" content="https://predictorator5000-d8c3e9e4hcbnbph2.uksouth-01.azurewebsites.net/images/lizwig.jpg" />
+    <meta property="og:type" content="website" />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
 <body class="@BodyClass">


### PR DESCRIPTION
## Summary
- add missing Open Graph meta tags to Blazor App
- update OG title to Predictotronix

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687cede1301c832892ee3aa5b0d2c93d