### PR TITLE
Move cache control into admin tab

### DIFF
--- a/Predictorator/Components/Pages/Admin/GameWeeks.razor
+++ b/Predictorator/Components/Pages/Admin/GameWeeks.razor
@@ -11,10 +11,10 @@
             <MudNumericField T="int" @bind-Value="_model.Number" Label="Week" Required="true" />
             <MudDatePicker @bind-Date="_start" Label="Start" Required="true" />
             <MudDatePicker @bind-Date="_end" Label="End" Required="true" />
-            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary">Save</MudButton>
+            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Save</MudButton>
             @if (_editingId != null)
             {
-                <MudButton Color="Color.Default" OnClick="CancelEdit">Cancel</MudButton>
+                <MudButton Color="Color.Default" Variant="Variant.Outlined" OnClick="CancelEdit">Cancel</MudButton>
             }
         </MudStack>
     </EditForm>
@@ -40,8 +40,8 @@ else
             <MudTd>@row.StartDate.ToString("yyyy-MM-dd")</MudTd>
             <MudTd>@row.EndDate.ToString("yyyy-MM-dd")</MudTd>
             <MudTd>
-                <MudButton Size="Size.Small" OnClick="() => Edit(row)">Edit</MudButton>
-                <MudButton Size="Size.Small" Color="Color.Error" OnClick="() => DeleteAsync(row.Id)">Delete</MudButton>
+                <MudButton Size="Size.Small" Variant="Variant.Outlined" OnClick="() => Edit(row)">Edit</MudButton>
+                <MudButton Size="Size.Small" Color="Color.Error" Variant="Variant.Filled" OnClick="() => DeleteAsync(row.Id)">Delete</MudButton>
             </MudTd>
         </RowTemplate>
     </MudTable>

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -5,16 +5,17 @@
 @inject AdminService AdminService
 @inject ToastInterop Toast
 
-<MudPaper Class="pa-2 mb-4">
-    <MudButton Color="Color.Error" OnClick="ClearCaches">Clear Caches</MudButton>
-</MudPaper>
-
 <MudTabs>
     <MudTabPanel Text="Subscribers">
         <Subscribers />
     </MudTabPanel>
     <MudTabPanel Text="Game Weeks">
         <GameWeeks />
+    </MudTabPanel>
+    <MudTabPanel Text="Maintenance">
+        <MudPaper Class="pa-2">
+            <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="ClearCaches">Clear Caches</MudButton>
+        </MudPaper>
     </MudTabPanel>
 </MudTabs>
 

--- a/Predictorator/Components/Pages/Admin/Subscribers.razor
+++ b/Predictorator/Components/Pages/Admin/Subscribers.razor
@@ -33,9 +33,9 @@ else
                 <MudTd>
                     @if (!row.IsVerified)
                     {
-                        <MudButton Size="Size.Small" Color="Color.Success" OnClick="@(()=>ConfirmAsync(row))">Confirm</MudButton>
+                        <MudButton Size="Size.Small" Color="Color.Success" Variant="Variant.Filled" OnClick="@(()=>ConfirmAsync(row))">Confirm</MudButton>
                     }
-                    <MudButton Size="Size.Small" Color="Color.Error" OnClick="@(()=>DeleteAsync(row))">Delete</MudButton>
+                    <MudButton Size="Size.Small" Color="Color.Error" Variant="Variant.Filled" OnClick="@(()=>DeleteAsync(row))">Delete</MudButton>
                 </MudTd>
             </RowTemplate>
         </MudTable>


### PR DESCRIPTION
## Summary
- relocate clear cache action into a new Maintenance tab
- ensure admin page buttons use a filled or outlined variant for visibility

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687f487303ec8328b58f889702a248d3