### PR TITLE
Add scheduling option for 1 hour sample

### DIFF
--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -48,6 +48,11 @@ else
             <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendNewFixturesSampleAsync">New Fixtures Sample</MudButton>
             <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendStartingSoonSampleAsync">Starting Soon Sample</MudButton>
         </MudStack>
+        <MudStack Row="true" Spacing="2" Class="mt-2" AlignItems="AlignItems.Center">
+            <MudDatePicker @bind-Date="_scheduleDate" Label="Date" Class="mr-2" />
+            <MudTimePicker @bind-Time="_scheduleTime" Label="Time" Class="mr-2" />
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleStartingSoonSampleAsync">Schedule Starting Soon Sample</MudButton>
+        </MudStack>
     </EditForm>
 }
 
@@ -62,6 +67,8 @@ else
     }
 
     private List<Item>? _items;
+    private DateTime? _scheduleDate = DateTime.Today;
+    private TimeSpan? _scheduleTime = TimeSpan.FromHours(9);
 
     protected override async Task OnInitializedAsync()
     {
@@ -129,6 +136,30 @@ else
         catch
         {
             await Toast.ShowToast("Failed to send sample notifications.", "error");
+        }
+    }
+
+    private async Task ScheduleStartingSoonSampleAsync()
+    {
+        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
+        if (!selected.Any())
+            return;
+
+        if (_scheduleDate == null || _scheduleTime == null)
+            return;
+
+        var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var sendLocal = _scheduleDate.Value.Date + _scheduleTime.Value;
+        var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
+
+        try
+        {
+            await AdminService.ScheduleFixturesStartingSoonSampleAsync(selected, sendUtc);
+            await Toast.ShowToast("Sample notification scheduled!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to schedule sample notification.", "error");
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow AdminService to schedule the "starting soon" sample
- add date and time pickers to admin page for scheduling
- test that the job gets scheduled

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e1ebeeecc83288e3df91e7bc3cd79