### PR TITLE
Adjust alert timings

### DIFF
--- a/Predictorator/Services/AdminService.cs
+++ b/Predictorator/Services/AdminService.cs
@@ -142,13 +142,13 @@ public class AdminService
     public async Task SendNewFixturesSampleAsync(IEnumerable<AdminSubscriberDto> recipients)
     {
         var baseUrl = _config["BASE_URL"] ?? "http://localhost";
-        await _notifications.SendSampleAsync(recipients, "New fixtures are available!", baseUrl);
+        await _notifications.SendSampleAsync(recipients, "Fixtures start today!", baseUrl);
     }
 
     public async Task SendFixturesStartingSoonSampleAsync(IEnumerable<AdminSubscriberDto> recipients)
     {
         var baseUrl = _config["BASE_URL"] ?? "http://localhost";
-        await _notifications.SendSampleAsync(recipients, "Fixtures start in 1 hour!", baseUrl);
+        await _notifications.SendSampleAsync(recipients, "Fixtures start in 2 hours!", baseUrl);
     }
 
     public Task ScheduleFixturesStartingSoonSampleAsync(IEnumerable<AdminSubscriberDto> recipients, DateTime sendUtc)
@@ -156,7 +156,7 @@ public class AdminService
         var baseUrl = _config["BASE_URL"] ?? "http://localhost";
         var delay = sendUtc - _time.UtcNow;
         if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
-        _jobs.Schedule<NotificationService>(s => s.SendSampleAsync(recipients, "Fixtures start in 1 hour!", baseUrl), delay);
+        _jobs.Schedule<NotificationService>(s => s.SendSampleAsync(recipients, "Fixtures start in 2 hours!", baseUrl), delay);
         return Task.CompletedTask;
     }
 }

--- a/Predictorator/Services/NotificationService.cs
+++ b/Predictorator/Services/NotificationService.cs
@@ -78,7 +78,8 @@ public class NotificationService
                 .AnyAsync(n => n.Type == "NewFixtures" && n.Key == key);
             if (!sent)
             {
-                var sendTimeUk = nowUk.Date.AddHours(10);
+                var futureUk = TimeZoneInfo.ConvertTime(future.Fixture.Date, ukTz);
+                var sendTimeUk = futureUk.Date.AddHours(10);
                 var sendTimeUtc = TimeZoneInfo.ConvertTimeToUtc(sendTimeUk, ukTz);
                 var delay = sendTimeUtc - nowUtc;
                 if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
@@ -97,7 +98,7 @@ public class NotificationService
                 .AnyAsync(n => n.Type == "FixturesStartingSoon" && n.Key == key);
             if (!sent)
             {
-                var sendTimeUtc = first.Fixture.Date.AddHours(-1);
+                var sendTimeUtc = first.Fixture.Date.AddHours(-2);
                 var delay = sendTimeUtc - nowUtc;
                 if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
                 _jobs.Schedule<NotificationService>(
@@ -110,13 +111,13 @@ public class NotificationService
     [AutomaticRetry(Attempts = 3)]
     public async Task SendNewFixturesAvailableAsync(string key, string baseUrl)
     {
-        await SendToAllAsync("New fixtures are available!", baseUrl, "NewFixtures", key);
+        await SendToAllAsync("Fixtures start today!", baseUrl, "NewFixtures", key);
     }
 
     [AutomaticRetry(Attempts = 3)]
     public async Task SendFixturesStartingSoonAsync(string key, string baseUrl)
     {
-        await SendToAllAsync("Fixtures start in 1 hour!", baseUrl, "FixturesStartingSoon", key);
+        await SendToAllAsync("Fixtures start in 2 hours!", baseUrl, "FixturesStartingSoon", key);
     }
 
     private EmailMessage CreateEmailMessage(string message, string baseUrl, Subscriber sub)


### PR DESCRIPTION
## Summary
- warn subscribers two hours before kickoff instead of one
- send the 'new fixtures' alert on the morning of the first fixture
- update fixtures alert text

## Testing
- `/root/.dotnet/dotnet build Predictorator.sln -warnaserror`
- `/root/.dotnet/dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e57457ed48328b715943c85494d7d