### PR TITLE
Add dynamic gameweek page title

### DIFF
--- a/Predictorator/Components/App.razor
+++ b/Predictorator/Components/App.razor
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
+    <title>Predictotronix</title>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -9,6 +9,8 @@
 @using Predictorator.Components.Layout
 @using Predictorator.Models
 
+<PageTitle>@PageTitleText</PageTitle>
+
 @if (UiModeService.IsCeefax)
 {
     <MudText Typo="Typo.h3" Class="my-4 pa-2 ceefax-title" Align="Align.Center" Color="Color.Success">Premiership Results Fixtures</MudText>
@@ -111,6 +113,10 @@ else if (_fixtures.Response.Any())
 
     [Parameter] public string? Season { get; set; }
     [Parameter] public int? Week { get; set; }
+
+    private string PageTitleText => !string.IsNullOrEmpty(Season) && Week.HasValue
+        ? $"Predictotronix | {Season} | GW{Week}"
+        : "Predictotronix";
 
     [Parameter, SupplyParameterFromQuery(Name = "fromDate")] public DateTime? FromDate { get; set; }
     [Parameter, SupplyParameterFromQuery(Name = "toDate")] public DateTime? ToDate { get; set; }


### PR DESCRIPTION
## Summary
- show full title on fixtures page as `Predictotronix | {season} | GW{gameweek}`
- add default document title for pages without specific titles

## Testing
- `dotnet format Predictorator.sln --verbosity diagnostic`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6894a8145814832889da513f2980bae1