### PR TITLE
Update Flyway migrations for SQL Server

### DIFF
--- a/flyway/sql/V1__InitialCreate.sql
+++ b/flyway/sql/V1__InitialCreate.sql
@@ -1,81 +1,78 @@
-CREATE TABLE IF NOT EXISTS "AspNetRoles" (
-    "Id" TEXT NOT NULL CONSTRAINT "PK_AspNetRoles" PRIMARY KEY,
-    "Name" TEXT NULL,
-    "NormalizedName" TEXT NULL,
-    "ConcurrencyStamp" TEXT NULL
+CREATE TABLE [AspNetRoles] (
+    [Id] nvarchar(450) NOT NULL,
+    [Name] nvarchar(256) NULL,
+    [NormalizedName] nvarchar(256) NULL,
+    [ConcurrencyStamp] nvarchar(max) NULL,
+    CONSTRAINT [PK_AspNetRoles] PRIMARY KEY ([Id])
 );
 
-CREATE TABLE IF NOT EXISTS "AspNetUsers" (
-    "Id" TEXT NOT NULL CONSTRAINT "PK_AspNetUsers" PRIMARY KEY,
-    "UserName" TEXT NULL,
-    "NormalizedUserName" TEXT NULL,
-    "Email" TEXT NULL,
-    "NormalizedEmail" TEXT NULL,
-    "EmailConfirmed" INTEGER NOT NULL,
-    "PasswordHash" TEXT NULL,
-    "SecurityStamp" TEXT NULL,
-    "ConcurrencyStamp" TEXT NULL,
-    "PhoneNumber" TEXT NULL,
-    "PhoneNumberConfirmed" INTEGER NOT NULL,
-    "TwoFactorEnabled" INTEGER NOT NULL,
-    "LockoutEnd" TEXT NULL,
-    "LockoutEnabled" INTEGER NOT NULL,
-    "AccessFailedCount" INTEGER NOT NULL
+CREATE TABLE [AspNetUsers] (
+    [Id] nvarchar(450) NOT NULL,
+    [UserName] nvarchar(256) NULL,
+    [NormalizedUserName] nvarchar(256) NULL,
+    [Email] nvarchar(256) NULL,
+    [NormalizedEmail] nvarchar(256) NULL,
+    [EmailConfirmed] bit NOT NULL,
+    [PasswordHash] nvarchar(max) NULL,
+    [SecurityStamp] nvarchar(max) NULL,
+    [ConcurrencyStamp] nvarchar(max) NULL,
+    [PhoneNumber] nvarchar(max) NULL,
+    [PhoneNumberConfirmed] bit NOT NULL,
+    [TwoFactorEnabled] bit NOT NULL,
+    [LockoutEnd] datetimeoffset NULL,
+    [LockoutEnabled] bit NOT NULL,
+    [AccessFailedCount] int NOT NULL,
+    CONSTRAINT [PK_AspNetUsers] PRIMARY KEY ([Id])
 );
 
-CREATE TABLE IF NOT EXISTS "AspNetRoleClaims" (
-    "Id" INTEGER NOT NULL CONSTRAINT "PK_AspNetRoleClaims" PRIMARY KEY AUTOINCREMENT,
-    "RoleId" TEXT NOT NULL,
-    "ClaimType" TEXT NULL,
-    "ClaimValue" TEXT NULL,
-    CONSTRAINT "FK_AspNetRoleClaims_AspNetRoles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "AspNetRoles" ("Id") ON DELETE CASCADE
+CREATE TABLE [AspNetRoleClaims] (
+    [Id] int NOT NULL IDENTITY,
+    [RoleId] nvarchar(450) NOT NULL,
+    [ClaimType] nvarchar(max) NULL,
+    [ClaimValue] nvarchar(max) NULL,
+    CONSTRAINT [PK_AspNetRoleClaims] PRIMARY KEY ([Id]),
+    CONSTRAINT [FK_AspNetRoleClaims_AspNetRoles_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [AspNetRoles] ([Id]) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS "AspNetUserClaims" (
-    "Id" INTEGER NOT NULL CONSTRAINT "PK_AspNetUserClaims" PRIMARY KEY AUTOINCREMENT,
-    "UserId" TEXT NOT NULL,
-    "ClaimType" TEXT NULL,
-    "ClaimValue" TEXT NULL,
-    CONSTRAINT "FK_AspNetUserClaims_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
+CREATE TABLE [AspNetUserClaims] (
+    [Id] int NOT NULL IDENTITY,
+    [UserId] nvarchar(450) NOT NULL,
+    [ClaimType] nvarchar(max) NULL,
+    [ClaimValue] nvarchar(max) NULL,
+    CONSTRAINT [PK_AspNetUserClaims] PRIMARY KEY ([Id]),
+    CONSTRAINT [FK_AspNetUserClaims_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS "AspNetUserLogins" (
-    "LoginProvider" TEXT NOT NULL,
-    "ProviderKey" TEXT NOT NULL,
-    "ProviderDisplayName" TEXT NULL,
-    "UserId" TEXT NOT NULL,
-    CONSTRAINT "PK_AspNetUserLogins" PRIMARY KEY ("LoginProvider", "ProviderKey"),
-    CONSTRAINT "FK_AspNetUserLogins_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
+CREATE TABLE [AspNetUserLogins] (
+    [LoginProvider] nvarchar(128) NOT NULL,
+    [ProviderKey] nvarchar(128) NOT NULL,
+    [ProviderDisplayName] nvarchar(max) NULL,
+    [UserId] nvarchar(450) NOT NULL,
+    CONSTRAINT [PK_AspNetUserLogins] PRIMARY KEY ([LoginProvider], [ProviderKey]),
+    CONSTRAINT [FK_AspNetUserLogins_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS "AspNetUserRoles" (
-    "UserId" TEXT NOT NULL,
-    "RoleId" TEXT NOT NULL,
-    CONSTRAINT "PK_AspNetUserRoles" PRIMARY KEY ("UserId", "RoleId"),
-    CONSTRAINT "FK_AspNetUserRoles_AspNetRoles_RoleId" FOREIGN KEY ("RoleId") REFERENCES "AspNetRoles" ("Id") ON DELETE CASCADE,
-    CONSTRAINT "FK_AspNetUserRoles_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
+CREATE TABLE [AspNetUserRoles] (
+    [UserId] nvarchar(450) NOT NULL,
+    [RoleId] nvarchar(450) NOT NULL,
+    CONSTRAINT [PK_AspNetUserRoles] PRIMARY KEY ([UserId], [RoleId]),
+    CONSTRAINT [FK_AspNetUserRoles_AspNetRoles_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [AspNetRoles] ([Id]) ON DELETE CASCADE,
+    CONSTRAINT [FK_AspNetUserRoles_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS "AspNetUserTokens" (
-    "UserId" TEXT NOT NULL,
-    "LoginProvider" TEXT NOT NULL,
-    "Name" TEXT NOT NULL,
-    "Value" TEXT NULL,
-    CONSTRAINT "PK_AspNetUserTokens" PRIMARY KEY ("UserId", "LoginProvider", "Name"),
-    CONSTRAINT "FK_AspNetUserTokens_AspNetUsers_UserId" FOREIGN KEY ("UserId") REFERENCES "AspNetUsers" ("Id") ON DELETE CASCADE
+CREATE TABLE [AspNetUserTokens] (
+    [UserId] nvarchar(450) NOT NULL,
+    [LoginProvider] nvarchar(128) NOT NULL,
+    [Name] nvarchar(128) NOT NULL,
+    [Value] nvarchar(max) NULL,
+    CONSTRAINT [PK_AspNetUserTokens] PRIMARY KEY ([UserId], [LoginProvider], [Name]),
+    CONSTRAINT [FK_AspNetUserTokens_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
 );
 
-CREATE INDEX IF NOT EXISTS "IX_AspNetRoleClaims_RoleId" ON "AspNetRoleClaims" ("RoleId");
-
-CREATE UNIQUE INDEX IF NOT EXISTS "RoleNameIndex" ON "AspNetRoles" ("NormalizedName");
-
-CREATE INDEX IF NOT EXISTS "IX_AspNetUserClaims_UserId" ON "AspNetUserClaims" ("UserId");
-
-CREATE INDEX IF NOT EXISTS "IX_AspNetUserLogins_UserId" ON "AspNetUserLogins" ("UserId");
-
-CREATE INDEX IF NOT EXISTS "IX_AspNetUserRoles_RoleId" ON "AspNetUserRoles" ("RoleId");
-
-CREATE INDEX IF NOT EXISTS "EmailIndex" ON "AspNetUsers" ("NormalizedEmail");
-
-CREATE UNIQUE INDEX IF NOT EXISTS "UserNameIndex" ON "AspNetUsers" ("NormalizedUserName");
-
+CREATE INDEX [IX_AspNetRoleClaims_RoleId] ON [AspNetRoleClaims] ([RoleId]);
+CREATE UNIQUE INDEX [RoleNameIndex] ON [AspNetRoles] ([NormalizedName]) WHERE [NormalizedName] IS NOT NULL;
+CREATE INDEX [IX_AspNetUserClaims_UserId] ON [AspNetUserClaims] ([UserId]);
+CREATE INDEX [IX_AspNetUserLogins_UserId] ON [AspNetUserLogins] ([UserId]);
+CREATE INDEX [IX_AspNetUserRoles_RoleId] ON [AspNetUserRoles] ([RoleId]);
+CREATE INDEX [EmailIndex] ON [AspNetUsers] ([NormalizedEmail]);
+CREATE UNIQUE INDEX [UserNameIndex] ON [AspNetUsers] ([NormalizedUserName]) WHERE [NormalizedUserName] IS NOT NULL;

--- a/flyway/sql/V2__AddSubscribers.sql
+++ b/flyway/sql/V2__AddSubscribers.sql
@@ -1,8 +1,8 @@
-CREATE TABLE IF NOT EXISTS "Subscribers" (
-    "Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    "Email" TEXT NOT NULL,
-    "IsVerified" INTEGER NOT NULL,
-    "VerificationToken" TEXT NOT NULL,
-    "UnsubscribeToken" TEXT NOT NULL,
-    "CreatedAt" TEXT NOT NULL
+CREATE TABLE [Subscribers] (
+    [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    [Email] nvarchar(256) NOT NULL,
+    [IsVerified] bit NOT NULL,
+    [VerificationToken] nvarchar(64) NOT NULL,
+    [UnsubscribeToken] nvarchar(64) NOT NULL,
+    [CreatedAt] datetime2 NOT NULL
 );

--- a/flyway/sql/V3__AddSmsSubscribers.sql
+++ b/flyway/sql/V3__AddSmsSubscribers.sql
@@ -1,8 +1,8 @@
-CREATE TABLE IF NOT EXISTS "SmsSubscribers" (
-    "Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    "PhoneNumber" TEXT NOT NULL,
-    "IsVerified" INTEGER NOT NULL,
-    "VerificationToken" TEXT NOT NULL,
-    "UnsubscribeToken" TEXT NOT NULL,
-    "CreatedAt" TEXT NOT NULL
+CREATE TABLE [SmsSubscribers] (
+    [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    [PhoneNumber] nvarchar(20) NOT NULL,
+    [IsVerified] bit NOT NULL,
+    [VerificationToken] nvarchar(64) NOT NULL,
+    [UnsubscribeToken] nvarchar(64) NOT NULL,
+    [CreatedAt] datetime2 NOT NULL
 );

--- a/flyway/sql/V4__AddGameWeeks.sql
+++ b/flyway/sql/V4__AddGameWeeks.sql
@@ -1,9 +1,9 @@
-CREATE TABLE IF NOT EXISTS "GameWeeks" (
-    "Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    "Season" TEXT NOT NULL,
-    "Number" INTEGER NOT NULL,
-    "StartDate" TEXT NOT NULL,
-    "EndDate" TEXT NOT NULL
+CREATE TABLE [GameWeeks] (
+    [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    [Season] nvarchar(20) NOT NULL,
+    [Number] int NOT NULL,
+    [StartDate] datetime2 NOT NULL,
+    [EndDate] datetime2 NOT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS "IX_GameWeeks_Season_Number" ON "GameWeeks" ("Season", "Number");
+CREATE UNIQUE INDEX [IX_GameWeeks_Season_Number] ON [GameWeeks] ([Season], [Number]);


### PR DESCRIPTION
## Summary
- update Flyway SQL scripts to use SQL Server syntax

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687e5c2f08688328bf6d89fb320023ab