### PR TITLE
Fix send predictions email memory

### DIFF
--- a/Predictorator/Components/EmailDialog.razor
+++ b/Predictorator/Components/EmailDialog.razor
@@ -1,7 +1,7 @@
 <MudDialog>
     <DialogContent>
         <MudForm @ref="_form" Model="_model">
-            <MudTextField For="@(() => _model.Email)" Label="Email" InputType="InputType.Email" Required="true" />
+            <MudTextField @bind-Value="_model.Email" For="@(() => _model.Email)" Label="Email" InputType="InputType.Email" Required="true" />
             <MudCheckBox T="bool" @bind-Value="_remember" Label="Remember email" Class="mt-4" />
         </MudForm>
     </DialogContent>


### PR DESCRIPTION
## Summary
- bind email input in send predictions dialog so address is captured and stored
- add bUnit test covering mailto link and localStorage persistence

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689737648b5c8328a059873da8ec143c