### PR TITLE
Fix concurrency in GameWeekService

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -125,6 +125,17 @@ builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =
         .EnableSensitiveDataLogging()
         .LogTo(message => efLogger.LogError(message), LogLevel.Error);
 });
+builder.Services.AddDbContextFactory<ApplicationDbContext>((serviceProvider, options) =>
+{
+    var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+    var efLogger = loggerFactory.CreateLogger("EFCore");
+    options
+        .UseSqlServer(connectionString)
+        .UseLoggerFactory(loggerFactory)
+        .EnableDetailedErrors()
+        .EnableSensitiveDataLogging()
+        .LogTo(message => efLogger.LogError(message), LogLevel.Error);
+});
 builder.Services.AddIdentity<IdentityUser, IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultUI()


### PR DESCRIPTION
## Summary
- create new `ApplicationDbContext` per call in `GameWeekService`
- register context factory in Program
- update GameWeekService tests for context factory usage

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687e6d14575c8328b6b3bdb65eaccb3a