### PR TITLE
Add privacy policy dialog

### DIFF
--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -7,6 +7,7 @@
 @inject IDialogService DialogService
 @inject NotificationFeatureService NotificationFeatures
 @using Predictorator.Components.Pages.Subscription
+@using Predictorator.Components.Privacy
 
 <MudThemeProvider Theme="@CurrentTheme"
                   @bind-IsDarkMode="@IsDarkMode"/>
@@ -90,6 +91,9 @@
     <MudMainContent>
         <MudContainer MaxWidth="MaxWidth.Large">
             @Body
+            <MudText Typo="Typo.caption" Align="Align.Center" Class="mt-6">
+                <MudLink Href="#" OnClick="OpenPrivacyPolicy">Privacy Policy</MudLink>
+            </MudText>
         </MudContainer>
     </MudMainContent>
 
@@ -260,6 +264,11 @@
     private void OpenSubscribe()
     {
         DialogService.Show<Subscribe>("Subscribe");
+    }
+
+    private void OpenPrivacyPolicy()
+    {
+        DialogService.Show<Privacy.PrivacyPolicyDialog>("Privacy Policy");
     }
 
     private bool? GetCookieBool(string key)

--- a/Predictorator/Components/Privacy/PrivacyPolicyDialog.razor
+++ b/Predictorator/Components/Privacy/PrivacyPolicyDialog.razor
@@ -1,0 +1,31 @@
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.h5" Class="mb-2">Privacy Policy</MudText>
+        <MudText Typo="Typo.subtitle2" Class="mb-4">Effective date: 01/07/2025</MudText>
+        <MudText Class="mb-2">This website is operated by a private individual as a non-commercial hobby project. I am committed to protecting your privacy and handling your personal data responsibly and in accordance with UK data protection laws.</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">1. Information Collected</MudText>
+        <MudText>- Email address</MudText>
+        <MudText Class="mb-2">- Phone number</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">2. Purpose of Data Use</MudText>
+        <MudText Class="mb-2">Your personal data is used solely for the purpose of sending you messages and updates related to this website and its content. Your information will never be sold, rented, or shared with third parties for marketing or commercial purposes.</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">3. Third-Party Services</MudText>
+        <MudText>- Twilio (for SMS messages)</MudText>
+        <MudText Class="mb-2">- Resend (for emails)</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">4. Legal Basis</MudText>
+        <MudText Class="mb-2">Your consent is the lawful basis under the UK GDPR for collecting and processing your email address and phone number. You can withdraw your consent at any time by contacting me or unsubscribing from communications.</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">5. Data Retention</MudText>
+        <MudText Class="mb-2">I will retain your personal data only for as long as is necessary to provide the messaging service. You may request deletion of your data at any time.</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">6. Your Rights</MudText>
+        <MudText Class="mb-2">Under the UK General Data Protection Regulation (UK GDPR), you have the right to access the personal data I hold about you, request correction or deletion of your data, withdraw your consent at any time, and lodge a complaint with the Information Commissioner's Office (ICO) if you believe your data has been misused.</MudText>
+        <MudText Typo="Typo.h6" Class="mt-3 mb-1">7. Contact</MudText>
+        <MudText>Email: t.i.w.carr@gmail.com</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Color="Color.Primary">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudBlazor.MudDialogInstance DialogInstance { get; set; } = default!;
+    private void Close() => DialogInstance.Close();
+}


### PR DESCRIPTION
## Summary
- show a new Privacy Policy pop-up from the main layout
- implement the privacy policy in a dialog component

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_688143ccaf848328aac44e7d06fc460e