### PR TITLE
Show Hangfire dashboard button on admin page

### DIFF
--- a/Predictorator.Tests/AdminPageLinkTests.cs
+++ b/Predictorator.Tests/AdminPageLinkTests.cs
@@ -11,6 +11,7 @@ public class AdminPageLinkTests
     {
         var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "Predictorator", "Components", "Pages", "Admin", "Index.razor"));
         var content = File.ReadAllText(path);
-        Assert.Contains("/hangfire", content);
+        Assert.Contains("<MudButton", content);
+        Assert.Contains("Href=\"/hangfire\"", content);
     }
 }

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -15,9 +15,9 @@
     <MudTabPanel Text="Maintenance">
         <MudPaper Class="pa-2">
             <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="ClearCaches">Clear Caches</MudButton>
-            <MudText Class="mt-4">
-                <MudLink Href="/hangfire" Target="_blank">Hangfire Dashboard</MudLink>
-            </MudText>
+            <MudButton Class="mt-4" Href="/hangfire" Target="_blank" Variant="Variant.Filled" Color="Color.Primary">
+                Hangfire Dashboard
+            </MudButton>
         </MudPaper>
     </MudTabPanel>
 </MudTabs>


### PR DESCRIPTION
## Summary
- make hangfire dashboard accessible from admin page via button
- assert hangfire button exists in admin page in tests

## Testing
- `~/.dotnet/dotnet build Predictorator.sln -warnaserror`
- `~/.dotnet/dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6890ac2726008328bd14dee3b61f6770