### PR TITLE
Fix test notification scheduling and feedback

### DIFF
--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -143,10 +143,16 @@ else
     {
         var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
         if (!selected.Any())
+        {
+            await Toast.ShowToast("Please select at least one subscriber.", "error");
             return;
+        }
 
         if (_scheduleDate == null || _scheduleTime == null)
+        {
+            await Toast.ShowToast("Please choose a date and time.", "error");
             return;
+        }
 
         var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
         var sendLocal = _scheduleDate.Value.Date + _scheduleTime.Value;

--- a/Predictorator/Services/AdminService.cs
+++ b/Predictorator/Services/AdminService.cs
@@ -9,10 +9,15 @@ namespace Predictorator.Services;
 
 public class AdminSubscriberDto
 {
-    public int Id { get; init; }
-    public string Contact { get; init; } = string.Empty;
+    public int Id { get; set; }
+    public string Contact { get; set; } = string.Empty;
     public bool IsVerified { get; set; }
-    public string Type { get; init; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+
+    // Parameterless constructor required for Hangfire deserialization
+    public AdminSubscriberDto()
+    {
+    }
 
     public AdminSubscriberDto(int id, string contact, bool isVerified, string type)
     {


### PR DESCRIPTION
## Summary
- deserialize AdminSubscriberDto properly
- show immediate toast warnings when scheduling samples

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e332f16bc832887b74cfb20470d35