### PR TITLE
Guard EF Core logging in production

### DIFF
--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -104,10 +104,15 @@ builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =
     var efLogger = loggerFactory.CreateLogger("EFCore");
     options
         .UseSqlServer(connectionString)
-        .UseLoggerFactory(loggerFactory)
-        .EnableDetailedErrors()
-        .EnableSensitiveDataLogging()
-        .LogTo(message => efLogger.LogError(message), LogLevel.Error);
+        .UseLoggerFactory(loggerFactory);
+
+    if (builder.Environment.IsDevelopment())
+    {
+        options.EnableDetailedErrors()
+            .EnableSensitiveDataLogging();
+    }
+
+    options.LogTo(message => efLogger.LogError(message), LogLevel.Error);
 });
 builder.Services.AddDbContextFactory<ApplicationDbContext>((serviceProvider, options) =>
 {
@@ -115,10 +120,15 @@ builder.Services.AddDbContextFactory<ApplicationDbContext>((serviceProvider, opt
     var efLogger = loggerFactory.CreateLogger("EFCore");
     options
         .UseSqlServer(connectionString)
-        .UseLoggerFactory(loggerFactory)
-        .EnableDetailedErrors()
-        .EnableSensitiveDataLogging()
-        .LogTo(message => efLogger.LogError(message), LogLevel.Error);
+        .UseLoggerFactory(loggerFactory);
+
+    if (builder.Environment.IsDevelopment())
+    {
+        options.EnableDetailedErrors()
+            .EnableSensitiveDataLogging();
+    }
+
+    options.LogTo(message => efLogger.LogError(message), LogLevel.Error);
 });
 builder.Services.AddIdentity<IdentityUser, IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()


### PR DESCRIPTION
## Summary
- Guard EF Core detailed error and sensitive data logging options behind `IsDevelopment` checks

## Testing
- `dotnet format Predictorator.sln --verify-no-changes --verbosity normal`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6898eb69f5388328bd610e8e3fafff72