### PR TITLE
Add social sharing metadata

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -10,8 +10,13 @@
     <link href="css/site.css" rel="stylesheet" />
     <meta property="og:title" content="Predictotronix" />
     <meta property="og:description" content="A predicting robot from the future." />
-    <meta property="og:image" content="https://predictorator5000-d8c3e9e4hcbnbph2.uksouth-01.azurewebsites.net/images/lizwig.jpg" />
+    <meta property="og:image" content="https://www.predictotronix.com/images/lizwig.jpg" />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.predictotronix.com/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Predictotronix" />
+    <meta name="twitter:description" content="A predicting robot from the future." />
+    <meta name="twitter:image" content="https://www.predictotronix.com/images/lizwig.jpg" />
     <HeadOutlet @rendermode="InteractiveServer" />
 </head>
 <body class="@BodyClass">

--- a/src/Predictotronix/Predictotronix/Predictotronix/Components/App.razor
+++ b/src/Predictotronix/Predictotronix/Predictotronix/Components/App.razor
@@ -10,6 +10,15 @@
     <link rel="stylesheet" href="@Assets["Predictotronix.styles.css"]"/>
     <ImportMap/>
     <link rel="icon" type="image/png" href="favicon.png"/>
+    <meta property="og:title" content="Predictotronix"/>
+    <meta property="og:description" content="A predicting robot from the future."/>
+    <meta property="og:image" content="https://www.predictotronix.com/favicon.png"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://www.predictotronix.com/"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:title" content="Predictotronix"/>
+    <meta name="twitter:description" content="A predicting robot from the future."/>
+    <meta name="twitter:image" content="https://www.predictotronix.com/favicon.png"/>
     <HeadOutlet/>
 </head>
 


### PR DESCRIPTION
## Summary
- add Twitter and additional Open Graph meta tags for cross-platform sharing
- use https://www.predictotronix.com/ for sharing metadata

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687d18605f7c832890aa5c55874ad552