### PR TITLE
Improve style of verify & unsubscribe pages

### DIFF
--- a/Predictorator/Components/Pages/Subscription/Unsubscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Unsubscribe.razor
@@ -4,20 +4,24 @@
 @inject PersistentComponentState State
 @implements IDisposable
 
-<h2>Unsubscribe</h2>
-@if (_result == null)
-{
-    <p>Are you sure you want to unsubscribe?</p>
-    <button class="btn btn-primary" @onclick="HandleUnsubscribe">Unsubscribe</button>
-}
-else if (_result == true)
-{
-    <p>You have been unsubscribed.</p>
-}
-else
-{
-    <p>Invalid unsubscribe link.</p>
-}
+<MudPaper Class="pa-4" Elevation="1">
+    <MudStack Spacing="2">
+        <h2>Unsubscribe</h2>
+        @if (_result == null)
+        {
+            <p>Are you sure you want to unsubscribe?</p>
+            <MudButton OnClick="HandleUnsubscribe" Color="Color.Primary" Variant="Variant.Filled">Unsubscribe</MudButton>
+        }
+        else if (_result == true)
+        {
+            <p>You have been unsubscribed.</p>
+        }
+        else
+        {
+            <p>Invalid unsubscribe link.</p>
+        }
+    </MudStack>
+</MudPaper>
 
 @code {
     [Parameter, SupplyParameterFromQuery]

--- a/Predictorator/Components/Pages/Subscription/Verify.razor
+++ b/Predictorator/Components/Pages/Subscription/Verify.razor
@@ -4,20 +4,24 @@
 @inject PersistentComponentState State
 @implements IDisposable
 
-<h2>Verification</h2>
-@if (_result == null)
-{
-    <p>Are you sure you want to verify your subscription?</p>
-    <button class="btn btn-primary" @onclick="HandleVerify">Verify</button>
-}
-else if (_result == true)
-{
-    <p>Your subscription has been verified.</p>
-}
-else
-{
-    <p>Invalid verification link.</p>
-}
+<MudPaper Class="pa-4" Elevation="1">
+    <MudStack Spacing="2">
+        <h2>Verification</h2>
+        @if (_result == null)
+        {
+            <p>Are you sure you want to verify your subscription?</p>
+            <MudButton OnClick="HandleVerify" Color="Color.Primary" Variant="Variant.Filled">Verify</MudButton>
+        }
+        else if (_result == true)
+        {
+            <p>Your subscription has been verified.</p>
+        }
+        else
+        {
+            <p>Invalid verification link.</p>
+        }
+    </MudStack>
+</MudPaper>
 
 @code {
     [Parameter, SupplyParameterFromQuery]


### PR DESCRIPTION
## Summary
- add MudBlazor layout to verify & unsubscribe pages
- use `MudButton` so buttons use the primary theme color
- add padding and spacing via `MudPaper` and `MudStack`

## Testing
- `dotnet format --no-restore --verbosity diagnostic`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e1cc524008328aa511da1cebb1d4d