### PR TITLE
Add verification confirmation

### DIFF
--- a/Predictorator.Tests/VerifyComponentBUnitTests.cs
+++ b/Predictorator.Tests/VerifyComponentBUnitTests.cs
@@ -1,0 +1,81 @@
+using Bunit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using MudBlazor;
+using Microsoft.AspNetCore.Components;
+using NSubstitute;
+using Predictorator.Components.Pages.Subscription;
+using Predictorator.Data;
+using Predictorator.Models;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+using Resend;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.IO;
+
+namespace Predictorator.Tests;
+
+public class VerifyComponentBUnitTests
+{
+    private BunitContext CreateContext()
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IHttpContextAccessor>(new HttpContextAccessor());
+        var storage = new FakeBrowserStorage();
+        ctx.Services.AddSingleton<IBrowserStorage>(storage);
+        ctx.Services.AddScoped<ToastInterop>();
+        ctx.Services.AddScoped<UiModeService>();
+        ctx.Services.AddSingleton(Substitute.For<IDialogService>());
+        ctx.AddBunitPersistentComponentState();
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        ctx.Services.AddSingleton<IConfiguration>(config);
+        ctx.Services.AddSingleton<NotificationFeatureService>();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var db = new ApplicationDbContext(options);
+        ctx.Services.AddSingleton(db);
+        var resend = Substitute.For<IResend>();
+        var sms = Substitute.For<ITwilioSmsSender>();
+        var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
+        var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
+        ctx.Services.AddSingleton<IDateTimeProvider>(time);
+        var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
+        Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
+        File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
+        var inliner = new EmailCssInliner(env);
+        var renderer = new EmailTemplateRenderer();
+        var logger = NullLogger<SubscriptionService>.Instance;
+        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer, logger));
+        return ctx;
+    }
+
+    [Fact]
+    public async Task Requires_confirmation_before_verifying()
+    {
+        await using var ctx = CreateContext();
+        var db = ctx.Services.GetRequiredService<ApplicationDbContext>();
+        db.Subscribers.Add(new Subscriber { Email = "a", IsVerified = false, VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync();
+
+        var navMan = ctx.Services.GetRequiredService<NavigationManager>();
+        var uri = navMan.GetUriWithQueryParameter("token", "v");
+        navMan.NavigateTo(uri);
+        var cut = ctx.Render<Verify>();
+
+        // Subscriber should not be verified before confirmation
+        Assert.False(db.Subscribers.Single().IsVerified);
+        Assert.Contains("verify", cut.Markup, StringComparison.OrdinalIgnoreCase);
+
+        cut.Find("button").Click();
+
+        cut.WaitForAssertion(() => Assert.True(db.Subscribers.Single().IsVerified));
+    }
+}

--- a/Predictorator/Components/Pages/Subscription/Verify.razor
+++ b/Predictorator/Components/Pages/Subscription/Verify.razor
@@ -1,11 +1,14 @@
 @page "/Subscription/Verify"
 @rendermode InteractiveServer
 @inject SubscriptionService SubscriptionService
+@inject PersistentComponentState State
+@implements IDisposable
 
 <h2>Verification</h2>
 @if (_result == null)
 {
-    <p>Loading...</p>
+    <p>Are you sure you want to verify your subscription?</p>
+    <button class="btn btn-primary" @onclick="HandleVerify">Verify</button>
 }
 else if (_result == true)
 {
@@ -21,9 +24,34 @@ else
     public string? token { get; set; }
 
     private bool? _result;
+    private PersistingComponentStateSubscription? _persistSubscription;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnParametersSet()
     {
-        _result = await SubscriptionService.VerifyAsync(token ?? "");
+        if (State.TryTakeFromJson<bool?>(nameof(_result), out var result))
+        {
+            _result = result;
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        _persistSubscription = State.RegisterOnPersisting(PersistState);
+    }
+
+    private async Task HandleVerify()
+    {
+        _result = await SubscriptionService.VerifyAsync(token ?? string.Empty);
+    }
+
+    private Task PersistState()
+    {
+        State.PersistAsJson(nameof(_result), _result);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _persistSubscription?.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- add a confirmation step when verifying subscriptions
- test verification component behavior

## Testing
- `dotnet format --no-restore`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e16a3a31c83288a1c0a5c8da4bc78