### PR TITLE
Lower production logging level and cap log files

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -35,14 +35,15 @@ builder.Host.UseSerilog((context, services, configuration) =>
 {
     var logDir = Path.Combine(context.HostingEnvironment.ContentRootPath, "logs");
     Directory.CreateDirectory(logDir);
+    var minLevel = context.HostingEnvironment.IsProduction() ? LogEventLevel.Warning : LogEventLevel.Information;
     configuration
-        .MinimumLevel.Information()
+        .MinimumLevel.Is(minLevel)
         .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
         .Enrich.FromLogContext()
         .ReadFrom.Configuration(context.Configuration)
-        .WriteTo.File(Path.Combine(logDir, "app.log"), rollingInterval: RollingInterval.Day)
+        .WriteTo.File(Path.Combine(logDir, "app.log"), rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7)
         .WriteTo.Console()
-        .WriteTo.AzureApp();
+        .WriteTo.AzureApp(restrictedToMinimumLevel: minLevel);
 });
 
 var error = StartupValidator.Validate(builder);


### PR DESCRIPTION
## Summary
- reduce Serilog minimum level to Warning in production
- cap log file retention to 7 days
- align Azure App logging with environment log level

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6898eb68421c8328a5c2e927f21f6117