### PR TITLE
Add HTML email template renderer

### DIFF
--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -35,13 +35,14 @@ public class AdminServiceTests
         Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
         File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
         var inliner = new EmailCssInliner(env);
+        var renderer = new EmailTemplateRenderer();
         var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
         var fixtures = new FakeFixtureService(new FixturesResponse());
         var range = new DateRangeCalculator(provider);
         var features = new NotificationFeatureService(config);
         var jobs = Substitute.For<IBackgroundJobClient>();
-        var notifications = new NotificationService(db, resend, sms, config, fixtures, range, features, provider, jobs, inliner);
-        return new AdminService(db, resend, sms, config, inliner, notifications);
+        var notifications = new NotificationService(db, resend, sms, config, fixtures, range, features, provider, jobs, inliner, renderer);
+        return new AdminService(db, resend, sms, config, inliner, renderer, notifications);
     }
 
     [Fact]

--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -61,7 +61,8 @@ public class NotificationServiceTests
         Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
         File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
         var inliner = new EmailCssInliner(env);
-        return new NotificationService(db, resend, sms, config, fixtures, calculator, features, provider, jobs, inliner);
+        var renderer = new EmailTemplateRenderer();
+        return new NotificationService(db, resend, sms, config, fixtures, calculator, features, provider, jobs, inliner, renderer);
     }
 
     [Fact]

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -47,7 +47,8 @@ public class SubscribeComponentBUnitTests
         Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
         File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
         var inliner = new EmailCssInliner(env);
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner));
+        var renderer = new EmailTemplateRenderer();
+        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer));
         return ctx;
     }
 

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -30,7 +30,8 @@ public class SubscriptionServiceTests
         provider ??= new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         var env = new FakeWebHostEnvironment { WebRootPath = Path.GetTempPath() };
         var inliner = new EmailCssInliner(env);
-        return new SubscriptionService(db, resend, config, sms, provider, jobs, inliner);
+        var renderer = new EmailTemplateRenderer();
+        return new SubscriptionService(db, resend, config, sms, provider, jobs, inliner, renderer);
     }
 
     [Fact]

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();
 builder.Services.AddTransient<AdminService>();
 builder.Services.AddSingleton<EmailCssInliner>();
+builder.Services.AddSingleton<EmailTemplateRenderer>();
 builder.Services.AddSingleton<NotificationFeatureService>();
 builder.Services.Configure<AdminUserOptions>(options =>
 {

--- a/Predictorator/Services/EmailTemplateRenderer.cs
+++ b/Predictorator/Services/EmailTemplateRenderer.cs
@@ -1,0 +1,91 @@
+using System;
+
+namespace Predictorator.Services;
+
+public class EmailTemplateRenderer
+{
+    public string Render(string messageHtml, string baseUrl, string? unsubscribeToken, string? buttonText = null, string? buttonUrl = null)
+    {
+        var year = DateTime.UtcNow.Year;
+        var buttonSection = string.Empty;
+        if (!string.IsNullOrWhiteSpace(buttonText) && !string.IsNullOrWhiteSpace(buttonUrl))
+        {
+            buttonSection = $@"
+              <p style=""text-align:center; margin:40px 0;"">
+                <a href=""{buttonUrl}""
+                   style=""
+                     background-color:#0000ff;
+                     color:#ffffff;
+                     text-decoration:none;
+                     padding:14px 28px;
+                     border-radius:4px;
+                     font-weight:bold;
+                     font-size:16px;
+                     text-transform:uppercase;
+                     display:inline-block;
+                   "">
+                  {buttonText}
+                </a>
+              </p>";
+        }
+
+        var unsubscribeSection = string.Empty;
+        if (!string.IsNullOrWhiteSpace(unsubscribeToken))
+        {
+            var link = $"{baseUrl}/Subscription/Unsubscribe?token={unsubscribeToken}";
+            unsubscribeSection = $"<a href=\"{link}\" style=\"color:#555555; text-decoration:none; font-size:11px;\">Unsubscribe</a>";
+        }
+
+        return $@"<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=""UTF-8"">
+  <title>Predictotronix</title>
+  <style>
+    .preheader {{ display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; }}
+  </style>
+</head>
+<body style=""margin:0; padding:0; background-color:#0a0a0a; color:#f0f0f0; font-family:'Courier New', Courier, monospace;"">
+  <span class=""preheader"">
+    Your latest predictions are locked and loaded at Predictotronix.
+  </span>
+  <table width=""100%"" cellpadding=""0"" cellspacing=""0"" style=""background-color:#0a0a0a; padding:20px 0;"">
+    <tr>
+      <td align=""center"">
+        <table width=""600"" cellpadding=""0"" cellspacing=""0"" style=""background-color:#1a1a1a; border:2px solid #00ff00; border-radius:8px; overflow:hidden;"">
+          <tr>
+            <td align=""center"" style=""background-color:#000000; padding:30px;"">
+              <h1 style=""margin:0; font-size:32px; color:#0000ff; letter-spacing:2px;"">
+                PREDICTOTRONIX
+              </h1>
+              <p style=""margin:5px 0 0 0; font-size:14px; color:#00ff00; text-transform:uppercase;"">
+                Death to humans
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style=""padding:30px; font-size:16px; line-height:1.6; color:#00ffff;"">
+              <p style=""margin-top:0;"">
+                {messageHtml}
+              </p>{buttonSection}
+              <p style=""font-size:14px; color:#909090; text-align:center;"">
+                You have 10 seconds to comply...
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style=""background-color:#000000; padding:15px 30px; text-align:center; font-size:12px; color:#555555;"">
+              <p style=""margin:0;"">© {year} Predictotronix. All Rights Reserved.</p>
+              <p style=""margin:8px 0 0 0;"">
+                {unsubscribeSection}
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>";
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EmailTemplateRenderer` for consistent email layout
- use new template in notification, subscription, and admin services
- inject the renderer via DI in `Program.cs`
- adjust unit tests for updated constructors

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687d5186bca883289ce7254714af4f55