### PR TITLE
Fix tests after merge mishap

### DIFF
--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -70,6 +70,9 @@ public class GameWeekServiceTests
 
         Assert.NotNull(result);
         Assert.Equal(3, result!.Number);
+    }
+
+    [Fact]
     public async Task AddOrUpdateAsync_updates_when_key_changes()
     {
         var service = CreateService(out var db);


### PR DESCRIPTION
## Summary
- close `GetNextGameWeekAsync_returns_next_week` in GameWeekServiceTests
- add missing `[Fact]` attribute to next test

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_687e6513cc248328b5420c3dd455e109