### PR TITLE
Restrict workflow runs to repo owner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
           retention-days: 1
 
   deploy_prod:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     needs: build
     environment: Production

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- restrict build and deployment workflows to only run when triggered by the repo owner

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_687f767d8554832897433e769b53e542