### PR TITLE
Configure Hangfire settings

### DIFF
--- a/Predictorator/Options/HangfireOptions.cs
+++ b/Predictorator/Options/HangfireOptions.cs
@@ -1,0 +1,13 @@
+namespace Predictorator.Options;
+
+public class HangfireOptions
+{
+    public const string SectionName = "Hangfire";
+
+    public bool RunServer { get; set; } = true;
+    public int QueuePollIntervalSeconds { get; set; } = 120;
+    public int SchedulePollingIntervalSeconds { get; set; } = 120;
+    public int ServerCheckIntervalSeconds { get; set; } = 120;
+    public int HeartbeatIntervalSeconds { get; set; } = 120;
+    public int WorkerCount { get; set; } = 1;
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -6,6 +6,7 @@ using MudBlazor.Services;
 using Predictorator.Components;
 using Hangfire;
 using Hangfire.Dashboard;
+using Hangfire.SqlServer;
 using Predictorator.Data;
 using Predictorator.Options;
 using Predictorator.Services;
@@ -96,6 +97,7 @@ builder.Services.Configure<AdminUserOptions>(options =>
     options.Email = builder.Configuration["ADMIN_EMAIL"] ?? options.Email;
     options.Password = builder.Configuration["ADMIN_PASSWORD"] ?? options.Password;
 });
+builder.Services.Configure<HangfireOptions>(builder.Configuration.GetSection(HangfireOptions.SectionName));
 
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!;
 builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =>
@@ -148,10 +150,25 @@ builder.Services.AddScoped<ISignInService, SignInManagerSignInService>();
 builder.Services.AddAuthorization();
 builder.Services.AddRazorPages();
 
+var hangfireOptions = builder.Configuration.GetSection(HangfireOptions.SectionName).Get<HangfireOptions>() ?? new HangfireOptions();
 if (!builder.Environment.IsEnvironment("Testing"))
 {
-    builder.Services.AddHangfire(config => config.UseSqlServerStorage(connectionString));
-    builder.Services.AddHangfireServer();
+    builder.Services.AddHangfire(config =>
+        config.UseSqlServerStorage(connectionString, new SqlServerStorageOptions
+        {
+            QueuePollInterval = TimeSpan.FromSeconds(hangfireOptions.QueuePollIntervalSeconds)
+        }));
+
+    if (hangfireOptions.RunServer)
+    {
+        builder.Services.AddHangfireServer(options =>
+        {
+            options.SchedulePollingInterval = TimeSpan.FromSeconds(hangfireOptions.SchedulePollingIntervalSeconds);
+            options.ServerCheckInterval = TimeSpan.FromSeconds(hangfireOptions.ServerCheckIntervalSeconds);
+            options.HeartbeatInterval = TimeSpan.FromSeconds(hangfireOptions.HeartbeatIntervalSeconds);
+            options.WorkerCount = hangfireOptions.WorkerCount;
+        });
+    }
 }
 
 var keyPath = builder.Configuration["DataProtection:KeyPath"];

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -11,5 +11,13 @@
   "GameWeekCache": {
     "CacheDurationHours": 2
   },
+  "Hangfire": {
+    "RunServer": true,
+    "QueuePollIntervalSeconds": 120,
+    "SchedulePollingIntervalSeconds": 120,
+    "ServerCheckIntervalSeconds": 120,
+    "HeartbeatIntervalSeconds": 120,
+    "WorkerCount": 1
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- add HangfireOptions with cost-saving defaults
- wire Hangfire to use configured polling intervals and worker count
- document default Hangfire values in appsettings

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`
- `dotnet format Predictorator.sln --verify-no-changes`

------
https://chatgpt.com/codex/tasks/task_e_6898ec93d3d48328b67bf907645a2068