### PR TITLE
Fix scheduled sample timezone issue

### DIFF
--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -155,7 +155,7 @@ else
         }
 
         var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        var sendLocal = _scheduleDate.Value.Date + _scheduleTime.Value;
+        var sendLocal = DateTime.SpecifyKind(_scheduleDate.Value.Date + _scheduleTime.Value, DateTimeKind.Unspecified);
         var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
 
         try


### PR DESCRIPTION
## Summary
- prevent time zone conversion errors when scheduling sample notifications

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e3d2220e08328a0399ae5a49d42c0