### PR TITLE
Add logging to SMS subscription flow

### DIFF
--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -13,6 +13,7 @@ using Predictorator.Tests.Helpers;
 using System.IO;
 using System;
 using Resend;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Predictorator.Tests;
 
@@ -48,7 +49,8 @@ public class SubscribeComponentBUnitTests
         File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer));
+        var logger = NullLogger<SubscriptionService>.Instance;
+        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer, logger));
         return ctx;
     }
 

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -7,6 +7,7 @@ using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
 using Predictorator.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Predictorator.Tests.Helpers;
 using System.IO;
 using Resend;
@@ -31,7 +32,8 @@ public class SubscriptionServiceTests
         var env = new FakeWebHostEnvironment { WebRootPath = Path.GetTempPath() };
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
-        return new SubscriptionService(db, resend, config, sms, provider, jobs, inliner, renderer);
+        var logger = NullLogger<SubscriptionService>.Instance;
+        return new SubscriptionService(db, resend, config, sms, provider, jobs, inliner, renderer, logger);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- log messages when scheduling subscriptions and handling SMS subscriptions
- provide NullLogger in tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687df54b60488328b9286ce273ed7158