### PR TITLE
Add predictions parsing page

### DIFF
--- a/Predictorator.Tests/PredictionEmailParserTests.cs
+++ b/Predictorator.Tests/PredictionEmailParserTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class PredictionEmailParserTests
+{
+    [Fact]
+    public void Parse_ReturnsExpectedPredictions()
+    {
+        var text = @"Saturday, August 17, 2024
+Arsenal 2 - 1 Chelsea
+
+Sunday, August 18, 2024
+Man City 0 - 0 Liverpool
+";
+        var result = PredictionEmailParser.Parse(text);
+
+        Assert.Equal(2, result.Count);
+
+        var first = result[0];
+        Assert.Equal(new DateTime(2024, 8, 17), first.Date);
+        Assert.Equal("Arsenal", first.HomeTeam);
+        Assert.Equal(2, first.HomeScore);
+        Assert.Equal(1, first.AwayScore);
+        Assert.Equal("Chelsea", first.AwayTeam);
+
+        var second = result[1];
+        Assert.Equal(new DateTime(2024, 8, 18), second.Date);
+        Assert.Equal("Man City", second.HomeTeam);
+        Assert.Equal(0, second.HomeScore);
+        Assert.Equal(0, second.AwayScore);
+        Assert.Equal("Liverpool", second.AwayTeam);
+    }
+}

--- a/Predictorator/Components/Pages/Parse.razor
+++ b/Predictorator/Components/Pages/Parse.razor
@@ -1,0 +1,59 @@
+@page "/parse"
+@rendermode InteractiveServer
+@inject IJSRuntime Js
+@using System.Text
+
+<MudStack Spacing="2">
+    <MudText Typo="Typo.h5" Class="my-4" Align="Align.Center">Parse Predictions</MudText>
+    <MudTextField @bind-Value="_name" Label="Name" />
+    <MudTextField @bind-Value="_input" Label="Predictions" Lines="10" />
+    <MudButton OnClick="ParseText" Variant="Variant.Filled" Color="Color.Primary">Parse</MudButton>
+</MudStack>
+
+@if (_predictions.Any())
+{
+    <MudTable Items="_predictions" Dense="true" Class="mt-4">
+        <HeaderContent>
+            <MudTh>Name</MudTh>
+            <MudTh>Date</MudTh>
+            <MudTh>Home Team</MudTh>
+            <MudTh>Home Prediction</MudTh>
+            <MudTh>Away Prediction</MudTh>
+            <MudTh>Away Team</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Name">@_name</MudTd>
+            <MudTd DataLabel="Date">@context.Date.ToString("dd/MM/yyyy")</MudTd>
+            <MudTd DataLabel="Home Team">@context.HomeTeam</MudTd>
+            <MudTd DataLabel="Home Prediction">@context.HomeScore</MudTd>
+            <MudTd DataLabel="Away Prediction">@context.AwayScore</MudTd>
+            <MudTd DataLabel="Away Team">@context.AwayTeam</MudTd>
+        </RowTemplate>
+    </MudTable>
+    <MudButton OnClick="CopyToClipboard" Variant="Variant.Filled" Color="Color.Secondary" Class="mt-4">Copy to Clipboard</MudButton>
+}
+
+@code {
+    private string _name = string.Empty;
+    private string _input = string.Empty;
+    private List<PredictionEmailParser.ParsedPrediction> _predictions = new();
+
+    private void ParseText()
+    {
+        _name = _name.Trim();
+        _predictions = PredictionEmailParser.Parse(_input).ToList();
+    }
+
+    private async Task CopyToClipboard()
+    {
+        if (_predictions.Count == 0)
+            return;
+        _name = _name.Trim();
+        var sb = new StringBuilder();
+        foreach (var p in _predictions)
+        {
+            sb.AppendLine($"{_name}\t{p.Date:dd/MM/yyyy}\t{p.HomeTeam}\t{p.HomeScore}\t{p.AwayScore}\t{p.AwayTeam}");
+        }
+        await Js.InvokeVoidAsync("navigator.clipboard.writeText", sb.ToString());
+    }
+}

--- a/Predictorator/Services/PredictionEmailParser.cs
+++ b/Predictorator/Services/PredictionEmailParser.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Predictorator.Services;
+
+public static class PredictionEmailParser
+{
+    private const string DateFormat = "dddd, MMMM d, yyyy";
+
+    public static IReadOnlyList<ParsedPrediction> Parse(string? text)
+    {
+        var result = new List<ParsedPrediction>();
+        if (string.IsNullOrWhiteSpace(text))
+            return result;
+
+        DateTime? currentDate = null;
+        var lines = text.Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            if (DateTime.TryParseExact(line, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            {
+                currentDate = date.Date;
+                continue;
+            }
+
+            if (!currentDate.HasValue)
+                continue;
+
+            var match = Regex.Match(line, @"^(.*?)\s+(\d+)\s*-\s*(\d+)\s+(.*)$");
+            if (!match.Success)
+                continue;
+
+            var homeTeam = match.Groups[1].Value.Trim();
+            var homeScore = int.Parse(match.Groups[2].Value);
+            var awayScore = int.Parse(match.Groups[3].Value);
+            var awayTeam = match.Groups[4].Value.Trim();
+
+            result.Add(new ParsedPrediction(currentDate.Value, homeTeam, homeScore, awayScore, awayTeam));
+        }
+
+        return result;
+    }
+
+    public record ParsedPrediction(DateTime Date, string HomeTeam, int HomeScore, int AwayScore, string AwayTeam);
+}


### PR DESCRIPTION
## Summary
- add parser page at `/parse` to turn emailed predictions into a table and copy rows for Excel
- implement prediction email parser service and accompanying unit test
- display user name column in parsed predictions table and include it in clipboard export

## Testing
- `dotnet format Predictorator.sln --verbosity diagnostic`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68979948436c83288a10f202398fca00