### PR TITLE
Fix unsubscribe rerender

### DIFF
--- a/Predictorator/Components/Pages/Subscription/Unsubscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Unsubscribe.razor
@@ -1,6 +1,8 @@
 @page "/Subscription/Unsubscribe"
 @rendermode InteractiveServer
 @inject SubscriptionService SubscriptionService
+@inject PersistentComponentState State
+@implements IDisposable
 
 <h2>Unsubscribe</h2>
 @if (_result == null)
@@ -21,9 +23,32 @@ else
     public string? token { get; set; }
 
     private bool? _result;
+    private PersistingComponentStateSubscription? _persistSubscription;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
+        if (State.TryTakeFromJson<bool?>(nameof(_result), out var result))
+        {
+            _result = result;
+            return;
+        }
+
         _result = await SubscriptionService.UnsubscribeAsync(token ?? "");
+    }
+
+    protected override void OnInitialized()
+    {
+        _persistSubscription = State.RegisterOnPersisting(PersistState);
+    }
+
+    private Task PersistState()
+    {
+        State.PersistAsJson(nameof(_result), _result);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _persistSubscription?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- remember unsubscribe result during prerender so it doesn't re-run

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687d59d3224c83289692ccc3255f9f6b