### PR TITLE
Add detailed SMS subscriber logging

### DIFF
--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -8,6 +8,7 @@ using Resend;
 using Predictorator.Tests.Helpers;
 using Predictorator.Models.Fixtures;
 using Hangfire;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
 using System.IO;
 using System;
@@ -41,8 +42,10 @@ public class AdminServiceTests
         var range = new DateRangeCalculator(provider);
         var features = new NotificationFeatureService(config);
         var jobs = Substitute.For<IBackgroundJobClient>();
-        var notifications = new NotificationService(db, resend, sms, config, fixtures, range, features, provider, jobs, inliner, renderer);
-        return new AdminService(db, resend, sms, config, inliner, renderer, notifications);
+        var nLogger = NullLogger<NotificationService>.Instance;
+        var notifications = new NotificationService(db, resend, sms, config, fixtures, range, features, provider, jobs, inliner, renderer, nLogger);
+        var aLogger = NullLogger<AdminService>.Instance;
+        return new AdminService(db, resend, sms, config, inliner, renderer, notifications, aLogger);
     }
 
     [Fact]

--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -8,6 +8,7 @@ using Predictorator.Services;
 using Predictorator.Tests.Helpers;
 using Resend;
 using Hangfire;
+using Microsoft.Extensions.Logging.Abstractions;
 using Hangfire.Common;
 using Hangfire.States;
 using System.Linq.Expressions;
@@ -62,7 +63,8 @@ public class NotificationServiceTests
         File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
-        return new NotificationService(db, resend, sms, config, fixtures, calculator, features, provider, jobs, inliner, renderer);
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<NotificationService>.Instance;
+        return new NotificationService(db, resend, sms, config, fixtures, calculator, features, provider, jobs, inliner, renderer, logger);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add ILogger usage to AdminService and NotificationService
- emit info logs in SubscriptionService when SMS rows are modified
- log SMS events in AdminService and NotificationService
- update tests for new logger parameters

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e07e89b6483288ccee8cdc4801ffb