### PR TITLE
Fix special recipient email layout

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -469,9 +469,13 @@ public class IndexPageBUnitTests
         Assert.Contains("mailto:vip@example.com", uri);
         var bodyEncoded = uri.Split("&body=")[1];
         var bodyText = Uri.UnescapeDataString(bodyEncoded);
-
-        Assert.StartsWith("[[SPECIAL PRE TEXT]]", bodyText);
-        Assert.EndsWith("[[SPECIAL POST TEXT]]", bodyText.TrimEnd());
+        Assert.StartsWith("Hello Helen Lyttle,", bodyText);
+        var preIndex = bodyText.IndexOf("My predictions are as follows...");
+        var tableIndex = bodyText.IndexOf("Home 1 - 0 Away");
+        var postIndex = bodyText.IndexOf("Yours sincerely,");
+        Assert.True(preIndex < tableIndex);
+        Assert.True(tableIndex < postIndex);
+        Assert.EndsWith("<insert name>.", bodyText.TrimEnd());
     }
 
     private class RecordingNavigationManager : NavigationManager

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -340,10 +340,10 @@ else if (_fixtures.Response.Any())
         sbPre.AppendLine("My predictions are as follows...");
         sbPre.AppendLine("");
         var sbPost = new StringBuilder();
-        sbPre.AppendLine("");
-        sbPre.AppendLine("Yours sincerely,");
-        sbPre.AppendLine("<insert name>.");
-            
+        sbPost.AppendLine("");
+        sbPost.AppendLine("Yours sincerely,");
+        sbPost.AppendLine("<insert name>.");
+
         return $"{sbPre}{body}{sbPost}";
 
     }


### PR DESCRIPTION
## Summary
- fix special recipient email so prediction table appears between pre and post text
- update tests to assert prediction table ordering

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689768f6dd208328a3d17f8c6fd0624e