### PR TITLE
Fix rate limiter with forwarded headers

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -13,6 +13,7 @@ using Predictorator.Endpoints;
 using Resend;
 using Serilog;
 using Serilog.Events;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
@@ -49,6 +50,12 @@ builder.Services.AddHttpClient("fixtures", client =>
 });
 
 builder.Services.AddHttpContextAccessor();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 builder.Services.AddTransient<IFixtureService, FixtureService>();
 builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
 var excludedIps = new HashSet<string>(
@@ -150,6 +157,7 @@ builder.Services.AddDataProtection()
 var app = builder.Build();
 
 
+app.UseForwardedHeaders();
 app.UseRateLimiter();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
## Summary
- trust forwarded headers so exclusions work behind proxies
- test forwarded header support

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e3313d7888328b0fe52492d25373b