### PR TITLE
Refactor admin UI and add cache clearing

### DIFF
--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -49,7 +49,8 @@ public class AdminServiceTests
         gameWeeks.Items.Add(new GameWeek { Season = "25-26", Number = 1, StartDate = provider.UtcNow.Date, EndDate = provider.UtcNow.Date.AddDays(6) });
         var notifications = new NotificationService(db, resend, sms, config, fixtures, gameWeeks, range, features, provider, jobs, inliner, renderer, nLogger);
         var aLogger = NullLogger<AdminService>.Instance;
-        return new AdminService(db, resend, sms, config, inliner, renderer, notifications, aLogger, jobs, provider);
+        var prefix = new CachePrefixService();
+        return new AdminService(db, resend, sms, config, inliner, renderer, notifications, aLogger, jobs, provider, prefix);
     }
 
     [Fact]

--- a/Predictorator.Tests/FixtureServiceTestTokenTests.cs
+++ b/Predictorator.Tests/FixtureServiceTestTokenTests.cs
@@ -38,7 +38,8 @@ public class FixtureServiceTestTokenTests
         services.AddHybridCache();
         var cache = services.BuildServiceProvider().GetRequiredService<HybridCache>();
 
-        var service = new FixtureService(httpClientFactory, cache, accessor, config, env);
+        var prefix = new CachePrefixService();
+        var service = new FixtureService(httpClientFactory, cache, prefix, accessor, config, env);
 
         var result = await service.GetFixturesAsync(DateTime.Today, DateTime.Today.AddDays(6));
 
@@ -73,7 +74,8 @@ public class FixtureServiceTestTokenTests
         services.AddHybridCache();
         var cache = services.BuildServiceProvider().GetRequiredService<HybridCache>();
 
-        var service = new FixtureService(httpClientFactory, cache, accessor, config, env);
+        var prefix = new CachePrefixService();
+        var service = new FixtureService(httpClientFactory, cache, prefix, accessor, config, env);
 
         var result = await service.GetFixturesAsync(DateTime.Today, DateTime.Today.AddDays(6));
 

--- a/Predictorator.Tests/FixtureServiceTests.cs
+++ b/Predictorator.Tests/FixtureServiceTests.cs
@@ -23,11 +23,12 @@ public class FixtureServiceTests
         var services = new ServiceCollection();
         services.AddHybridCache();
         var cache = services.BuildServiceProvider().GetRequiredService<HybridCache>();
+        var prefix = new CachePrefixService();
         var accessor = Substitute.For<IHttpContextAccessor>();
         var config = Substitute.For<IConfiguration>();
         var env = Substitute.For<IWebHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
-        var service = new FixtureService(httpClientFactory, cache, accessor, config, env);
+        var service = new FixtureService(httpClientFactory, cache, prefix, accessor, config, env);
 
         var result1 = await service.GetFixturesAsync(DateTime.Today, DateTime.Today);
         var result2 = await service.GetFixturesAsync(DateTime.Today, DateTime.Today);

--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -41,7 +41,8 @@ public class GameWeekServiceTests
         var provider = services.BuildServiceProvider();
         var cache = provider.GetRequiredService<HybridCache>();
         var opts = provider.GetRequiredService<IOptions<GameWeekCacheOptions>>();
-        return new GameWeekService(factory, cache, opts);
+        var prefix = new CachePrefixService();
+        return new GameWeekService(factory, cache, prefix, opts);
     }
 
     [Fact]

--- a/Predictorator/Components/Pages/Admin/GameWeeks.razor
+++ b/Predictorator/Components/Pages/Admin/GameWeeks.razor
@@ -1,7 +1,4 @@
-@page "/admin/gameweeks"
 @rendermode InteractiveServer
-@using Microsoft.AspNetCore.Authorization
-@attribute [Authorize(Roles="Admin")]
 @inject IGameWeekService Service
 @inject ToastInterop Toast
 

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -1,171 +1,27 @@
 @page "/admin"
 @rendermode InteractiveServer
-@using Predictorator.Services
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize(Roles="Admin")]
 @inject AdminService AdminService
 @inject ToastInterop Toast
 
-<h2>Subscribers</h2>
-@if (_items == null)
-{
-    <p>Loading...</p>
-}
-else
-{
-    <EditForm Model="this" OnValidSubmit="SendTestAsync">
-        <MudTable Items="_items" Hover="true" Breakpoint="Breakpoint.None">
-            <HeaderContent>
-                <MudTh></MudTh>
-                <MudTh>Contact</MudTh>
-                <MudTh>Status</MudTh>
-                <MudTh></MudTh>
-            </HeaderContent>
-            <RowTemplate Context="row">
-                <MudTd><MudCheckBox T="bool" @bind-Value="row.Selected" /></MudTd>
-                <MudTd>@row.Contact</MudTd>
-                <MudTd>
-                    @if (row.IsVerified)
-                    {
-                        <MudChip T="string" Color="Color.Success" Variant="Variant.Filled">Verified</MudChip>
-                    }
-                    else
-                    {
-                        <MudChip T="string" Color="Color.Warning" Variant="Variant.Filled">Pending</MudChip>
-                    }
-                </MudTd>
-                <MudTd>
-                    @if (!row.IsVerified)
-                    {
-                        <MudButton Size="Size.Small" Color="Color.Success" OnClick="@(()=>ConfirmAsync(row))">Confirm</MudButton>
-                    }
-                    <MudButton Size="Size.Small" Color="Color.Error" OnClick="@(()=>DeleteAsync(row))">Delete</MudButton>
-                </MudTd>
-            </RowTemplate>
-        </MudTable>
-        <MudStack Row="true" Spacing="2" Class="mt-2">
-            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Send Test</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendNewFixturesSampleAsync">New Fixtures Sample</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendStartingSoonSampleAsync">Starting Soon Sample</MudButton>
-        </MudStack>
-        <MudStack Row="true" Spacing="2" Class="mt-2" AlignItems="AlignItems.Center">
-            <MudDatePicker @bind-Date="_scheduleDate" Label="Date" Class="mr-2" />
-            <MudTimePicker @bind-Time="_scheduleTime" Label="Time" Class="mr-2" />
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleStartingSoonSampleAsync">Schedule Starting Soon Sample</MudButton>
-        </MudStack>
-    </EditForm>
-}
+<MudPaper Class="pa-2 mb-4">
+    <MudButton Color="Color.Error" OnClick="ClearCaches">Clear Caches</MudButton>
+</MudPaper>
+
+<MudTabs>
+    <MudTabPanel Text="Subscribers">
+        <Subscribers />
+    </MudTabPanel>
+    <MudTabPanel Text="Game Weeks">
+        <GameWeeks />
+    </MudTabPanel>
+</MudTabs>
 
 @code {
-    private class Item : AdminSubscriberDto
+    private async Task ClearCaches()
     {
-        public Item(int id, string contact, bool verified, string type) : base(id, contact, verified, type)
-        {
-        }
-
-        public bool Selected { get; set; }
-    }
-
-    private List<Item>? _items;
-    private DateTime? _scheduleDate = DateTime.Today;
-    private TimeSpan? _scheduleTime = TimeSpan.FromHours(9);
-
-    protected override async Task OnInitializedAsync()
-    {
-        var data = await AdminService.GetSubscribersAsync();
-        _items = data.Select(d => new Item(d.Id, d.Contact, d.IsVerified, d.Type)).ToList();
-    }
-
-    private async Task ConfirmAsync(Item item)
-    {
-        await AdminService.ConfirmAsync(item.Type, item.Id);
-        item.IsVerified = true;
-    }
-
-    private async Task DeleteAsync(Item item)
-    {
-        await AdminService.DeleteAsync(item.Type, item.Id);
-        _items!.Remove(item);
-    }
-
-    private async Task SendTestAsync()
-    {
-        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
-        if (!selected.Any())
-            return;
-
-        try
-        {
-            await AdminService.SendTestAsync(selected);
-            await Toast.ShowToast("Test notifications sent!", "success");
-        }
-        catch
-        {
-            await Toast.ShowToast("Failed to send test notifications.", "error");
-        }
-    }
-
-    private async Task SendNewFixturesSampleAsync()
-    {
-        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
-        if (!selected.Any())
-            return;
-
-        try
-        {
-            await AdminService.SendNewFixturesSampleAsync(selected);
-            await Toast.ShowToast("Sample notifications sent!", "success");
-        }
-        catch
-        {
-            await Toast.ShowToast("Failed to send sample notifications.", "error");
-        }
-    }
-
-    private async Task SendStartingSoonSampleAsync()
-    {
-        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
-        if (!selected.Any())
-            return;
-
-        try
-        {
-            await AdminService.SendFixturesStartingSoonSampleAsync(selected);
-            await Toast.ShowToast("Sample notifications sent!", "success");
-        }
-        catch
-        {
-            await Toast.ShowToast("Failed to send sample notifications.", "error");
-        }
-    }
-
-    private async Task ScheduleStartingSoonSampleAsync()
-    {
-        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
-        if (!selected.Any())
-        {
-            await Toast.ShowToast("Please select at least one subscriber.", "error");
-            return;
-        }
-
-        if (_scheduleDate == null || _scheduleTime == null)
-        {
-            await Toast.ShowToast("Please choose a date and time.", "error");
-            return;
-        }
-
-        var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        var sendLocal = DateTime.SpecifyKind(_scheduleDate.Value.Date + _scheduleTime.Value, DateTimeKind.Unspecified);
-        var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
-
-        try
-        {
-            await AdminService.ScheduleFixturesStartingSoonSampleAsync(selected, sendUtc);
-            await Toast.ShowToast("Sample notification scheduled!", "success");
-        }
-        catch
-        {
-            await Toast.ShowToast("Failed to schedule sample notification.", "error");
-        }
+        await AdminService.ClearCachesAsync();
+        await Toast.ShowToast("Caches cleared!", "success");
     }
 }

--- a/Predictorator/Components/Pages/Admin/Subscribers.razor
+++ b/Predictorator/Components/Pages/Admin/Subscribers.razor
@@ -1,0 +1,167 @@
+@rendermode InteractiveServer
+@inject AdminService AdminService
+@inject ToastInterop Toast
+
+<h2>Subscribers</h2>
+@if (_items == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <EditForm Model="this" OnValidSubmit="SendTestAsync">
+        <MudTable Items="_items" Hover="true" Breakpoint="Breakpoint.None">
+            <HeaderContent>
+                <MudTh></MudTh>
+                <MudTh>Contact</MudTh>
+                <MudTh>Status</MudTh>
+                <MudTh></MudTh>
+            </HeaderContent>
+            <RowTemplate Context="row">
+                <MudTd><MudCheckBox T="bool" @bind-Value="row.Selected" /></MudTd>
+                <MudTd>@row.Contact</MudTd>
+                <MudTd>
+                    @if (row.IsVerified)
+                    {
+                        <MudChip T="string" Color="Color.Success" Variant="Variant.Filled">Verified</MudChip>
+                    }
+                    else
+                    {
+                        <MudChip T="string" Color="Color.Warning" Variant="Variant.Filled">Pending</MudChip>
+                    }
+                </MudTd>
+                <MudTd>
+                    @if (!row.IsVerified)
+                    {
+                        <MudButton Size="Size.Small" Color="Color.Success" OnClick="@(()=>ConfirmAsync(row))">Confirm</MudButton>
+                    }
+                    <MudButton Size="Size.Small" Color="Color.Error" OnClick="@(()=>DeleteAsync(row))">Delete</MudButton>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+        <MudStack Row="true" Spacing="2" Class="mt-2">
+            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Send Test</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendNewFixturesSampleAsync">New Fixtures Sample</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendStartingSoonSampleAsync">Starting Soon Sample</MudButton>
+        </MudStack>
+        <MudStack Row="true" Spacing="2" Class="mt-2" AlignItems="AlignItems.Center">
+            <MudDatePicker @bind-Date="_scheduleDate" Label="Date" Class="mr-2" />
+            <MudTimePicker @bind-Time="_scheduleTime" Label="Time" Class="mr-2" />
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleStartingSoonSampleAsync">Schedule Starting Soon Sample</MudButton>
+        </MudStack>
+    </EditForm>
+}
+
+@code {
+    private class Item : AdminSubscriberDto
+    {
+        public Item(int id, string contact, bool verified, string type) : base(id, contact, verified, type)
+        {
+        }
+
+        public bool Selected { get; set; }
+    }
+
+    private List<Item>? _items;
+    private DateTime? _scheduleDate = DateTime.Today;
+    private TimeSpan? _scheduleTime = TimeSpan.FromHours(9);
+
+    protected override async Task OnInitializedAsync()
+    {
+        var data = await AdminService.GetSubscribersAsync();
+        _items = data.Select(d => new Item(d.Id, d.Contact, d.IsVerified, d.Type)).ToList();
+    }
+
+    private async Task ConfirmAsync(Item item)
+    {
+        await AdminService.ConfirmAsync(item.Type, item.Id);
+        item.IsVerified = true;
+    }
+
+    private async Task DeleteAsync(Item item)
+    {
+        await AdminService.DeleteAsync(item.Type, item.Id);
+        _items!.Remove(item);
+    }
+
+    private async Task SendTestAsync()
+    {
+        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
+        if (!selected.Any())
+            return;
+
+        try
+        {
+            await AdminService.SendTestAsync(selected);
+            await Toast.ShowToast("Test notifications sent!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to send test notifications.", "error");
+        }
+    }
+
+    private async Task SendNewFixturesSampleAsync()
+    {
+        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
+        if (!selected.Any())
+            return;
+
+        try
+        {
+            await AdminService.SendNewFixturesSampleAsync(selected);
+            await Toast.ShowToast("Sample notifications sent!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to send sample notifications.", "error");
+        }
+    }
+
+    private async Task SendStartingSoonSampleAsync()
+    {
+        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
+        if (!selected.Any())
+            return;
+
+        try
+        {
+            await AdminService.SendFixturesStartingSoonSampleAsync(selected);
+            await Toast.ShowToast("Sample notifications sent!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to send sample notifications.", "error");
+        }
+    }
+
+    private async Task ScheduleStartingSoonSampleAsync()
+    {
+        var selected = _items!.Where(i => i.Selected).Cast<AdminSubscriberDto>().ToList();
+        if (!selected.Any())
+        {
+            await Toast.ShowToast("Please select at least one subscriber.", "error");
+            return;
+        }
+
+        if (_scheduleDate == null || _scheduleTime == null)
+        {
+            await Toast.ShowToast("Please choose a date and time.", "error");
+            return;
+        }
+
+        var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var sendLocal = DateTime.SpecifyKind(_scheduleDate.Value.Date + _scheduleTime.Value, DateTimeKind.Unspecified);
+        var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
+
+        try
+        {
+            await AdminService.ScheduleFixturesStartingSoonSampleAsync(selected, sendUtc);
+            await Toast.ShowToast("Sample notification scheduled!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to schedule sample notification.", "error");
+        }
+    }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -92,6 +92,7 @@ builder.Services.AddRateLimiter(options =>
 });
 builder.Services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
 builder.Services.AddHybridCache();
+builder.Services.AddSingleton<CachePrefixService>();
 builder.Services.Configure<GameWeekCacheOptions>(builder.Configuration.GetSection(GameWeekCacheOptions.SectionName));
 builder.Services.AddHttpClient<ResendClient>();
 builder.Services.Configure<ResendClientOptions>(o =>

--- a/Predictorator/Services/AdminService.cs
+++ b/Predictorator/Services/AdminService.cs
@@ -40,6 +40,7 @@ public class AdminService
     private readonly ILogger<AdminService> _logger;
     private readonly IBackgroundJobClient _jobs;
     private readonly IDateTimeProvider _time;
+    private readonly CachePrefixService _prefix;
 
     public AdminService(
         ApplicationDbContext db,
@@ -51,7 +52,8 @@ public class AdminService
         NotificationService notifications,
         ILogger<AdminService> logger,
         IBackgroundJobClient jobs,
-        IDateTimeProvider time)
+        IDateTimeProvider time,
+        CachePrefixService prefix)
     {
         _db = db;
         _resend = resend;
@@ -63,6 +65,7 @@ public class AdminService
         _logger = logger;
         _jobs = jobs;
         _time = time;
+        _prefix = prefix;
     }
 
     public async Task<List<AdminSubscriberDto>> GetSubscribersAsync()
@@ -157,6 +160,12 @@ public class AdminService
         var delay = sendUtc - _time.UtcNow;
         if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
         _jobs.Schedule<NotificationService>(s => s.SendSampleAsync(recipients, "Fixtures start in 2 hours!", baseUrl), delay);
+        return Task.CompletedTask;
+    }
+
+    public Task ClearCachesAsync()
+    {
+        _prefix.Clear();
         return Task.CompletedTask;
     }
 }

--- a/Predictorator/Services/CachePrefixService.cs
+++ b/Predictorator/Services/CachePrefixService.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+
+namespace Predictorator.Services;
+
+public sealed class CachePrefixService
+{
+    private string _prefix = string.Empty;
+
+    public string Prefix => _prefix;
+
+    public void Clear()
+    {
+        Interlocked.Exchange(ref _prefix, Guid.NewGuid().ToString("N") + "_");
+    }
+}

--- a/Predictorator/Services/FixtureService.cs
+++ b/Predictorator/Services/FixtureService.cs
@@ -9,6 +9,7 @@ namespace Predictorator.Services
     {
         private readonly HttpClient _httpClient;
         private readonly HybridCache _cache;
+        private readonly CachePrefixService _prefix;
         private readonly IHttpContextAccessor _contextAccessor;
         private readonly IConfiguration _configuration;
         private readonly IWebHostEnvironment _environment;
@@ -17,12 +18,14 @@ namespace Predictorator.Services
         public FixtureService(
             IHttpClientFactory httpClientFactory,
             HybridCache cache,
+            CachePrefixService prefix,
             IHttpContextAccessor contextAccessor,
             IConfiguration configuration,
             IWebHostEnvironment environment)
         {
             _httpClient = httpClientFactory.CreateClient("fixtures");
             _cache = cache;
+            _prefix = prefix;
             _contextAccessor = contextAccessor;
             _configuration = configuration;
             _environment = environment;
@@ -30,7 +33,7 @@ namespace Predictorator.Services
 
         public async Task<FixturesResponse> GetFixturesAsync(DateTime fromDate, DateTime toDate)
         {
-            var cacheKey = $"{fromDate:yyyy-MM-dd}_{toDate:yyyy-MM-dd}";
+            var cacheKey = $"{_prefix.Prefix}{fromDate:yyyy-MM-dd}_{toDate:yyyy-MM-dd}";
 
             var options = new HybridCacheEntryOptions { Expiration = _cacheDuration, LocalCacheExpiration = _cacheDuration };
 


### PR DESCRIPTION
## Summary
- add `CachePrefixService` for invalidating cached data
- update `FixtureService` and `GameWeekService` to prefix cache keys
- expose `ClearCachesAsync` via `AdminService`
- consolidate admin pages under `/admin` with tabs
- adjust unit tests for new constructors

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687e783acd248328979c373dba2eef50