### PR TITLE
Add optional Azure Table storage backend

### DIFF
--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -47,10 +47,11 @@ public class AdminServiceTests
         var nLogger = NullLogger<NotificationService>.Instance;
         var gameWeeks = new FakeGameWeekService();
         gameWeeks.Items.Add(new GameWeek { Season = "25-26", Number = 1, StartDate = provider.UtcNow.Date, EndDate = provider.UtcNow.Date.AddDays(6) });
-        var notifications = new NotificationService(db, resend, sms, config, fixtures, gameWeeks, range, features, provider, jobs, inliner, renderer, nLogger);
+        var store = new EfDataStore(db);
+        var notifications = new NotificationService(store, resend, sms, config, fixtures, gameWeeks, range, features, provider, jobs, inliner, renderer, nLogger);
         var aLogger = NullLogger<AdminService>.Instance;
         var prefix = new CachePrefixService();
-        return new AdminService(db, resend, sms, config, inliner, renderer, notifications, aLogger, jobs, provider, prefix);
+        return new AdminService(store, resend, sms, config, inliner, renderer, notifications, aLogger, jobs, provider, prefix);
     }
 
     [Fact]

--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -26,6 +26,7 @@ public class NotificationServiceTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         db = new ApplicationDbContext(options);
+        var store = new EfDataStore(db);
         jobs = Substitute.For<IBackgroundJobClient>();
         resend = Substitute.For<IResend>();
         sms = Substitute.For<ITwilioSmsSender>();
@@ -66,7 +67,7 @@ public class NotificationServiceTests
         var gameWeeks = new FakeGameWeekService();
         gameWeeks.Items.Add(new GameWeek { Season = "25-26", Number = 1, StartDate = nowUtc.Date, EndDate = nowUtc.Date.AddDays(6) });
         var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<NotificationService>.Instance;
-        return new NotificationService(db, resend, sms, config, fixtures, gameWeeks, calculator, features, provider, jobs, inliner, renderer, logger);
+        return new NotificationService(store, resend, sms, config, fixtures, gameWeeks, calculator, features, provider, jobs, inliner, renderer, logger);
     }
 
     [Fact]

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -39,6 +39,7 @@ public class SubscribeComponentBUnitTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         var db = new ApplicationDbContext(options);
+        var store = new EfDataStore(db);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
         var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
@@ -50,7 +51,7 @@ public class SubscribeComponentBUnitTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer, logger));
+        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, jobs, inliner, renderer, logger));
         return ctx;
     }
 

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -22,6 +22,7 @@ public class SubscriptionServiceTests
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         db = new ApplicationDbContext(options);
+        var store = new EfDataStore(db);
         resend = Substitute.For<IResend>();
         sms = Substitute.For<ITwilioSmsSender>();
         jobs = Substitute.For<IBackgroundJobClient>();
@@ -33,7 +34,7 @@ public class SubscriptionServiceTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        return new SubscriptionService(db, resend, config, sms, provider, jobs, inliner, renderer, logger);
+        return new SubscriptionService(store, resend, config, sms, provider, jobs, inliner, renderer, logger);
     }
 
     [Fact]

--- a/Predictorator.Tests/UnsubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/UnsubscribeComponentBUnitTests.cs
@@ -42,6 +42,7 @@ public class UnsubscribeComponentBUnitTests
             .Options;
         var db = new ApplicationDbContext(options);
         ctx.Services.AddSingleton(db);
+        var store = new EfDataStore(db);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
         var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
@@ -53,7 +54,7 @@ public class UnsubscribeComponentBUnitTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer, logger));
+        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, jobs, inliner, renderer, logger));
         return ctx;
     }
 

--- a/Predictorator.Tests/VerifyComponentBUnitTests.cs
+++ b/Predictorator.Tests/VerifyComponentBUnitTests.cs
@@ -42,6 +42,7 @@ public class VerifyComponentBUnitTests
             .Options;
         var db = new ApplicationDbContext(options);
         ctx.Services.AddSingleton(db);
+        var store = new EfDataStore(db);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
         var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
@@ -53,7 +54,7 @@ public class VerifyComponentBUnitTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        ctx.Services.AddSingleton(new SubscriptionService(db, resend, config, sms, time, jobs, inliner, renderer, logger));
+        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, jobs, inliner, renderer, logger));
         return ctx;
     }
 

--- a/Predictorator/Data/EfDataStore.cs
+++ b/Predictorator/Data/EfDataStore.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Models;
+
+namespace Predictorator.Data;
+
+public class EfDataStore : IDataStore
+{
+    private readonly ApplicationDbContext _db;
+
+    public EfDataStore(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    // Email subscribers
+    public Task<bool> EmailSubscriberExistsAsync(string email) =>
+        _db.Subscribers.AnyAsync(s => s.Email == email);
+
+    public async Task AddEmailSubscriberAsync(Subscriber subscriber)
+    {
+        _db.Subscribers.Add(subscriber);
+        await _db.SaveChangesAsync();
+    }
+
+    public Task<Subscriber?> GetEmailSubscriberByVerificationTokenAsync(string token) =>
+        _db.Subscribers.FirstOrDefaultAsync(s => s.VerificationToken == token);
+
+    public Task<Subscriber?> GetEmailSubscriberByUnsubscribeTokenAsync(string token) =>
+        _db.Subscribers.FirstOrDefaultAsync(s => s.UnsubscribeToken == token);
+
+    public Task<int> CountExpiredEmailSubscribersAsync(DateTime cutoff) =>
+        _db.Subscribers.CountAsync(s => !s.IsVerified && s.CreatedAt < cutoff);
+
+    public Task<Subscriber?> GetEmailSubscriberByEmailAsync(string normalizedEmail) =>
+        _db.Subscribers.FirstOrDefaultAsync(s => s.Email.ToLower() == normalizedEmail);
+
+    public Task<List<Subscriber>> GetEmailSubscribersAsync() =>
+        _db.Subscribers.ToListAsync();
+
+    public Task<List<Subscriber>> GetVerifiedEmailSubscribersAsync() =>
+        _db.Subscribers.Where(s => s.IsVerified).ToListAsync();
+
+    public Task<Subscriber?> GetEmailSubscriberByIdAsync(int id) =>
+        _db.Subscribers.FirstOrDefaultAsync(s => s.Id == id);
+
+    public async Task UpdateEmailSubscriberAsync(Subscriber subscriber)
+    {
+        _db.Subscribers.Update(subscriber);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task RemoveEmailSubscriberAsync(Subscriber subscriber)
+    {
+        _db.Subscribers.Remove(subscriber);
+        await _db.SaveChangesAsync();
+    }
+
+    // SMS subscribers
+    public Task<bool> SmsSubscriberExistsAsync(string phoneNumber) =>
+        _db.SmsSubscribers.AnyAsync(s => s.PhoneNumber == phoneNumber);
+
+    public async Task AddSmsSubscriberAsync(SmsSubscriber subscriber)
+    {
+        _db.SmsSubscribers.Add(subscriber);
+        await _db.SaveChangesAsync();
+    }
+
+    public Task<SmsSubscriber?> GetSmsSubscriberByVerificationTokenAsync(string token) =>
+        _db.SmsSubscribers.FirstOrDefaultAsync(s => s.VerificationToken == token);
+
+    public Task<SmsSubscriber?> GetSmsSubscriberByUnsubscribeTokenAsync(string token) =>
+        _db.SmsSubscribers.FirstOrDefaultAsync(s => s.UnsubscribeToken == token);
+
+    public Task<int> CountExpiredSmsSubscribersAsync(DateTime cutoff) =>
+        _db.SmsSubscribers.CountAsync(s => !s.IsVerified && s.CreatedAt < cutoff);
+
+    public Task<List<SmsSubscriber>> GetSmsSubscribersAsync() =>
+        _db.SmsSubscribers.ToListAsync();
+
+    public Task<List<SmsSubscriber>> GetVerifiedSmsSubscribersAsync() =>
+        _db.SmsSubscribers.Where(s => s.IsVerified).ToListAsync();
+
+    public Task<SmsSubscriber?> GetSmsSubscriberByIdAsync(int id) =>
+        _db.SmsSubscribers.FirstOrDefaultAsync(s => s.Id == id);
+
+    public async Task UpdateSmsSubscriberAsync(SmsSubscriber subscriber)
+    {
+        _db.SmsSubscribers.Update(subscriber);
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task RemoveSmsSubscriberAsync(SmsSubscriber subscriber)
+    {
+        _db.SmsSubscribers.Remove(subscriber);
+        await _db.SaveChangesAsync();
+    }
+
+    // Sent notifications
+    public Task<bool> SentNotificationExistsAsync(string type, string key) =>
+        _db.SentNotifications.AnyAsync(n => n.Type == type && n.Key == key);
+
+    public async Task AddSentNotificationAsync(SentNotification notification)
+    {
+        _db.SentNotifications.Add(notification);
+        await _db.SaveChangesAsync();
+    }
+}

--- a/Predictorator/Data/IDataStore.cs
+++ b/Predictorator/Data/IDataStore.cs
@@ -1,0 +1,35 @@
+using Predictorator.Models;
+
+namespace Predictorator.Data;
+
+public interface IDataStore
+{
+    // Email subscribers
+    Task<bool> EmailSubscriberExistsAsync(string email);
+    Task AddEmailSubscriberAsync(Subscriber subscriber);
+    Task<Subscriber?> GetEmailSubscriberByVerificationTokenAsync(string token);
+    Task<Subscriber?> GetEmailSubscriberByUnsubscribeTokenAsync(string token);
+    Task<int> CountExpiredEmailSubscribersAsync(DateTime cutoff);
+    Task<Subscriber?> GetEmailSubscriberByEmailAsync(string normalizedEmail);
+    Task<List<Subscriber>> GetEmailSubscribersAsync();
+    Task<List<Subscriber>> GetVerifiedEmailSubscribersAsync();
+    Task<Subscriber?> GetEmailSubscriberByIdAsync(int id);
+    Task UpdateEmailSubscriberAsync(Subscriber subscriber);
+    Task RemoveEmailSubscriberAsync(Subscriber subscriber);
+
+    // SMS subscribers
+    Task<bool> SmsSubscriberExistsAsync(string phoneNumber);
+    Task AddSmsSubscriberAsync(SmsSubscriber subscriber);
+    Task<SmsSubscriber?> GetSmsSubscriberByVerificationTokenAsync(string token);
+    Task<SmsSubscriber?> GetSmsSubscriberByUnsubscribeTokenAsync(string token);
+    Task<int> CountExpiredSmsSubscribersAsync(DateTime cutoff);
+    Task<List<SmsSubscriber>> GetSmsSubscribersAsync();
+    Task<List<SmsSubscriber>> GetVerifiedSmsSubscribersAsync();
+    Task<SmsSubscriber?> GetSmsSubscriberByIdAsync(int id);
+    Task UpdateSmsSubscriberAsync(SmsSubscriber subscriber);
+    Task RemoveSmsSubscriberAsync(SmsSubscriber subscriber);
+
+    // Sent notifications
+    Task<bool> SentNotificationExistsAsync(string type, string key);
+    Task AddSentNotificationAsync(SentNotification notification);
+}

--- a/Predictorator/Data/TableDataStore.cs
+++ b/Predictorator/Data/TableDataStore.cs
@@ -1,0 +1,312 @@
+using Azure;
+using Azure.Data.Tables;
+using Predictorator.Models;
+
+namespace Predictorator.Data;
+
+public class TableDataStore : IDataStore
+{
+    private readonly TableClient _emailSubscribers;
+    private readonly TableClient _smsSubscribers;
+    private readonly TableClient _sentNotifications;
+
+    public TableDataStore(TableServiceClient client)
+    {
+        _emailSubscribers = client.GetTableClient("EmailSubscribers");
+        _emailSubscribers.CreateIfNotExists();
+        _smsSubscribers = client.GetTableClient("SmsSubscribers");
+        _smsSubscribers.CreateIfNotExists();
+        _sentNotifications = client.GetTableClient("SentNotifications");
+        _sentNotifications.CreateIfNotExists();
+    }
+
+    private static Subscriber ToSubscriber(SubscriberEntity e) => new()
+    {
+        Id = e.Id,
+        Email = e.Email,
+        IsVerified = e.IsVerified,
+        VerificationToken = e.VerificationToken,
+        UnsubscribeToken = e.UnsubscribeToken,
+        CreatedAt = e.CreatedAt
+    };
+
+    private static SmsSubscriber ToSmsSubscriber(SmsSubscriberEntity e) => new()
+    {
+        Id = e.Id,
+        PhoneNumber = e.PhoneNumber,
+        IsVerified = e.IsVerified,
+        VerificationToken = e.VerificationToken,
+        UnsubscribeToken = e.UnsubscribeToken,
+        CreatedAt = e.CreatedAt
+    };
+
+    private async Task<int> GetNextIdAsync(TableClient table)
+    {
+        var max = 0;
+        await foreach (var e in table.QueryAsync<TableEntity>(select: new[] { "Id" }))
+        {
+            if (e.TryGetValue("Id", out object? obj) && obj is int id && id > max)
+                max = id;
+        }
+        return max + 1;
+    }
+
+    // Email subscribers
+    public async Task<bool> EmailSubscriberExistsAsync(string email)
+    {
+        await foreach (var _ in _emailSubscribers.QueryAsync<SubscriberEntity>(e => e.Email == email))
+            return true;
+        return false;
+    }
+
+    public async Task AddEmailSubscriberAsync(Subscriber subscriber)
+    {
+        subscriber.Id = await GetNextIdAsync(_emailSubscribers);
+        var entity = new SubscriberEntity
+        {
+            PartitionKey = "E",
+            RowKey = subscriber.Id.ToString(),
+            Id = subscriber.Id,
+            Email = subscriber.Email,
+            IsVerified = subscriber.IsVerified,
+            VerificationToken = subscriber.VerificationToken,
+            UnsubscribeToken = subscriber.UnsubscribeToken,
+            CreatedAt = subscriber.CreatedAt
+        };
+        await _emailSubscribers.AddEntityAsync(entity);
+    }
+
+    public async Task<Subscriber?> GetEmailSubscriberByVerificationTokenAsync(string token)
+    {
+        await foreach (var e in _emailSubscribers.QueryAsync<SubscriberEntity>(e => e.VerificationToken == token))
+            return ToSubscriber(e);
+        return null;
+    }
+
+    public async Task<Subscriber?> GetEmailSubscriberByUnsubscribeTokenAsync(string token)
+    {
+        await foreach (var e in _emailSubscribers.QueryAsync<SubscriberEntity>(e => e.UnsubscribeToken == token))
+            return ToSubscriber(e);
+        return null;
+    }
+
+    public async Task<int> CountExpiredEmailSubscribersAsync(DateTime cutoff)
+    {
+        var count = 0;
+        await foreach (var _ in _emailSubscribers.QueryAsync<SubscriberEntity>(e => !e.IsVerified && e.CreatedAt < cutoff))
+            count++;
+        return count;
+    }
+
+    public async Task<Subscriber?> GetEmailSubscriberByEmailAsync(string normalizedEmail)
+    {
+        await foreach (var e in _emailSubscribers.QueryAsync<SubscriberEntity>(e => e.Email.ToLower() == normalizedEmail))
+            return ToSubscriber(e);
+        return null;
+    }
+
+    public async Task<List<Subscriber>> GetEmailSubscribersAsync()
+    {
+        var list = new List<Subscriber>();
+        await foreach (var e in _emailSubscribers.QueryAsync<SubscriberEntity>())
+            list.Add(ToSubscriber(e));
+        return list;
+    }
+
+    public async Task<List<Subscriber>> GetVerifiedEmailSubscribersAsync()
+    {
+        var list = new List<Subscriber>();
+        await foreach (var e in _emailSubscribers.QueryAsync<SubscriberEntity>(e => e.IsVerified))
+            list.Add(ToSubscriber(e));
+        return list;
+    }
+
+    public async Task<Subscriber?> GetEmailSubscriberByIdAsync(int id)
+    {
+        try
+        {
+            var e = await _emailSubscribers.GetEntityAsync<SubscriberEntity>("E", id.ToString());
+            return ToSubscriber(e.Value);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task UpdateEmailSubscriberAsync(Subscriber subscriber)
+    {
+        var entity = new SubscriberEntity
+        {
+            PartitionKey = "E",
+            RowKey = subscriber.Id.ToString(),
+            Id = subscriber.Id,
+            Email = subscriber.Email,
+            IsVerified = subscriber.IsVerified,
+            VerificationToken = subscriber.VerificationToken,
+            UnsubscribeToken = subscriber.UnsubscribeToken,
+            CreatedAt = subscriber.CreatedAt
+        };
+        await _emailSubscribers.UpsertEntityAsync(entity, TableUpdateMode.Replace);
+    }
+
+    public Task RemoveEmailSubscriberAsync(Subscriber subscriber) =>
+        _emailSubscribers.DeleteEntityAsync("E", subscriber.Id.ToString());
+
+    // SMS subscribers
+    public async Task<bool> SmsSubscriberExistsAsync(string phoneNumber)
+    {
+        await foreach (var _ in _smsSubscribers.QueryAsync<SmsSubscriberEntity>(e => e.PhoneNumber == phoneNumber))
+            return true;
+        return false;
+    }
+
+    public async Task AddSmsSubscriberAsync(SmsSubscriber subscriber)
+    {
+        subscriber.Id = await GetNextIdAsync(_smsSubscribers);
+        var entity = new SmsSubscriberEntity
+        {
+            PartitionKey = "S",
+            RowKey = subscriber.Id.ToString(),
+            Id = subscriber.Id,
+            PhoneNumber = subscriber.PhoneNumber,
+            IsVerified = subscriber.IsVerified,
+            VerificationToken = subscriber.VerificationToken,
+            UnsubscribeToken = subscriber.UnsubscribeToken,
+            CreatedAt = subscriber.CreatedAt
+        };
+        await _smsSubscribers.AddEntityAsync(entity);
+    }
+
+    public async Task<SmsSubscriber?> GetSmsSubscriberByVerificationTokenAsync(string token)
+    {
+        await foreach (var e in _smsSubscribers.QueryAsync<SmsSubscriberEntity>(e => e.VerificationToken == token))
+            return ToSmsSubscriber(e);
+        return null;
+    }
+
+    public async Task<SmsSubscriber?> GetSmsSubscriberByUnsubscribeTokenAsync(string token)
+    {
+        await foreach (var e in _smsSubscribers.QueryAsync<SmsSubscriberEntity>(e => e.UnsubscribeToken == token))
+            return ToSmsSubscriber(e);
+        return null;
+    }
+
+    public async Task<int> CountExpiredSmsSubscribersAsync(DateTime cutoff)
+    {
+        var count = 0;
+        await foreach (var _ in _smsSubscribers.QueryAsync<SmsSubscriberEntity>(e => !e.IsVerified && e.CreatedAt < cutoff))
+            count++;
+        return count;
+    }
+
+    public async Task<List<SmsSubscriber>> GetSmsSubscribersAsync()
+    {
+        var list = new List<SmsSubscriber>();
+        await foreach (var e in _smsSubscribers.QueryAsync<SmsSubscriberEntity>())
+            list.Add(ToSmsSubscriber(e));
+        return list;
+    }
+
+    public async Task<List<SmsSubscriber>> GetVerifiedSmsSubscribersAsync()
+    {
+        var list = new List<SmsSubscriber>();
+        await foreach (var e in _smsSubscribers.QueryAsync<SmsSubscriberEntity>(e => e.IsVerified))
+            list.Add(ToSmsSubscriber(e));
+        return list;
+    }
+
+    public async Task<SmsSubscriber?> GetSmsSubscriberByIdAsync(int id)
+    {
+        try
+        {
+            var e = await _smsSubscribers.GetEntityAsync<SmsSubscriberEntity>("S", id.ToString());
+            return ToSmsSubscriber(e.Value);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task UpdateSmsSubscriberAsync(SmsSubscriber subscriber)
+    {
+        var entity = new SmsSubscriberEntity
+        {
+            PartitionKey = "S",
+            RowKey = subscriber.Id.ToString(),
+            Id = subscriber.Id,
+            PhoneNumber = subscriber.PhoneNumber,
+            IsVerified = subscriber.IsVerified,
+            VerificationToken = subscriber.VerificationToken,
+            UnsubscribeToken = subscriber.UnsubscribeToken,
+            CreatedAt = subscriber.CreatedAt
+        };
+        await _smsSubscribers.UpsertEntityAsync(entity, TableUpdateMode.Replace);
+    }
+
+    public Task RemoveSmsSubscriberAsync(SmsSubscriber subscriber) =>
+        _smsSubscribers.DeleteEntityAsync("S", subscriber.Id.ToString());
+
+    // Sent notifications
+    public async Task<bool> SentNotificationExistsAsync(string type, string key)
+    {
+        try
+        {
+            await _sentNotifications.GetEntityAsync<SentNotificationEntity>(type, key);
+            return true;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return false;
+        }
+    }
+
+    public async Task AddSentNotificationAsync(SentNotification notification)
+    {
+        var entity = new SentNotificationEntity
+        {
+            PartitionKey = notification.Type,
+            RowKey = notification.Key,
+            SentAt = notification.SentAt
+        };
+        await _sentNotifications.UpsertEntityAsync(entity);
+    }
+
+    private class SubscriberEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; } = "E";
+        public string RowKey { get; set; } = string.Empty;
+        public int Id { get; set; }
+        public string Email { get; set; } = string.Empty;
+        public bool IsVerified { get; set; }
+        public string VerificationToken { get; set; } = string.Empty;
+        public string UnsubscribeToken { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+    }
+
+    private class SmsSubscriberEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; } = "S";
+        public string RowKey { get; set; } = string.Empty;
+        public int Id { get; set; }
+        public string PhoneNumber { get; set; } = string.Empty;
+        public bool IsVerified { get; set; }
+        public string VerificationToken { get; set; } = string.Empty;
+        public string UnsubscribeToken { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+    }
+
+    private class SentNotificationEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; } = string.Empty;
+        public string RowKey { get; set; } = string.Empty;
+        public DateTime SentAt { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+    }
+}

--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.7" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
     <PackageReference Include="MudBlazor" Version="7.2.0" />
     <PackageReference Include="PreMailer.Net" Version="2.2.0" />
     <PackageReference Include="Resend" Version="0.1.4" />


### PR DESCRIPTION
## Summary
- introduce IDataStore abstraction with EF and Azure Table storage implementations
- switch services to use IDataStore and conditionally select Table storage via config
- update tests for new data store abstraction

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689a006a91ec8328a19af36a44a1e10e