### PR TITLE
Ensure parse table always renders in table layout

### DIFF
--- a/Predictorator/Components/Pages/Parse.razor
+++ b/Predictorator/Components/Pages/Parse.razor
@@ -15,7 +15,7 @@
 
 @if (_predictions.Any())
 {
-    <MudTable Items="_predictions" Dense="true" Class="mt-4">
+    <MudTable Items="_predictions" Dense="true" Class="mt-4" Breakpoint="Breakpoint.None">
         <HeaderContent>
             <MudTh>Name</MudTh>
             <MudTh>Date</MudTh>


### PR DESCRIPTION
## Summary
- prevent Parse page table from switching to cards on small screens by setting `Breakpoint.None`

## Testing
- `dotnet format Predictorator.sln --verbosity diagnostic`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68984a5843d08328b74b51d6b0557c7d