### PR TITLE
Add manual scheduling for notification jobs

### DIFF
--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -134,4 +134,30 @@ public class AdminServiceTests
             Arg.Is<Job>(j => j.Method.Name == nameof(NotificationService.SendSampleAsync)),
             Arg.Is<IState>(s => s is ScheduledState));
     }
+
+    [Fact]
+    public async Task ScheduleNewFixturesAsync_schedules_job()
+    {
+        var service = CreateService(out _, out _, out _, out var jobs, out var time);
+        var sendAt = time.UtcNow.AddMinutes(30);
+
+        await service.ScheduleNewFixturesAsync(sendAt);
+
+        jobs.Received().Create(
+            Arg.Is<Job>(j => j.Method.Name == nameof(NotificationService.SendNewFixturesAvailableAsync)),
+            Arg.Is<IState>(s => s is ScheduledState));
+    }
+
+    [Fact]
+    public async Task ScheduleFixturesStartingSoonAsync_schedules_job()
+    {
+        var service = CreateService(out _, out _, out _, out var jobs, out var time);
+        var sendAt = time.UtcNow.AddMinutes(30);
+
+        await service.ScheduleFixturesStartingSoonAsync(sendAt);
+
+        jobs.Received().Create(
+            Arg.Is<Job>(j => j.Method.Name == nameof(NotificationService.SendFixturesStartingSoonAsync)),
+            Arg.Is<IState>(s => s is ScheduledState));
+    }
 }

--- a/Predictorator/Components/Pages/Admin/Subscribers.razor
+++ b/Predictorator/Components/Pages/Admin/Subscribers.razor
@@ -39,17 +39,37 @@ else
                 </MudTd>
             </RowTemplate>
         </MudTable>
-        <MudStack Row="true" Spacing="2" Class="mt-2">
-            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Send Test</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendNewFixturesSampleAsync">New Fixtures Sample</MudButton>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendStartingSoonSampleAsync">Starting Soon Sample</MudButton>
-        </MudStack>
-        <MudStack Row="true" Spacing="2" Class="mt-2" AlignItems="AlignItems.Center">
-            <MudDatePicker @bind-Date="_scheduleDate" Label="Date" Class="mr-2" />
-            <MudTimePicker @bind-Time="_scheduleTime" Label="Time" Class="mr-2" />
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleStartingSoonSampleAsync">Schedule Starting Soon Sample</MudButton>
-        </MudStack>
+        <MudPaper Class="pa-2 mt-2">
+            <MudText Typo="Typo.h6">Test Notifications</MudText>
+            <MudStack Row="true" Spacing="2" Class="mt-2">
+                <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Send Test</MudButton>
+            </MudStack>
+        </MudPaper>
+        <MudPaper Class="pa-2 mt-2">
+            <MudText Typo="Typo.h6">Sample Notifications</MudText>
+            <MudStack Row="true" Spacing="2" Class="mt-2">
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendNewFixturesSampleAsync">New Fixtures Sample</MudButton>
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@SendStartingSoonSampleAsync">Starting Soon Sample</MudButton>
+            </MudStack>
+        </MudPaper>
+        <MudPaper Class="pa-2 mt-2">
+            <MudText Typo="Typo.h6">Schedule Sample Notification</MudText>
+            <MudStack Row="true" Spacing="2" Class="mt-2" AlignItems="AlignItems.Center">
+                <MudDatePicker @bind-Date="_sampleDate" Label="Date" Class="mr-2" />
+                <MudTimePicker @bind-Time="_sampleTime" Label="Time" Class="mr-2" />
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleStartingSoonSampleAsync">Schedule Starting Soon Sample</MudButton>
+            </MudStack>
+        </MudPaper>
     </EditForm>
+    <MudPaper Class="pa-2 mt-4">
+        <MudText Typo="Typo.h6">Schedule Real Notifications</MudText>
+        <MudStack Row="true" Spacing="2" Class="mt-2" AlignItems="AlignItems.Center">
+            <MudDatePicker @bind-Date="_realDate" Label="Date" Class="mr-2" />
+            <MudTimePicker @bind-Time="_realTime" Label="Time" Class="mr-2" />
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleNewFixturesAsync">Schedule New Fixtures</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ScheduleFixturesStartingSoonAsync">Schedule Fixtures Starting Soon</MudButton>
+        </MudStack>
+    </MudPaper>
 }
 
 @code {
@@ -63,8 +83,10 @@ else
     }
 
     private List<Item>? _items;
-    private DateTime? _scheduleDate = DateTime.Today;
-    private TimeSpan? _scheduleTime = TimeSpan.FromHours(9);
+    private DateTime? _sampleDate = DateTime.Today;
+    private TimeSpan? _sampleTime = TimeSpan.FromHours(9);
+    private DateTime? _realDate = DateTime.Today;
+    private TimeSpan? _realTime = TimeSpan.FromHours(9);
 
     protected override async Task OnInitializedAsync()
     {
@@ -144,14 +166,14 @@ else
             return;
         }
 
-        if (_scheduleDate == null || _scheduleTime == null)
+        if (_sampleDate == null || _sampleTime == null)
         {
             await Toast.ShowToast("Please choose a date and time.", "error");
             return;
         }
 
         var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        var sendLocal = DateTime.SpecifyKind(_scheduleDate.Value.Date + _scheduleTime.Value, DateTimeKind.Unspecified);
+        var sendLocal = DateTime.SpecifyKind(_sampleDate.Value.Date + _sampleTime.Value, DateTimeKind.Unspecified);
         var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
 
         try
@@ -162,6 +184,52 @@ else
         catch
         {
             await Toast.ShowToast("Failed to schedule sample notification.", "error");
+        }
+    }
+
+    private async Task ScheduleNewFixturesAsync()
+    {
+        if (_realDate == null || _realTime == null)
+        {
+            await Toast.ShowToast("Please choose a date and time.", "error");
+            return;
+        }
+
+        var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var sendLocal = DateTime.SpecifyKind(_realDate.Value.Date + _realTime.Value, DateTimeKind.Unspecified);
+        var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
+
+        try
+        {
+            await AdminService.ScheduleNewFixturesAsync(sendUtc);
+            await Toast.ShowToast("New fixtures notification scheduled!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to schedule new fixtures notification.", "error");
+        }
+    }
+
+    private async Task ScheduleFixturesStartingSoonAsync()
+    {
+        if (_realDate == null || _realTime == null)
+        {
+            await Toast.ShowToast("Please choose a date and time.", "error");
+            return;
+        }
+
+        var uk = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var sendLocal = DateTime.SpecifyKind(_realDate.Value.Date + _realTime.Value, DateTimeKind.Unspecified);
+        var sendUtc = TimeZoneInfo.ConvertTimeToUtc(sendLocal, uk);
+
+        try
+        {
+            await AdminService.ScheduleFixturesStartingSoonAsync(sendUtc);
+            await Toast.ShowToast("Starting soon notification scheduled!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to schedule starting soon notification.", "error");
         }
     }
 }

--- a/Predictorator/Services/AdminService.cs
+++ b/Predictorator/Services/AdminService.cs
@@ -163,6 +163,26 @@ public class AdminService
         return Task.CompletedTask;
     }
 
+    public Task ScheduleNewFixturesAsync(DateTime sendUtc)
+    {
+        var baseUrl = _config["BASE_URL"] ?? "http://localhost";
+        var key = sendUtc.ToString("yyyy-MM-dd");
+        var delay = sendUtc - _time.UtcNow;
+        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        _jobs.Schedule<NotificationService>(s => s.SendNewFixturesAvailableAsync(key, baseUrl), delay);
+        return Task.CompletedTask;
+    }
+
+    public Task ScheduleFixturesStartingSoonAsync(DateTime sendUtc)
+    {
+        var baseUrl = _config["BASE_URL"] ?? "http://localhost";
+        var key = sendUtc.ToString("O");
+        var delay = sendUtc - _time.UtcNow;
+        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        _jobs.Schedule<NotificationService>(s => s.SendFixturesStartingSoonAsync(key, baseUrl), delay);
+        return Task.CompletedTask;
+    }
+
     public Task ClearCachesAsync()
     {
         _prefix.Clear();


### PR DESCRIPTION
## Summary
- allow admins to schedule real notification jobs for all users
- group admin test actions into clear sections and add real notification scheduler
- cover new scheduling paths with unit tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6894a41fc5f48328bf895ee2bf8b8ed8