### PR TITLE
Fix privacy policy link

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -143,4 +143,14 @@ public class HomePageTests
         await _page.WaitForURLAsync(initialUrl);
         Assert.That(_page.Url, Is.EqualTo(initialUrl));
     }
+
+    [Test]
+    public async Task PrivacyPolicyLink_Should_Display_Dialog()
+    {
+        await NavigateWithRetriesAsync(_page!, BaseUrl);
+        var initialUrl = _page!.Url;
+        await _page.GetByRole(AriaRole.Link, new() { Name = "Privacy Policy" }).ClickAsync();
+        await _page.GetByRole(AriaRole.Dialog).GetByText("Privacy Policy").WaitForAsync();
+        Assert.That(_page.Url, Is.EqualTo(initialUrl));
+    }
 }

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -92,7 +92,7 @@
         <MudContainer MaxWidth="MaxWidth.Large">
             @Body
             <MudText Typo="Typo.caption" Align="Align.Center" Class="mt-6">
-                <MudLink Href="#" OnClick="OpenPrivacyPolicy">Privacy Policy</MudLink>
+                <MudLink OnClick="OpenPrivacyPolicy">Privacy Policy</MudLink>
             </MudText>
         </MudContainer>
     </MudMainContent>


### PR DESCRIPTION
## Summary
- ensure the privacy policy link opens the dialog instead of navigating away
- add UI test to verify the privacy policy dialog renders

## Testing
- `dotnet format style Predictorator.sln --verify-no-changes`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_6891e6d913fc8328baaa2bb6bd29b1a8