### PR TITLE
Add gameweek configuration

### DIFF
--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -32,6 +32,7 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         var provider = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
 
@@ -175,6 +176,7 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddScoped<UiModeService>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
 
         var settings = new Dictionary<string, string?>
@@ -213,6 +215,7 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddScoped<UiModeService>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
 
         var settings = new Dictionary<string, string?>
@@ -266,6 +269,7 @@ public class CeefaxModeBUnitTests
             }
         };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         var provider = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
 

--- a/Predictorator.Tests/DarkModeBUnitTests.cs
+++ b/Predictorator.Tests/DarkModeBUnitTests.cs
@@ -28,6 +28,7 @@ public class DarkModeBUnitTests
         ctx.Services.AddScoped<UiModeService>();
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         var provider = new FakeDateTimeProvider
         {
             Today = new DateTime(2024, 1, 1),
@@ -90,6 +91,7 @@ public class DarkModeBUnitTests
         ctx.Services.AddScoped<UiModeService>();
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
 
         var settings = new Dictionary<string, string?>

--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Data;
+using Predictorator.Models;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class GameWeekServiceTests
+{
+    private static GameWeekService CreateService(out ApplicationDbContext db)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        db = new ApplicationDbContext(options);
+        return new GameWeekService(db);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAsync_adds_new_gameweek()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { Season = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today.AddDays(6) };
+
+        await service.AddOrUpdateAsync(gw);
+
+        Assert.Single(db.GameWeeks);
+    }
+
+    [Fact]
+    public async Task AddOrUpdateAsync_updates_existing()
+    {
+        var service = CreateService(out var db);
+        db.GameWeeks.Add(new GameWeek { Season = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today.AddDays(6) });
+        await db.SaveChangesAsync();
+
+        var gw = new GameWeek { Season = "25-26", Number = 1, StartDate = DateTime.Today.AddDays(7), EndDate = DateTime.Today.AddDays(13) };
+        await service.AddOrUpdateAsync(gw);
+
+        var updated = await db.GameWeeks.FirstAsync();
+        Assert.Equal(gw.StartDate, updated.StartDate);
+        Assert.Equal(gw.EndDate, updated.EndDate);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_removes_item()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { Season = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today };
+        db.GameWeeks.Add(gw);
+        await db.SaveChangesAsync();
+
+        await service.DeleteAsync(gw.Id);
+
+        Assert.Empty(db.GameWeeks);
+    }
+}

--- a/Predictorator.Tests/Helpers/FakeGameWeekService.cs
+++ b/Predictorator.Tests/Helpers/FakeGameWeekService.cs
@@ -1,0 +1,41 @@
+using Predictorator.Models;
+using Predictorator.Services;
+
+namespace Predictorator.Tests.Helpers;
+
+public class FakeGameWeekService : IGameWeekService
+{
+    public List<GameWeek> Items { get; set; } = new();
+
+    public Task AddOrUpdateAsync(GameWeek gameWeek)
+    {
+        var existing = Items.FirstOrDefault(g => g.Season == gameWeek.Season && g.Number == gameWeek.Number);
+        if (existing == null)
+            Items.Add(gameWeek);
+        else
+        {
+            existing.StartDate = gameWeek.StartDate;
+            existing.EndDate = gameWeek.EndDate;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(int id)
+    {
+        Items.RemoveAll(g => g.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task<GameWeek?> GetGameWeekAsync(string season, int number)
+    {
+        return Task.FromResult<GameWeek?>(Items.FirstOrDefault(g => g.Season == season && g.Number == number));
+    }
+
+    public Task<List<GameWeek>> GetGameWeeksAsync(string? season = null)
+    {
+        var query = Items.AsEnumerable();
+        if (!string.IsNullOrEmpty(season))
+            query = query.Where(g => g.Season == season);
+        return Task.FromResult(query.ToList());
+    }
+}

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -26,6 +26,7 @@ public class IndexPageBUnitTests
         ctx.Services.AddScoped<UiModeService>();
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         var provider = new FakeDateTimeProvider
         {
             Today = new DateTime(2024, 1, 1),
@@ -157,6 +158,7 @@ public class IndexPageBUnitTests
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
         var fixtureService = new AutoWeekFixtureService();
         ctx.Services.AddSingleton<IFixtureService>(fixtureService);
+        ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
 
         var settings = new Dictionary<string, string?>
         {

--- a/Predictorator/Components/Pages/Admin/GameWeeks.razor
+++ b/Predictorator/Components/Pages/Admin/GameWeeks.razor
@@ -1,0 +1,117 @@
+@page "/admin/gameweeks"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles="Admin")]
+@inject IGameWeekService Service
+@inject ToastInterop Toast
+
+<h2>Game Weeks</h2>
+
+<MudPaper Class="pa-2" Elevation="1">
+    <EditForm Model="_model" OnValidSubmit="SaveAsync">
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudTextField @bind-Value="_model.Season" Label="Season" Required="true" />
+            <MudNumericField T="int" @bind-Value="_model.Number" Label="Week" Required="true" />
+            <MudDatePicker @bind-Date="_start" Label="Start" Required="true" />
+            <MudDatePicker @bind-Date="_end" Label="End" Required="true" />
+            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary">Save</MudButton>
+            @if (_editingId != null)
+            {
+                <MudButton Color="Color.Default" OnClick="CancelEdit">Cancel</MudButton>
+            }
+        </MudStack>
+    </EditForm>
+</MudPaper>
+
+@if (_items == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <MudTable Items="_items" Hover="true" Breakpoint="Breakpoint.None">
+        <HeaderContent>
+            <MudTh>Season</MudTh>
+            <MudTh>Week</MudTh>
+            <MudTh>Start</MudTh>
+            <MudTh>End</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate Context="row">
+            <MudTd>@row.Season</MudTd>
+            <MudTd>@row.Number</MudTd>
+            <MudTd>@row.StartDate.ToString("yyyy-MM-dd")</MudTd>
+            <MudTd>@row.EndDate.ToString("yyyy-MM-dd")</MudTd>
+            <MudTd>
+                <MudButton Size="Size.Small" OnClick="() => Edit(row)">Edit</MudButton>
+                <MudButton Size="Size.Small" Color="Color.Error" OnClick="() => DeleteAsync(row.Id)">Delete</MudButton>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    private List<GameWeek>? _items;
+    private GameWeek _model = new();
+    private DateTime? _start;
+    private DateTime? _end;
+    private int? _editingId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _items = await Service.GetGameWeeksAsync();
+        StateHasChanged();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (_start == null || _end == null)
+        {
+            await Toast.ShowToast("Please choose start and end dates", "error");
+            return;
+        }
+        if (_start > _end)
+        {
+            await Toast.ShowToast("Start must be before end", "error");
+            return;
+        }
+        _model.StartDate = _start.Value.Date;
+        _model.EndDate = _end.Value.Date;
+        await Service.AddOrUpdateAsync(_model);
+        _model = new GameWeek();
+        _start = _end = null;
+        _editingId = null;
+        await LoadAsync();
+    }
+
+    private void Edit(GameWeek item)
+    {
+        _model = new GameWeek
+        {
+            Id = item.Id,
+            Season = item.Season,
+            Number = item.Number,
+        };
+        _start = item.StartDate;
+        _end = item.EndDate;
+        _editingId = item.Id;
+    }
+
+    private void CancelEdit()
+    {
+        _model = new GameWeek();
+        _start = _end = null;
+        _editingId = null;
+    }
+
+    private async Task DeleteAsync(int id)
+    {
+        await Service.DeleteAsync(id);
+        await LoadAsync();
+    }
+}

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -1,8 +1,10 @@
 @page "/"
+@page "/{Season}/gw{Week:int}"
 @rendermode InteractiveServer
 @inject NavigationManager NavigationManager
 @inject IFixtureService FixtureService
 @inject IDateRangeCalculator DateRangeCalculator
+@inject IGameWeekService GameWeekService
 @inject UiModeService UiModeService
 @using Predictorator.Components.Layout
 
@@ -97,6 +99,9 @@ else if (_fixtures.Response.Any())
 
     [CascadingParameter] public MainLayout? Layout { get; set; }
 
+    [Parameter] public string? Season { get; set; }
+    [Parameter] public int? Week { get; set; }
+
     [Parameter, SupplyParameterFromQuery(Name = "fromDate")] public DateTime? FromDate { get; set; }
     [Parameter, SupplyParameterFromQuery(Name = "toDate")] public DateTime? ToDate { get; set; }
     [Parameter, SupplyParameterFromQuery(Name = "weekOffset")] public int? WeekOffset { get; set; }
@@ -107,6 +112,16 @@ else if (_fixtures.Response.Any())
         if (!query.ContainsKey("fromDate")) FromDate = null;
         if (!query.ContainsKey("toDate")) ToDate = null;
         if (!query.ContainsKey("weekOffset")) WeekOffset = null;
+
+        if (!string.IsNullOrEmpty(Season) && Week.HasValue)
+        {
+            var gw = await GameWeekService.GetGameWeekAsync(Season, Week.Value);
+            if (gw != null)
+            {
+                FromDate = gw.StartDate;
+                ToDate = gw.EndDate;
+            }
+        }
 
         var (from, to) = DateRangeCalculator.GetDates(FromDate, ToDate, WeekOffset);
         _fromDate = from;

--- a/Predictorator/Components/_Imports.razor
+++ b/Predictorator/Components/_Imports.razor
@@ -15,3 +15,4 @@
 @using MudBlazor
 @using Predictorator.Services
 @using System.ComponentModel.DataAnnotations
+@using Predictorator.Models

--- a/Predictorator/Data/ApplicationDbContext.cs
+++ b/Predictorator/Data/ApplicationDbContext.cs
@@ -15,4 +15,5 @@ public class ApplicationDbContext : IdentityDbContext<IdentityUser>
     public DbSet<Subscriber> Subscribers => Set<Subscriber>();
     public DbSet<SmsSubscriber> SmsSubscribers => Set<SmsSubscriber>();
     public DbSet<SentNotification> SentNotifications => Set<SentNotification>();
+    public DbSet<GameWeek> GameWeeks => Set<GameWeek>();
 }

--- a/Predictorator/Models/GameWeek.cs
+++ b/Predictorator/Models/GameWeek.cs
@@ -1,0 +1,10 @@
+namespace Predictorator.Models;
+
+public class GameWeek
+{
+    public int Id { get; set; }
+    public string Season { get; set; } = string.Empty; // e.g. "25-26"
+    public int Number { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -102,6 +102,7 @@ builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();
 builder.Services.AddTransient<AdminService>();
+builder.Services.AddTransient<IGameWeekService, GameWeekService>();
 builder.Services.AddSingleton<EmailCssInliner>();
 builder.Services.AddSingleton<EmailTemplateRenderer>();
 builder.Services.AddSingleton<NotificationFeatureService>();

--- a/Predictorator/Services/GameWeekService.cs
+++ b/Predictorator/Services/GameWeekService.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Data;
+using Predictorator.Models;
+
+namespace Predictorator.Services;
+
+public class GameWeekService : IGameWeekService
+{
+    private readonly ApplicationDbContext _db;
+
+    public GameWeekService(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<List<GameWeek>> GetGameWeeksAsync(string? season = null)
+    {
+        var query = _db.GameWeeks.AsQueryable();
+        if (!string.IsNullOrEmpty(season))
+            query = query.Where(g => g.Season == season);
+        return query.OrderBy(g => g.Season).ThenBy(g => g.Number).ToListAsync();
+    }
+
+    public Task<GameWeek?> GetGameWeekAsync(string season, int number)
+    {
+        return _db.GameWeeks
+            .FirstOrDefaultAsync(g => g.Season == season && g.Number == number);
+    }
+
+    public async Task AddOrUpdateAsync(GameWeek gameWeek)
+    {
+        var existing = await _db.GameWeeks
+            .FirstOrDefaultAsync(g => g.Season == gameWeek.Season && g.Number == gameWeek.Number);
+        if (existing == null)
+        {
+            _db.GameWeeks.Add(gameWeek);
+        }
+        else
+        {
+            existing.StartDate = gameWeek.StartDate;
+            existing.EndDate = gameWeek.EndDate;
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _db.GameWeeks.FindAsync(id);
+        if (entity != null)
+        {
+            _db.GameWeeks.Remove(entity);
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/Predictorator/Services/IGameWeekService.cs
+++ b/Predictorator/Services/IGameWeekService.cs
@@ -1,0 +1,11 @@
+using Predictorator.Models;
+
+namespace Predictorator.Services;
+
+public interface IGameWeekService
+{
+    Task<List<GameWeek>> GetGameWeeksAsync(string? season = null);
+    Task<GameWeek?> GetGameWeekAsync(string season, int number);
+    Task AddOrUpdateAsync(GameWeek gameWeek);
+    Task DeleteAsync(int id);
+}

--- a/flyway/sql/V4__AddGameWeeks.sql
+++ b/flyway/sql/V4__AddGameWeeks.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "GameWeeks" (
+    "Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "Season" TEXT NOT NULL,
+    "Number" INTEGER NOT NULL,
+    "StartDate" TEXT NOT NULL,
+    "EndDate" TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_GameWeeks_Season_Number" ON "GameWeeks" ("Season", "Number");


### PR DESCRIPTION
## Summary
- add GameWeek model and service with CRUD operations
- expose GameWeek management in the admin area
- allow seasons to specify gameweek routes
- support retrieval of gameweek dates via route
- register service in DI and add database migration
- adjust tests for new service

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e5613bb008328a9f01b7a480a227c