### PR TITLE
Schedule weekly check for expired subscriptions

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -215,9 +215,9 @@ if (!app.Environment.IsEnvironment("Testing"))
             TimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")
         });
     RecurringJob.AddOrUpdate<SubscriptionService>(
-        "cleanup-unverified",
-        service => service.RemoveExpiredUnverifiedAsync(),
-        "*/15 * * * *",
+        "check-unverified-expired",
+        service => service.CountExpiredUnverifiedAsync(),
+        "0 1 * * 1",
         new RecurringJobOptions
         {
             TimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time")

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ is provided at `.env.example`. Copy this file to `.env` and update the values
 as needed before running the containers.
 
 Verification links sent to subscribers are valid for one hour. A background job
-runs every 15 minutes to remove unverified subscriptions that have expired.
+runs weekly to calculate unverified subscriptions that have expired.
 
 Ceefax mode provides a retro Teletext-inspired theme. When enabled, dark mode is
 also automatically activated for optimal contrast. If no prior preference is


### PR DESCRIPTION
## Summary
- Count expired unverified subscriptions instead of deleting them
- Run weekly Hangfire job to report expired subscriptions
- Update tests and docs for new weekly check

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_6898e86ac0f88328aa62c87e6804a012