### PR TITLE
Fix EF update issue

### DIFF
--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -54,4 +54,30 @@ public class GameWeekServiceTests
 
         Assert.Empty(db.GameWeeks);
     }
+
+    [Fact]
+    public async Task AddOrUpdateAsync_updates_when_key_changes()
+    {
+        var service = CreateService(out var db);
+        var gw = new GameWeek { Season = "25-26", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today.AddDays(6) };
+        db.GameWeeks.Add(gw);
+        await db.SaveChangesAsync();
+
+        var updated = new GameWeek
+        {
+            Id = gw.Id,
+            Season = "26-27",
+            Number = 2,
+            StartDate = DateTime.Today.AddDays(7),
+            EndDate = DateTime.Today.AddDays(13)
+        };
+
+        await service.AddOrUpdateAsync(updated);
+
+        var dbItem = await db.GameWeeks.SingleAsync();
+        Assert.Equal(updated.Season, dbItem.Season);
+        Assert.Equal(updated.Number, dbItem.Number);
+        Assert.Equal(updated.StartDate, dbItem.StartDate);
+        Assert.Equal(updated.EndDate, dbItem.EndDate);
+    }
 }

--- a/Predictorator/Services/GameWeekService.cs
+++ b/Predictorator/Services/GameWeekService.cs
@@ -15,7 +15,7 @@ public class GameWeekService : IGameWeekService
 
     public Task<List<GameWeek>> GetGameWeeksAsync(string? season = null)
     {
-        var query = _db.GameWeeks.AsQueryable();
+        var query = _db.GameWeeks.AsNoTracking().AsQueryable();
         if (!string.IsNullOrEmpty(season))
             query = query.Where(g => g.Season == season);
         return query.OrderBy(g => g.Season).ThenBy(g => g.Number).ToListAsync();
@@ -24,22 +24,37 @@ public class GameWeekService : IGameWeekService
     public Task<GameWeek?> GetGameWeekAsync(string season, int number)
     {
         return _db.GameWeeks
+            .AsNoTracking()
             .FirstOrDefaultAsync(g => g.Season == season && g.Number == number);
     }
 
     public async Task AddOrUpdateAsync(GameWeek gameWeek)
     {
-        var existing = await _db.GameWeeks
-            .FirstOrDefaultAsync(g => g.Season == gameWeek.Season && g.Number == gameWeek.Number);
+        GameWeek? existing = null;
+
+        if (gameWeek.Id != 0)
+        {
+            existing = await _db.GameWeeks.FindAsync(gameWeek.Id);
+        }
+
+        if (existing == null)
+        {
+            existing = await _db.GameWeeks
+                .FirstOrDefaultAsync(g => g.Season == gameWeek.Season && g.Number == gameWeek.Number);
+        }
+
         if (existing == null)
         {
             _db.GameWeeks.Add(gameWeek);
         }
         else
         {
+            existing.Season = gameWeek.Season;
+            existing.Number = gameWeek.Number;
             existing.StartDate = gameWeek.StartDate;
             existing.EndDate = gameWeek.EndDate;
         }
+
         await _db.SaveChangesAsync();
     }
 


### PR DESCRIPTION
## Summary
- don't track GameWeek entities when fetching
- allow updates when season or week number changes
- add a regression test

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687e60570de883288d114980b228f47b