### PR TITLE
Ensure idempotent flyway migrations

### DIFF
--- a/flyway/sql/V1__InitialCreate.sql
+++ b/flyway/sql/V1__InitialCreate.sql
@@ -1,11 +1,11 @@
-CREATE TABLE "AspNetRoles" (
+CREATE TABLE IF NOT EXISTS "AspNetRoles" (
     "Id" TEXT NOT NULL CONSTRAINT "PK_AspNetRoles" PRIMARY KEY,
     "Name" TEXT NULL,
     "NormalizedName" TEXT NULL,
     "ConcurrencyStamp" TEXT NULL
 );
 
-CREATE TABLE "AspNetUsers" (
+CREATE TABLE IF NOT EXISTS "AspNetUsers" (
     "Id" TEXT NOT NULL CONSTRAINT "PK_AspNetUsers" PRIMARY KEY,
     "UserName" TEXT NULL,
     "NormalizedUserName" TEXT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE "AspNetUsers" (
     "AccessFailedCount" INTEGER NOT NULL
 );
 
-CREATE TABLE "AspNetRoleClaims" (
+CREATE TABLE IF NOT EXISTS "AspNetRoleClaims" (
     "Id" INTEGER NOT NULL CONSTRAINT "PK_AspNetRoleClaims" PRIMARY KEY AUTOINCREMENT,
     "RoleId" TEXT NOT NULL,
     "ClaimType" TEXT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE "AspNetRoleClaims" (
     CONSTRAINT "FK_AspNetRoleClaims_AspNetRoles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "AspNetRoles" ("Id") ON DELETE CASCADE
 );
 
-CREATE TABLE "AspNetUserClaims" (
+CREATE TABLE IF NOT EXISTS "AspNetUserClaims" (
     "Id" INTEGER NOT NULL CONSTRAINT "PK_AspNetUserClaims" PRIMARY KEY AUTOINCREMENT,
     "UserId" TEXT NOT NULL,
     "ClaimType" TEXT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE "AspNetUserClaims" (
     CONSTRAINT "FK_AspNetUserClaims_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
 );
 
-CREATE TABLE "AspNetUserLogins" (
+CREATE TABLE IF NOT EXISTS "AspNetUserLogins" (
     "LoginProvider" TEXT NOT NULL,
     "ProviderKey" TEXT NOT NULL,
     "ProviderDisplayName" TEXT NULL,
@@ -48,7 +48,7 @@ CREATE TABLE "AspNetUserLogins" (
     CONSTRAINT "FK_AspNetUserLogins_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
 );
 
-CREATE TABLE "AspNetUserRoles" (
+CREATE TABLE IF NOT EXISTS "AspNetUserRoles" (
     "UserId" TEXT NOT NULL,
     "RoleId" TEXT NOT NULL,
     CONSTRAINT "PK_AspNetUserRoles" PRIMARY KEY ("UserId", "RoleId"),
@@ -56,7 +56,7 @@ CREATE TABLE "AspNetUserRoles" (
     CONSTRAINT "FK_AspNetUserRoles_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
 );
 
-CREATE TABLE "AspNetUserTokens" (
+CREATE TABLE IF NOT EXISTS "AspNetUserTokens" (
     "UserId" TEXT NOT NULL,
     "LoginProvider" TEXT NOT NULL,
     "Name" TEXT NOT NULL,
@@ -65,17 +65,17 @@ CREATE TABLE "AspNetUserTokens" (
     CONSTRAINT "FK_AspNetUserTokens_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
 );
 
-CREATE INDEX "IX_AspNetRoleClaims_RoleId" ON "AspNetRoleClaims" ("RoleId");
+CREATE INDEX IF NOT EXISTS "IX_AspNetRoleClaims_RoleId" ON "AspNetRoleClaims" ("RoleId");
 
-CREATE UNIQUE INDEX "RoleNameIndex" ON "AspNetRoles" ("NormalizedName");
+CREATE UNIQUE INDEX IF NOT EXISTS "RoleNameIndex" ON "AspNetRoles" ("NormalizedName");
 
-CREATE INDEX "IX_AspNetUserClaims_UserId" ON "AspNetUserClaims" ("UserId");
+CREATE INDEX IF NOT EXISTS "IX_AspNetUserClaims_UserId" ON "AspNetUserClaims" ("UserId");
 
-CREATE INDEX "IX_AspNetUserLogins_UserId" ON "AspNetUserLogins" ("UserId");
+CREATE INDEX IF NOT EXISTS "IX_AspNetUserLogins_UserId" ON "AspNetUserLogins" ("UserId");
 
-CREATE INDEX "IX_AspNetUserRoles_RoleId" ON "AspNetUserRoles" ("RoleId");
+CREATE INDEX IF NOT EXISTS "IX_AspNetUserRoles_RoleId" ON "AspNetUserRoles" ("RoleId");
 
-CREATE INDEX "EmailIndex" ON "AspNetUsers" ("NormalizedEmail");
+CREATE INDEX IF NOT EXISTS "EmailIndex" ON "AspNetUsers" ("NormalizedEmail");
 
-CREATE UNIQUE INDEX "UserNameIndex" ON "AspNetUsers" ("NormalizedUserName");
+CREATE UNIQUE INDEX IF NOT EXISTS "UserNameIndex" ON "AspNetUsers" ("NormalizedUserName");
 


### PR DESCRIPTION
## Summary
- make initial Flyway script resilient to re-runs using `IF NOT EXISTS`
- keep build & tests green

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687e1d36994083288f38a74d7427bc30