### PR TITLE
Add season and gameweek admin support

### DIFF
--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Data;
+using Predictorator.Models;
+using Predictorator.Services;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Predictorator.Tests;
+
+public class GameWeekServiceTests
+{
+    private static GameWeekService CreateService(out ApplicationDbContext db)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        db = new ApplicationDbContext(options);
+        return new GameWeekService(db);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAsync_adds_new_week()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { SeasonId = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today.AddDays(6) };
+
+        await service.AddOrUpdateAsync(gw);
+
+        Assert.Equal(1, await db.GameWeeks.CountAsync());
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAsync_updates_existing()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { SeasonId = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today.AddDays(6) };
+        await service.AddOrUpdateAsync(gw);
+        gw.EndDate = gw.EndDate.AddDays(1);
+
+        await service.AddOrUpdateAsync(gw);
+
+        var stored = await db.GameWeeks.FirstAsync();
+        Assert.Equal(gw.EndDate, stored.EndDate);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_removes_week()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { SeasonId = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today };
+        await service.AddOrUpdateAsync(gw);
+
+        await service.DeleteAsync(gw);
+
+        Assert.Empty(db.GameWeeks);
+    }
+
+    [Fact]
+    public async Task GetGameWeekAsync_returns_week()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { SeasonId = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today };
+        await service.AddOrUpdateAsync(gw);
+
+        var result = await service.GetGameWeekAsync("25-26", 1);
+
+        Assert.NotNull(result);
+        Assert.Equal(gw.StartDate, result!.StartDate);
+    }
+}

--- a/Predictorator/Components/Pages/Admin/GameWeeks.razor
+++ b/Predictorator/Components/Pages/Admin/GameWeeks.razor
@@ -1,0 +1,129 @@
+@page "/admin/gameweeks"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles="Admin")]
+@inject GameWeekService GameWeekService
+@inject ToastInterop Toast
+@using Predictorator.Models
+
+<h2>Gameweeks</h2>
+@if (_loaded)
+{
+    <MudPaper Class="pa-2" Elevation="1">
+        <MudSelect T="string" Label="Season" Value="_seasonId" ValueChanged="OnSeasonChanged" Dense="true">
+            @foreach (var season in _seasons)
+            {
+                <MudSelectItem T="string" Value="@season.Id">@season.Id</MudSelectItem>
+            }
+        </MudSelect>
+        <MudTextField T="string" Label="New Season" @bind-Value="_newSeasonId" Immediate="true" />
+        <MudButton OnClick="AddSeason" Disabled="string.IsNullOrWhiteSpace(_newSeasonId)">Add Season</MudButton>
+    </MudPaper>
+    @if (_currentSeason != null)
+    {
+        <MudTable Items="_currentSeason.GameWeeks" Hover="true" Dense="true">
+            <HeaderContent>
+                <MudTh>#</MudTh>
+                <MudTh>Start</MudTh>
+                <MudTh>End</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate Context="gw">
+                <MudTd>@gw.Number</MudTd>
+                <MudTd>@gw.StartDate.ToString("dd MMM yyyy")</MudTd>
+                <MudTd>@gw.EndDate.ToString("dd MMM yyyy")</MudTd>
+                <MudTd>
+                    <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="() => Edit(gw)" />
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="() => Delete(gw)" />
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+    <EditForm Model="_editModel" OnValidSubmit="Save">
+        <MudTextField T="int" Label="Week" @bind-Value="_editModel.Number" Required="true" />
+        <MudDatePicker @bind-Date="_editStart" Required="true" />
+        <MudDatePicker @bind-Date="_editEnd" Required="true" />
+        <MudButton ButtonType="ButtonType.Submit">Save</MudButton>
+    </EditForm>
+}
+else
+{
+    <p>Loading...</p>
+}
+
+@code {
+    private List<Season> _seasons = new();
+    private string? _seasonId;
+    private string? _newSeasonId;
+    private Season? _currentSeason;
+    private GameWeek _editModel = new();
+    private DateTime? _editStart;
+    private DateTime? _editEnd;
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _seasons = await GameWeekService.GetSeasonsAsync();
+        _seasonId = _seasons.FirstOrDefault()?.Id;
+        await LoadSeason();
+        _loaded = true;
+    }
+
+    private async Task OnSeasonChanged(string? season)
+    {
+        _seasonId = season;
+        await LoadSeason();
+    }
+
+    private async Task LoadSeason()
+    {
+        if (!string.IsNullOrWhiteSpace(_seasonId))
+        {
+            _currentSeason = await GameWeekService.GetSeasonAsync(_seasonId);
+        }
+    }
+
+    private async Task AddSeason()
+    {
+        if (string.IsNullOrWhiteSpace(_newSeasonId)) return;
+        if (_seasons.Any(s => s.Id == _newSeasonId)) return;
+        var season = new Season { Id = _newSeasonId };
+        _seasons.Add(season);
+        _seasonId = _newSeasonId;
+        _newSeasonId = string.Empty;
+        _currentSeason = season;
+        await GameWeekService.AddOrUpdateAsync(new GameWeek { SeasonId = season.Id, Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today });
+        _currentSeason = await GameWeekService.GetSeasonAsync(season.Id);
+    }
+
+    private void Edit(GameWeek gw)
+    {
+        _editModel = new GameWeek
+        {
+            SeasonId = gw.SeasonId,
+            Number = gw.Number,
+            StartDate = gw.StartDate,
+            EndDate = gw.EndDate
+        };
+        _editStart = gw.StartDate;
+        _editEnd = gw.EndDate;
+    }
+
+    private async Task Save()
+    {
+        _editModel.SeasonId = _seasonId!;
+        _editModel.StartDate = _editStart ?? DateTime.Today;
+        _editModel.EndDate = _editEnd ?? _editModel.StartDate;
+        await GameWeekService.AddOrUpdateAsync(_editModel);
+        _currentSeason = await GameWeekService.GetSeasonAsync(_seasonId!);
+        _editModel = new GameWeek();
+        _editStart = null;
+        _editEnd = null;
+    }
+
+    private async Task Delete(GameWeek gw)
+    {
+        await GameWeekService.DeleteAsync(gw);
+        _currentSeason = await GameWeekService.GetSeasonAsync(_seasonId!);
+    }
+}

--- a/Predictorator/Components/Pages/Gameweek/View.razor
+++ b/Predictorator/Components/Pages/Gameweek/View.razor
@@ -1,0 +1,26 @@
+@page "/{season}/gw{week:int}"
+@rendermode InteractiveServer
+@inject GameWeekService GameWeekService
+@using Predictorator.Models
+
+<h2>Gameweek @week (@season)</h2>
+@if (_gameWeek == null)
+{
+    <p>Not found.</p>
+}
+else
+{
+    <p>@_gameWeek.StartDate.ToString("dd MMM yyyy") - @_gameWeek.EndDate.ToString("dd MMM yyyy")</p>
+}
+
+@code {
+    [Parameter] public string season { get; set; } = string.Empty;
+    [Parameter] public int week { get; set; }
+
+    private GameWeek? _gameWeek;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        _gameWeek = await GameWeekService.GetGameWeekAsync(season, week);
+    }
+}

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -15,4 +15,6 @@ public class ApplicationDbContext : IdentityDbContext<IdentityUser>
     public DbSet<Subscriber> Subscribers => Set<Subscriber>();
     public DbSet<SmsSubscriber> SmsSubscribers => Set<SmsSubscriber>();
     public DbSet<SentNotification> SentNotifications => Set<SentNotification>();
+    public DbSet<Season> Seasons => Set<Season>();
+    public DbSet<GameWeek> GameWeeks => Set<GameWeek>();
 }

--- a/Predictorator/Models/GameWeek.cs
+++ b/Predictorator/Models/GameWeek.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Predictorator.Models;
+
+public class GameWeek
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(10)]
+    public string SeasonId { get; set; } = string.Empty;
+    public Season? Season { get; set; }
+
+    public int Number { get; set; }
+
+    [Column(TypeName = "date")]
+    public DateTime StartDate { get; set; }
+
+    [Column(TypeName = "date")]
+    public DateTime EndDate { get; set; }
+}

--- a/Predictorator/Models/Season.cs
+++ b/Predictorator/Models/Season.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Predictorator.Models;
+
+public class Season
+{
+    [Key]
+    [MaxLength(10)]
+    public string Id { get; set; } = string.Empty; // e.g., "25-26"
+
+    public ICollection<GameWeek> GameWeeks { get; set; } = new List<GameWeek>();
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -102,6 +102,7 @@ builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();
 builder.Services.AddTransient<AdminService>();
+builder.Services.AddTransient<GameWeekService>();
 builder.Services.AddSingleton<EmailCssInliner>();
 builder.Services.AddSingleton<EmailTemplateRenderer>();
 builder.Services.AddSingleton<NotificationFeatureService>();

--- a/Predictorator/Services/GameWeekService.cs
+++ b/Predictorator/Services/GameWeekService.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Data;
+using Predictorator.Models;
+
+namespace Predictorator.Services;
+
+public class GameWeekService
+{
+    private readonly ApplicationDbContext _db;
+
+    public GameWeekService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<List<Season>> GetSeasonsAsync()
+    {
+        return await _db.Seasons
+            .Include(s => s.GameWeeks.OrderBy(g => g.Number))
+            .OrderBy(s => s.Id)
+            .ToListAsync();
+    }
+
+    public async Task<Season?> GetSeasonAsync(string id)
+    {
+        return await _db.Seasons
+            .Include(s => s.GameWeeks.OrderBy(g => g.Number))
+            .FirstOrDefaultAsync(s => s.Id == id);
+    }
+
+    public async Task<GameWeek?> GetGameWeekAsync(string seasonId, int number)
+    {
+        return await _db.GameWeeks
+            .FirstOrDefaultAsync(g => g.SeasonId == seasonId && g.Number == number);
+    }
+
+    public async Task AddOrUpdateAsync(GameWeek gameWeek)
+    {
+        var existing = await _db.GameWeeks
+            .FirstOrDefaultAsync(g => g.SeasonId == gameWeek.SeasonId && g.Number == gameWeek.Number);
+        if (existing == null)
+        {
+            _db.GameWeeks.Add(gameWeek);
+        }
+        else
+        {
+            existing.StartDate = gameWeek.StartDate;
+            existing.EndDate = gameWeek.EndDate;
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(GameWeek gameWeek)
+    {
+        _db.GameWeeks.Remove(gameWeek);
+        await _db.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- allow seasons and gameweeks to be stored
- provide CRUD APIs via `GameWeekService`
- expose admin UI at `/admin/gameweeks`
- show basic gameweek info at `/{season}/gw{week}`
- test `GameWeekService`

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e5613bb008328a9f01b7a480a227c