### PR TITLE
Show fixture results on parse page

### DIFF
--- a/Predictorator.Tests/ParsePageBUnitTests.cs
+++ b/Predictorator.Tests/ParsePageBUnitTests.cs
@@ -1,0 +1,97 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using Predictorator.Components.Pages;
+using Predictorator.Models.Fixtures;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+
+namespace Predictorator.Tests;
+
+public class ParsePageBUnitTests
+{
+    private BunitContext CreateContext(FixturesResponse fixtures, DateTime now)
+    {
+        var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
+        ctx.Services.AddSingleton<IDateTimeProvider>(new FakeDateTimeProvider { UtcNow = now, Today = now.Date });
+        return ctx;
+    }
+
+    [Fact]
+    public async Task ShowsActualScores_WhenPastThreshold()
+    {
+        var fixtureTime = new DateTime(2024, 1, 1, 15, 0, 0, DateTimeKind.Utc);
+        var fixtures = new FixturesResponse
+        {
+            FromDate = fixtureTime.Date,
+            ToDate = fixtureTime.Date,
+            Response =
+            [
+                new FixtureData
+                {
+                    Fixture = new Fixture { Id = 1, Date = fixtureTime, Venue = new Venue() },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Team A" },
+                        Away = new Team { Name = "Team B" }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = 3, Away = 2 } }
+                }
+            ]
+        };
+
+        const string text = "Monday, January 1, 2024\nTeam A 1 - 2 Team B";
+        await using var ctx = CreateContext(fixtures, fixtureTime.AddHours(4));
+        var cut = ctx.Render<Parse>();
+        cut.Find("input").Change("Bob");
+        cut.Find("textarea").Change(text);
+        cut.Find("button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal("3", cut.Find("td[data-label='Home Actual']").TextContent);
+            Assert.Equal("2", cut.Find("td[data-label='Away Actual']").TextContent);
+        });
+    }
+
+    [Fact]
+    public async Task DoesNotShowScores_BeforeThreshold()
+    {
+        var fixtureTime = new DateTime(2024, 1, 1, 15, 0, 0, DateTimeKind.Utc);
+        var fixtures = new FixturesResponse
+        {
+            FromDate = fixtureTime.Date,
+            ToDate = fixtureTime.Date,
+            Response =
+            [
+                new FixtureData
+                {
+                    Fixture = new Fixture { Id = 1, Date = fixtureTime, Venue = new Venue() },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Team A" },
+                        Away = new Team { Name = "Team B" }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = 3, Away = 2 } }
+                }
+            ]
+        };
+
+        const string text = "Monday, January 1, 2024\nTeam A 1 - 2 Team B";
+        await using var ctx = CreateContext(fixtures, fixtureTime.AddHours(2));
+        var cut = ctx.Render<Parse>();
+        cut.Find("input").Change("Bob");
+        cut.Find("textarea").Change(text);
+        cut.Find("button").Click();
+
+        cut.WaitForAssertion(() =>
+        {
+            Assert.Equal(string.Empty, cut.Find("td[data-label='Home Actual']").TextContent);
+            Assert.Equal(string.Empty, cut.Find("td[data-label='Away Actual']").TextContent);
+        });
+    }
+}
+

--- a/Predictorator/Components/Pages/Parse.razor
+++ b/Predictorator/Components/Pages/Parse.razor
@@ -1,7 +1,10 @@
 @page "/parse"
 @rendermode InteractiveServer
 @inject IJSRuntime Js
+@inject IFixtureService FixtureService
+@inject IDateTimeProvider TimeProvider
 @using System.Text
+@using Predictorator.Services
 
 <MudStack Spacing="2">
     <MudText Typo="Typo.h5" Class="my-4" Align="Align.Center">Parse Predictions</MudText>
@@ -18,7 +21,9 @@
             <MudTh>Date</MudTh>
             <MudTh>Home Team</MudTh>
             <MudTh>Home Prediction</MudTh>
+            <MudTh>Home Actual</MudTh>
             <MudTh>Away Prediction</MudTh>
+            <MudTh>Away Actual</MudTh>
             <MudTh>Away Team</MudTh>
         </HeaderContent>
         <RowTemplate>
@@ -26,7 +31,9 @@
             <MudTd DataLabel="Date">@context.Date.ToString("dd/MM/yyyy")</MudTd>
             <MudTd DataLabel="Home Team">@context.HomeTeam</MudTd>
             <MudTd DataLabel="Home Prediction">@context.HomeScore</MudTd>
+            <MudTd DataLabel="Home Actual">@context.ActualHomeScore</MudTd>
             <MudTd DataLabel="Away Prediction">@context.AwayScore</MudTd>
+            <MudTd DataLabel="Away Actual">@context.ActualAwayScore</MudTd>
             <MudTd DataLabel="Away Team">@context.AwayTeam</MudTd>
         </RowTemplate>
     </MudTable>
@@ -36,12 +43,57 @@
 @code {
     private string _name = string.Empty;
     private string _input = string.Empty;
-    private List<PredictionEmailParser.ParsedPrediction> _predictions = new();
+    private List<Prediction> _predictions = new();
 
-    private void ParseText()
+    private async Task ParseText()
     {
         _name = _name.Trim();
-        _predictions = PredictionEmailParser.Parse(_input).ToList();
+        var parsed = PredictionEmailParser.Parse(_input).ToList();
+        _predictions = parsed.Select(p => new Prediction
+        {
+            Date = p.Date,
+            HomeTeam = p.HomeTeam,
+            HomeScore = p.HomeScore,
+            AwayScore = p.AwayScore,
+            AwayTeam = p.AwayTeam
+        }).ToList();
+
+        if (_predictions.Count == 0)
+            return;
+
+        var from = _predictions.Min(p => p.Date);
+        var to = _predictions.Max(p => p.Date);
+
+        var fixtures = await FixtureService.GetFixturesAsync(from, to);
+        var lookup = fixtures.Response.ToDictionary(
+            f => (f.Fixture.Date.Date,
+                   f.Teams.Home.Name.ToLowerInvariant(),
+                   f.Teams.Away.Name.ToLowerInvariant()));
+
+        DateTime? lastFixtureTime = null;
+        foreach (var p in _predictions)
+        {
+            var key = (p.Date.Date, p.HomeTeam.ToLowerInvariant(), p.AwayTeam.ToLowerInvariant());
+            if (lookup.TryGetValue(key, out var fixture))
+            {
+                var fixtureDate = DateTime.SpecifyKind(fixture.Fixture.Date, DateTimeKind.Utc);
+                if (lastFixtureTime == null || fixtureDate > lastFixtureTime)
+                    lastFixtureTime = fixtureDate;
+            }
+        }
+
+        if (lastFixtureTime.HasValue && TimeProvider.UtcNow >= lastFixtureTime.Value.AddHours(3))
+        {
+            foreach (var p in _predictions)
+            {
+                var key = (p.Date.Date, p.HomeTeam.ToLowerInvariant(), p.AwayTeam.ToLowerInvariant());
+                if (lookup.TryGetValue(key, out var fixture))
+                {
+                    p.ActualHomeScore = fixture.Score?.Fulltime.Home;
+                    p.ActualAwayScore = fixture.Score?.Fulltime.Away;
+                }
+            }
+        }
     }
 
     private async Task CopyToClipboard()
@@ -55,5 +107,16 @@
             sb.AppendLine($"{_name}\t{p.Date:dd/MM/yyyy}\t{p.HomeTeam}\t{p.HomeScore}\t{p.AwayScore}\t{p.AwayTeam}");
         }
         await Js.InvokeVoidAsync("navigator.clipboard.writeText", sb.ToString());
+    }
+
+    private class Prediction
+    {
+        public DateTime Date { get; init; }
+        public string HomeTeam { get; init; } = string.Empty;
+        public int HomeScore { get; init; }
+        public int AwayScore { get; init; }
+        public string AwayTeam { get; init; } = string.Empty;
+        public int? ActualHomeScore { get; set; }
+        public int? ActualAwayScore { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- fetch fixture scores in parse view and display actual home and away results once matches are 3+ hours old
- add bUnit tests for parse page covering score visibility

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689843a6263c83289eec531c217ec81e