### PR TITLE
Fix SMS verification link formatting

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -193,7 +193,10 @@ if (!app.Environment.IsEnvironment("Testing"))
         "cleanup-unverified",
         service => service.RemoveExpiredUnverifiedAsync(),
         "*/15 * * * *",
-        new RecurringJobOptions());
+        new RecurringJobOptions
+        {
+            TimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")
+        });
 }
 
 app.Run();

--- a/Predictorator/Services/SubscriptionService.cs
+++ b/Predictorator/Services/SubscriptionService.cs
@@ -161,7 +161,7 @@ public class SubscriptionService
 
         var verifyLink = $"{baseUrl}/Subscription/Verify?token={subscriber.VerificationToken}";
         var unsubscribeLink = $"{baseUrl}/Subscription/Unsubscribe?token={subscriber.UnsubscribeToken}";
-        var message = $"Verify your phone subscription: {verifyLink}. To unsubscribe: {unsubscribeLink}";
+        var message = $"Verify your phone subscription: {verifyLink} To unsubscribe: {unsubscribeLink}";
         await _smsSender.SendSmsAsync(phoneNumber, message);
     }
 


### PR DESCRIPTION
## Summary
- avoid trailing period in SMS verification links so they parse correctly on phones
- align Hangfire cleanup job with GMT timezone

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687d5b9120008328ada60197c0245345