### PR TITLE
Add configurable maintenance notice to subscription modal

### DIFF
--- a/Predictorator.Core/Services/NotificationFeatureService.cs
+++ b/Predictorator.Core/Services/NotificationFeatureService.cs
@@ -16,5 +16,11 @@ public class NotificationFeatureService
         !string.IsNullOrWhiteSpace(_config["Twilio:AuthToken"]) &&
         !string.IsNullOrWhiteSpace(_config["Twilio:FromNumber"]);
 
+    public bool SubscriptionDisabled => _config.GetValue<bool>("Subscription:Disabled");
+
+    public string SubscriptionDisabledMessage =>
+        _config["Subscription:DisabledMessage"] ??
+        "This functionality is temporarily unavailable due to maintenance. Please check back soon.";
+
     public bool AnyEnabled => EmailEnabled || SmsEnabled;
 }

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -92,4 +92,18 @@ public class SubscribeComponentBUnitTests
             Assert.Contains("verification link", cut.Markup, StringComparison.OrdinalIgnoreCase);
         });
     }
+
+    [Fact]
+    public async Task Shows_Disabled_Message_When_Disabled()
+    {
+        await using var ctx = CreateContext(new Dictionary<string, string?>
+        {
+            ["Subscription:Disabled"] = "true",
+            ["Subscription:DisabledMessage"] = "temporarily unavailable"
+        });
+        var cut = ctx.Render<Subscribe>();
+        Assert.Contains("temporarily unavailable", cut.Markup, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Email address", cut.Markup);
+        Assert.DoesNotContain("UK mobile number", cut.Markup);
+    }
 }

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -6,7 +6,11 @@
 
 <MudPaper Class="pa-4" Elevation="1">
     <h2>Subscribe to Notifications</h2>
-    @if (_emailSubmitted)
+    @if (Features.SubscriptionDisabled)
+    {
+        <p>@Features.SubscriptionDisabledMessage</p>
+    }
+    else if (_emailSubmitted)
     {
         <p>A verification link has been sent to your email address. It will be valid for one hour.</p>
     }

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -19,5 +19,9 @@
     "HeartbeatIntervalSeconds": 120,
     "WorkerCount": 1
   },
+  "Subscription": {
+    "Disabled": false,
+    "DisabledMessage": "This functionality is temporarily unavailable due to maintenance. Please check back soon."
+  },
   "AllowedHosts": "*"
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ as needed before running the containers.
 Verification links sent to subscribers are valid for one hour. A background job
 runs weekly to calculate unverified subscriptions that have expired.
 
+To temporarily disable new subscriptions, set `Subscription:Disabled` to `true`.
+The notice shown in the subscribe dialog can be customized with
+`Subscription:DisabledMessage`.
+
 Ceefax mode provides a retro Teletext-inspired theme. When enabled, dark mode is
 also automatically activated for optimal contrast. If no prior preference is
 stored in the browser, the site defaults to Ceefax mode with dark mode enabled.


### PR DESCRIPTION
## Summary
- allow disabling subscriptions via config and show maintenance message
- make subscribe dialog display custom message when disabled
- document new Subscription settings

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_689b15a0ab98832882dcaf9a424aeccd