### PR TITLE
Make SQL migrations idempotent

### DIFF
--- a/flyway/sql/V1__InitialCreate.sql
+++ b/flyway/sql/V1__InitialCreate.sql
@@ -1,78 +1,106 @@
-CREATE TABLE [AspNetRoles] (
-    [Id] nvarchar(450) NOT NULL,
-    [Name] nvarchar(256) NULL,
-    [NormalizedName] nvarchar(256) NULL,
-    [ConcurrencyStamp] nvarchar(max) NULL,
-    CONSTRAINT [PK_AspNetRoles] PRIMARY KEY ([Id])
-);
+IF OBJECT_ID(N'[AspNetRoles]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetRoles] (
+        [Id] nvarchar(450) NOT NULL,
+        [Name] nvarchar(256) NULL,
+        [NormalizedName] nvarchar(256) NULL,
+        [ConcurrencyStamp] nvarchar(max) NULL,
+        CONSTRAINT [PK_AspNetRoles] PRIMARY KEY ([Id])
+    );
+END;
 
-CREATE TABLE [AspNetUsers] (
-    [Id] nvarchar(450) NOT NULL,
-    [UserName] nvarchar(256) NULL,
-    [NormalizedUserName] nvarchar(256) NULL,
-    [Email] nvarchar(256) NULL,
-    [NormalizedEmail] nvarchar(256) NULL,
-    [EmailConfirmed] bit NOT NULL,
-    [PasswordHash] nvarchar(max) NULL,
-    [SecurityStamp] nvarchar(max) NULL,
-    [ConcurrencyStamp] nvarchar(max) NULL,
-    [PhoneNumber] nvarchar(max) NULL,
-    [PhoneNumberConfirmed] bit NOT NULL,
-    [TwoFactorEnabled] bit NOT NULL,
-    [LockoutEnd] datetimeoffset NULL,
-    [LockoutEnabled] bit NOT NULL,
-    [AccessFailedCount] int NOT NULL,
-    CONSTRAINT [PK_AspNetUsers] PRIMARY KEY ([Id])
-);
+IF OBJECT_ID(N'[AspNetUsers]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetUsers] (
+        [Id] nvarchar(450) NOT NULL,
+        [UserName] nvarchar(256) NULL,
+        [NormalizedUserName] nvarchar(256) NULL,
+        [Email] nvarchar(256) NULL,
+        [NormalizedEmail] nvarchar(256) NULL,
+        [EmailConfirmed] bit NOT NULL,
+        [PasswordHash] nvarchar(max) NULL,
+        [SecurityStamp] nvarchar(max) NULL,
+        [ConcurrencyStamp] nvarchar(max) NULL,
+        [PhoneNumber] nvarchar(max) NULL,
+        [PhoneNumberConfirmed] bit NOT NULL,
+        [TwoFactorEnabled] bit NOT NULL,
+        [LockoutEnd] datetimeoffset NULL,
+        [LockoutEnabled] bit NOT NULL,
+        [AccessFailedCount] int NOT NULL,
+        CONSTRAINT [PK_AspNetUsers] PRIMARY KEY ([Id])
+    );
+END;
 
-CREATE TABLE [AspNetRoleClaims] (
-    [Id] int NOT NULL IDENTITY,
-    [RoleId] nvarchar(450) NOT NULL,
-    [ClaimType] nvarchar(max) NULL,
-    [ClaimValue] nvarchar(max) NULL,
-    CONSTRAINT [PK_AspNetRoleClaims] PRIMARY KEY ([Id]),
-    CONSTRAINT [FK_AspNetRoleClaims_AspNetRoles_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [AspNetRoles] ([Id]) ON DELETE CASCADE
-);
+IF OBJECT_ID(N'[AspNetRoleClaims]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetRoleClaims] (
+        [Id] int NOT NULL IDENTITY,
+        [RoleId] nvarchar(450) NOT NULL,
+        [ClaimType] nvarchar(max) NULL,
+        [ClaimValue] nvarchar(max) NULL,
+        CONSTRAINT [PK_AspNetRoleClaims] PRIMARY KEY ([Id]),
+        CONSTRAINT [FK_AspNetRoleClaims_AspNetRoles_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [AspNetRoles] ([Id]) ON DELETE CASCADE
+    );
+END;
 
-CREATE TABLE [AspNetUserClaims] (
-    [Id] int NOT NULL IDENTITY,
-    [UserId] nvarchar(450) NOT NULL,
-    [ClaimType] nvarchar(max) NULL,
-    [ClaimValue] nvarchar(max) NULL,
-    CONSTRAINT [PK_AspNetUserClaims] PRIMARY KEY ([Id]),
-    CONSTRAINT [FK_AspNetUserClaims_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
-);
+IF OBJECT_ID(N'[AspNetUserClaims]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetUserClaims] (
+        [Id] int NOT NULL IDENTITY,
+        [UserId] nvarchar(450) NOT NULL,
+        [ClaimType] nvarchar(max) NULL,
+        [ClaimValue] nvarchar(max) NULL,
+        CONSTRAINT [PK_AspNetUserClaims] PRIMARY KEY ([Id]),
+        CONSTRAINT [FK_AspNetUserClaims_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
+    );
+END;
 
-CREATE TABLE [AspNetUserLogins] (
-    [LoginProvider] nvarchar(128) NOT NULL,
-    [ProviderKey] nvarchar(128) NOT NULL,
-    [ProviderDisplayName] nvarchar(max) NULL,
-    [UserId] nvarchar(450) NOT NULL,
-    CONSTRAINT [PK_AspNetUserLogins] PRIMARY KEY ([LoginProvider], [ProviderKey]),
-    CONSTRAINT [FK_AspNetUserLogins_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
-);
+IF OBJECT_ID(N'[AspNetUserLogins]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetUserLogins] (
+        [LoginProvider] nvarchar(128) NOT NULL,
+        [ProviderKey] nvarchar(128) NOT NULL,
+        [ProviderDisplayName] nvarchar(max) NULL,
+        [UserId] nvarchar(450) NOT NULL,
+        CONSTRAINT [PK_AspNetUserLogins] PRIMARY KEY ([LoginProvider], [ProviderKey]),
+        CONSTRAINT [FK_AspNetUserLogins_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
+    );
+END;
 
-CREATE TABLE [AspNetUserRoles] (
-    [UserId] nvarchar(450) NOT NULL,
-    [RoleId] nvarchar(450) NOT NULL,
-    CONSTRAINT [PK_AspNetUserRoles] PRIMARY KEY ([UserId], [RoleId]),
-    CONSTRAINT [FK_AspNetUserRoles_AspNetRoles_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [AspNetRoles] ([Id]) ON DELETE CASCADE,
-    CONSTRAINT [FK_AspNetUserRoles_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
-);
+IF OBJECT_ID(N'[AspNetUserRoles]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetUserRoles] (
+        [UserId] nvarchar(450) NOT NULL,
+        [RoleId] nvarchar(450) NOT NULL,
+        CONSTRAINT [PK_AspNetUserRoles] PRIMARY KEY ([UserId], [RoleId]),
+        CONSTRAINT [FK_AspNetUserRoles_AspNetRoles_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [AspNetRoles] ([Id]) ON DELETE CASCADE,
+        CONSTRAINT [FK_AspNetUserRoles_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
+    );
+END;
 
-CREATE TABLE [AspNetUserTokens] (
-    [UserId] nvarchar(450) NOT NULL,
-    [LoginProvider] nvarchar(128) NOT NULL,
-    [Name] nvarchar(128) NOT NULL,
-    [Value] nvarchar(max) NULL,
-    CONSTRAINT [PK_AspNetUserTokens] PRIMARY KEY ([UserId], [LoginProvider], [Name]),
-    CONSTRAINT [FK_AspNetUserTokens_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
-);
+IF OBJECT_ID(N'[AspNetUserTokens]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [AspNetUserTokens] (
+        [UserId] nvarchar(450) NOT NULL,
+        [LoginProvider] nvarchar(128) NOT NULL,
+        [Name] nvarchar(128) NOT NULL,
+        [Value] nvarchar(max) NULL,
+        CONSTRAINT [PK_AspNetUserTokens] PRIMARY KEY ([UserId], [LoginProvider], [Name]),
+        CONSTRAINT [FK_AspNetUserTokens_AspNetUsers_UserId] FOREIGN KEY ([UserId]) REFERENCES [AspNetUsers] ([Id]) ON DELETE CASCADE
+    );
+END;
 
-CREATE INDEX [IX_AspNetRoleClaims_RoleId] ON [AspNetRoleClaims] ([RoleId]);
-CREATE UNIQUE INDEX [RoleNameIndex] ON [AspNetRoles] ([NormalizedName]) WHERE [NormalizedName] IS NOT NULL;
-CREATE INDEX [IX_AspNetUserClaims_UserId] ON [AspNetUserClaims] ([UserId]);
-CREATE INDEX [IX_AspNetUserLogins_UserId] ON [AspNetUserLogins] ([UserId]);
-CREATE INDEX [IX_AspNetUserRoles_RoleId] ON [AspNetUserRoles] ([RoleId]);
-CREATE INDEX [EmailIndex] ON [AspNetUsers] ([NormalizedEmail]);
-CREATE UNIQUE INDEX [UserNameIndex] ON [AspNetUsers] ([NormalizedUserName]) WHERE [NormalizedUserName] IS NOT NULL;
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_AspNetRoleClaims_RoleId')
+    CREATE INDEX [IX_AspNetRoleClaims_RoleId] ON [AspNetRoleClaims] ([RoleId]);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'RoleNameIndex')
+    CREATE UNIQUE INDEX [RoleNameIndex] ON [AspNetRoles] ([NormalizedName]) WHERE [NormalizedName] IS NOT NULL;
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_AspNetUserClaims_UserId')
+    CREATE INDEX [IX_AspNetUserClaims_UserId] ON [AspNetUserClaims] ([UserId]);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_AspNetUserLogins_UserId')
+    CREATE INDEX [IX_AspNetUserLogins_UserId] ON [AspNetUserLogins] ([UserId]);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_AspNetUserRoles_RoleId')
+    CREATE INDEX [IX_AspNetUserRoles_RoleId] ON [AspNetUserRoles] ([RoleId]);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'EmailIndex')
+    CREATE INDEX [EmailIndex] ON [AspNetUsers] ([NormalizedEmail]);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'UserNameIndex')
+    CREATE UNIQUE INDEX [UserNameIndex] ON [AspNetUsers] ([NormalizedUserName]) WHERE [NormalizedUserName] IS NOT NULL;

--- a/flyway/sql/V2__AddSubscribers.sql
+++ b/flyway/sql/V2__AddSubscribers.sql
@@ -1,8 +1,11 @@
-CREATE TABLE [Subscribers] (
-    [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
-    [Email] nvarchar(256) NOT NULL,
-    [IsVerified] bit NOT NULL,
-    [VerificationToken] nvarchar(64) NOT NULL,
-    [UnsubscribeToken] nvarchar(64) NOT NULL,
-    [CreatedAt] datetime2 NOT NULL
-);
+IF OBJECT_ID(N'[Subscribers]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [Subscribers] (
+        [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        [Email] nvarchar(256) NOT NULL,
+        [IsVerified] bit NOT NULL,
+        [VerificationToken] nvarchar(64) NOT NULL,
+        [UnsubscribeToken] nvarchar(64) NOT NULL,
+        [CreatedAt] datetime2 NOT NULL
+    );
+END;

--- a/flyway/sql/V3__AddSmsSubscribers.sql
+++ b/flyway/sql/V3__AddSmsSubscribers.sql
@@ -1,8 +1,11 @@
-CREATE TABLE [SmsSubscribers] (
-    [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
-    [PhoneNumber] nvarchar(20) NOT NULL,
-    [IsVerified] bit NOT NULL,
-    [VerificationToken] nvarchar(64) NOT NULL,
-    [UnsubscribeToken] nvarchar(64) NOT NULL,
-    [CreatedAt] datetime2 NOT NULL
-);
+IF OBJECT_ID(N'[SmsSubscribers]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [SmsSubscribers] (
+        [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        [PhoneNumber] nvarchar(20) NOT NULL,
+        [IsVerified] bit NOT NULL,
+        [VerificationToken] nvarchar(64) NOT NULL,
+        [UnsubscribeToken] nvarchar(64) NOT NULL,
+        [CreatedAt] datetime2 NOT NULL
+    );
+END;

--- a/flyway/sql/V4__AddGameWeeks.sql
+++ b/flyway/sql/V4__AddGameWeeks.sql
@@ -1,9 +1,13 @@
-CREATE TABLE [GameWeeks] (
-    [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
-    [Season] nvarchar(20) NOT NULL,
-    [Number] int NOT NULL,
-    [StartDate] datetime2 NOT NULL,
-    [EndDate] datetime2 NOT NULL
-);
+IF OBJECT_ID(N'[GameWeeks]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [GameWeeks] (
+        [Id] int IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        [Season] nvarchar(20) NOT NULL,
+        [Number] int NOT NULL,
+        [StartDate] datetime2 NOT NULL,
+        [EndDate] datetime2 NOT NULL
+    );
+END;
 
-CREATE UNIQUE INDEX [IX_GameWeeks_Season_Number] ON [GameWeeks] ([Season], [Number]);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'IX_GameWeeks_Season_Number')
+    CREATE UNIQUE INDEX [IX_GameWeeks_Season_Number] ON [GameWeeks] ([Season], [Number]);


### PR DESCRIPTION
## Summary
- make all Flyway migrations idempotent

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687e610a6450832880a944635c3688f8