### PR TITLE
Add Hangfire link

### DIFF
--- a/Predictorator.Tests/AdminPageLinkTests.cs
+++ b/Predictorator.Tests/AdminPageLinkTests.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Predictorator.Tests;
+
+public class AdminPageLinkTests
+{
+    [Fact]
+    public void AdminPage_Should_Contain_Hangfire_Link()
+    {
+        var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Predictorator", "Components", "Pages", "Admin", "Index.razor"));
+        var content = File.ReadAllText(path);
+        Assert.Contains("/hangfire", content);
+    }
+}

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -15,6 +15,9 @@
     <MudTabPanel Text="Maintenance">
         <MudPaper Class="pa-2">
             <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="ClearCaches">Clear Caches</MudButton>
+            <MudText Class="mt-4">
+                <MudLink Href="/hangfire" Target="_blank">Hangfire Dashboard</MudLink>
+            </MudText>
         </MudPaper>
     </MudTabPanel>
 </MudTabs>


### PR DESCRIPTION
## Summary
- add Hangfire dashboard link to admin page
- ensure admin page source contains dashboard link

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_688cfaae7e60832892c632bf6ed5cbd2