### PR TITLE
Ensure spacing between special recipient email paragraphs

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -333,8 +333,11 @@ else if (_fixtures.Response.Any())
         sbPre.AppendLine("Hello Helen Lyttle,");
         sbPre.AppendLine("");
         sbPre.AppendLine("I trust you are well.");
+        sbPre.AppendLine("");
         sbPre.AppendLine("I would like to take this opportunity to put on record my continuing gratitude for your tireless efforts in administering the Premier League Prediction League.");
+        sbPre.AppendLine("");
         sbPre.AppendLine("Here is a funny joke I heard recently that I thought you might enjoy...");
+        sbPre.AppendLine("");
         sbPre.AppendLine("<insert joke>.");
         sbPre.AppendLine("");
         sbPre.AppendLine("My predictions are as follows...");
@@ -342,6 +345,7 @@ else if (_fixtures.Response.Any())
         var sbPost = new StringBuilder();
         sbPost.AppendLine("");
         sbPost.AppendLine("Yours sincerely,");
+        sbPost.AppendLine("");
         sbPost.AppendLine("<insert name>.");
 
         return $"{sbPre}{body}{sbPost}";


### PR DESCRIPTION
## Summary
- ensure all paragraphs in the special recipient email are separated by blank lines

## Testing
- `dotnet format Predictorator.sln --include Predictorator/Components/Pages/Index.razor`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68976ca1432083289e8516094245ca7e