### PR TITLE
Dynamic email preheader

### DIFF
--- a/Predictorator/Services/AdminService.cs
+++ b/Predictorator/Services/AdminService.cs
@@ -123,7 +123,7 @@ public class AdminService
                 var sub = await _db.Subscribers.FirstOrDefaultAsync(x => x.Id == s.Id);
                 if (sub != null)
                 {
-                    var html = _renderer.Render("This is a test notification.", baseUrl, sub.UnsubscribeToken, "VIEW FIXTURES", baseUrl);
+                    var html = _renderer.Render("This is a test notification.", baseUrl, sub.UnsubscribeToken, "VIEW FIXTURES", baseUrl, preheader: "This is a test notification.");
                     var message = new EmailMessage
                     {
                         From = _config["Resend:From"] ?? "Predictorator <noreply@example.com>",

--- a/Predictorator/Services/EmailTemplateRenderer.cs
+++ b/Predictorator/Services/EmailTemplateRenderer.cs
@@ -4,7 +4,7 @@ namespace Predictorator.Services;
 
 public class EmailTemplateRenderer
 {
-    public string Render(string messageHtml, string baseUrl, string? unsubscribeToken, string? buttonText = null, string? buttonUrl = null)
+    public string Render(string messageHtml, string baseUrl, string? unsubscribeToken, string? buttonText = null, string? buttonUrl = null, string? preheader = null)
     {
         var year = DateTime.UtcNow.Year;
         var buttonSection = string.Empty;
@@ -36,6 +36,10 @@ public class EmailTemplateRenderer
             unsubscribeSection = $"<a href=\"{link}\" style=\"color:#555555; text-decoration:none; font-size:11px;\">Unsubscribe</a>";
         }
 
+        var preheaderText = string.IsNullOrWhiteSpace(preheader)
+            ? "Updates from Predictotronix"
+            : preheader;
+
         return $@"<!DOCTYPE html>
 <html>
 <head>
@@ -47,7 +51,7 @@ public class EmailTemplateRenderer
 </head>
 <body style=""margin:0; padding:0; background-color:#0a0a0a; color:#f0f0f0; font-family:'Courier New', Courier, monospace;"">
   <span class=""preheader"">
-    Your latest predictions are locked and loaded at Predictotronix.
+    {preheaderText}
   </span>
   <table width=""100%"" cellpadding=""0"" cellspacing=""0"" style=""background-color:#0a0a0a; padding:20px 0;"">
     <tr>

--- a/Predictorator/Services/NotificationService.cs
+++ b/Predictorator/Services/NotificationService.cs
@@ -137,7 +137,7 @@ public class NotificationService
 
     private EmailMessage CreateEmailMessage(string message, string baseUrl, Subscriber sub)
     {
-        var html = _renderer.Render(message, baseUrl, sub.UnsubscribeToken, "VIEW FIXTURES", baseUrl);
+        var html = _renderer.Render(message, baseUrl, sub.UnsubscribeToken, "VIEW FIXTURES", baseUrl, preheader: message);
         var emailMessage = new EmailMessage
         {
             From = _config["Resend:From"] ?? "Prediction Fairy <no-reply@example.com>",

--- a/Predictorator/Services/SubscriptionService.cs
+++ b/Predictorator/Services/SubscriptionService.cs
@@ -27,7 +27,7 @@ public class SubscriptionService
 
     private async Task SendAdminEmailAsync(string subject, string body)
     {
-        var html = _renderer.Render(body, _config["BASE_URL"] ?? string.Empty, null);
+        var html = _renderer.Render(body, _config["BASE_URL"] ?? string.Empty, null, preheader: body);
         var message = new EmailMessage
         {
             From = _config["Resend:From"] ?? "Prediction Fairy <no-reply@example.com>",
@@ -160,7 +160,7 @@ public class SubscriptionService
 
         var verifyLink = $"{baseUrl}/Subscription/Verify?token={subscriber.VerificationToken}";
 
-        var html = _renderer.Render("Please verify your email.", baseUrl, subscriber.UnsubscribeToken, "VERIFY EMAIL", verifyLink);
+        var html = _renderer.Render("Please verify your email.", baseUrl, subscriber.UnsubscribeToken, "VERIFY EMAIL", verifyLink, preheader: "Please verify your email.");
         var message = new EmailMessage
         {
             From = _config["Resend:From"] ?? "Prediction Fairy <no-reply@example.com>",


### PR DESCRIPTION
## Summary
- allow EmailTemplateRenderer to accept a custom preheader
- pass alert message as the preheader when building emails
- use a generic fallback preheader text

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6880fd1306f083288e9e0b0afd8089c7