### PR TITLE
Fix early scheduling of new fixtures notification

### DIFF
--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -70,17 +70,31 @@ public class NotificationServiceTests
     }
 
     [Fact]
-    public async Task CheckFixturesAsync_schedules_new_fixture_job()
+    public async Task CheckFixturesAsync_schedules_new_fixture_job_on_fixture_day()
     {
         var now = new DateTime(2024, 6, 1, 8, 0, 0, DateTimeKind.Utc);
-        var fixture = now.AddDays(2);
-        var service = CreateService(now, fixture, out var db, out var jobs, out _, out _);
+        var fixture = now.AddHours(2);
+        var service = CreateService(now, fixture, out _, out var jobs, out _, out _);
 
         await service.CheckFixturesAsync();
 
         jobs.Received().Create(
             Arg.Is<Job>(j => j.Method.Name == nameof(NotificationService.SendNewFixturesAvailableAsync)),
             Arg.Is<IState>(s => s is ScheduledState));
+    }
+
+    [Fact]
+    public async Task CheckFixturesAsync_does_not_schedule_new_fixture_job_in_advance()
+    {
+        var now = new DateTime(2024, 6, 1, 8, 0, 0, DateTimeKind.Utc);
+        var fixture = now.AddDays(2);
+        var service = CreateService(now, fixture, out _, out var jobs, out _, out _);
+
+        await service.CheckFixturesAsync();
+
+        jobs.DidNotReceive().Create(
+            Arg.Is<Job>(j => j.Method.Name == nameof(NotificationService.SendNewFixturesAvailableAsync)),
+            Arg.Any<IState>());
     }
 
     [Fact]

--- a/Predictorator/Services/NotificationService.cs
+++ b/Predictorator/Services/NotificationService.cs
@@ -94,13 +94,16 @@ public class NotificationService
             if (!sent)
             {
                 var futureUk = TimeZoneInfo.ConvertTime(future.Fixture.Date, ukTz);
-                var sendTimeUk = futureUk.Date.AddHours(10);
-                var sendTimeUtc = TimeZoneInfo.ConvertTimeToUtc(sendTimeUk, ukTz);
-                var delay = sendTimeUtc - nowUtc;
-                if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
-                _jobs.Schedule<NotificationService>(
-                    s => s.SendNewFixturesAvailableAsync(key, baseUrl),
-                    delay);
+                if (futureUk.Date == nowUk.Date)
+                {
+                    var sendTimeUk = futureUk.Date.AddHours(10);
+                    var sendTimeUtc = TimeZoneInfo.ConvertTimeToUtc(sendTimeUk, ukTz);
+                    var delay = sendTimeUtc - nowUtc;
+                    if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+                    _jobs.Schedule<NotificationService>(
+                        s => s.SendNewFixturesAvailableAsync(key, baseUrl),
+                        delay);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- only schedule new fixtures notifications on the morning of the fixtures
- add tests for scheduling and avoiding early jobs

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68907c767d388328b77697d8ed1c99af