### PR TITLE
Add admin protection for Hangfire dashboard

### DIFF
--- a/Predictorator.Tests/HangfireDashboardAuthorizationFilterTests.cs
+++ b/Predictorator.Tests/HangfireDashboardAuthorizationFilterTests.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+using Hangfire.Dashboard;
+using Hangfire;
+using Hangfire.Storage;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Predictorator.Authorization;
+
+namespace Predictorator.Tests;
+
+public class HangfireDashboardAuthorizationFilterTests
+{
+    private class FakeJobStorage : JobStorage
+    {
+        public override IStorageConnection GetConnection() => throw new NotImplementedException();
+        public override IMonitoringApi GetMonitoringApi() => throw new NotImplementedException();
+    }
+
+    private static AspNetCoreDashboardContext CreateContext(ClaimsPrincipal user)
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var http = new DefaultHttpContext { User = user, RequestServices = services };
+        return new AspNetCoreDashboardContext(new FakeJobStorage(), new DashboardOptions(), http);
+    }
+
+    [Fact]
+    public void Authorize_returns_false_for_anonymous_user()
+    {
+        var filter = new HangfireDashboardAuthorizationFilter();
+        var ctx = CreateContext(new ClaimsPrincipal(new ClaimsIdentity()));
+
+        var result = filter.Authorize(ctx);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Authorize_returns_false_for_non_admin_user()
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "user") }, "Test");
+        var filter = new HangfireDashboardAuthorizationFilter();
+        var ctx = CreateContext(new ClaimsPrincipal(identity));
+
+        var result = filter.Authorize(ctx);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Authorize_returns_true_for_admin_user()
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "admin"), new Claim(ClaimTypes.Role, "Admin") }, "Test");
+        var filter = new HangfireDashboardAuthorizationFilter();
+        var ctx = CreateContext(new ClaimsPrincipal(identity));
+
+        var result = filter.Authorize(ctx);
+
+        Assert.True(result);
+    }
+}

--- a/Predictorator.Tests/Predictorator.Tests.csproj
+++ b/Predictorator.Tests/Predictorator.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" />
     <PackageReference Include="AngleSharp" Version="1.3.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.20" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />

--- a/Predictorator/Authorization/HangfireDashboardAuthorizationFilter.cs
+++ b/Predictorator/Authorization/HangfireDashboardAuthorizationFilter.cs
@@ -1,0 +1,14 @@
+using Hangfire.Dashboard;
+using Microsoft.AspNetCore.Http;
+
+namespace Predictorator.Authorization;
+
+public class HangfireDashboardAuthorizationFilter : IDashboardAuthorizationFilter
+{
+    public bool Authorize(DashboardContext context)
+    {
+        var httpContext = context.GetHttpContext();
+        return httpContext.User.Identity?.IsAuthenticated == true &&
+               httpContext.User.IsInRole("Admin");
+    }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using MudBlazor.Services;
 using Predictorator.Components;
 using Hangfire;
+using Hangfire.Dashboard;
 using Predictorator.Data;
 using Predictorator.Options;
 using Predictorator.Services;
@@ -180,7 +181,10 @@ app.MapGet("/logout", async (SignInManager<IdentityUser> sm) =>
 if (!app.Environment.IsEnvironment("Testing"))
 {
     await ApplicationDbInitializer.SeedAdminUserAsync(app.Services);
-    app.UseHangfireDashboard();
+    app.UseHangfireDashboard("/hangfire", new DashboardOptions
+    {
+        Authorization = new[] { new Predictorator.Authorization.HangfireDashboardAuthorizationFilter() }
+    });
     RecurringJob.AddOrUpdate<NotificationService>(
         "fixture-notifications",
         s => s.CheckFixturesAsync(),

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ dotnet test Predictorator.sln
 
 The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
-`ADMIN_PASSWORD` environment variables before running the application.
+`ADMIN_PASSWORD` environment variables before running the application. Once
+logged in as an administrator you can view background jobs via the Hangfire
+dashboard at `/hangfire`.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 Set `BASE_URL` to the public address of the site so scheduled notifications


### PR DESCRIPTION
## Summary
- add Hangfire dashboard authorization filter
- restrict dashboard to admin role
- document dashboard URL
- test dashboard authorization logic

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687df78d8b1483288bf826db01c4f659