### PR TITLE
Add subscriber CSV import and export

### DIFF
--- a/Predictorator/Components/Pages/Admin/Subscribers.razor
+++ b/Predictorator/Components/Pages/Admin/Subscribers.razor
@@ -1,6 +1,7 @@
 @rendermode InteractiveServer
 @inject AdminService AdminService
 @inject ToastInterop Toast
+@inject IJSRuntime JS
 
 <h2>Subscribers</h2>
 @if (_items == null)
@@ -9,6 +10,14 @@
 }
 else
 {
+    <MudPaper Class="pa-2 mb-2">
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ExportAsync">Export CSV</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" HtmlTag="label">Import CSV
+                <InputFile OnChange="@ImportAsync" style="display:none" />
+            </MudButton>
+        </MudStack>
+    </MudPaper>
     <MudPaper Class="pa-2 mb-2">
         <EditForm Model="_newSub" OnValidSubmit="AddSubscriberAsync">
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
@@ -154,6 +163,36 @@ else
         catch
         {
             await Toast.ShowToast("Failed to send test notifications.", "error");
+        }
+    }
+
+    private async Task ExportAsync()
+    {
+        try
+        {
+            var csv = await AdminService.ExportSubscribersCsvAsync();
+            await JS.InvokeVoidAsync("app.downloadFile", $"subscribers-{DateTime.UtcNow:yyyyMMddHHmmss}.csv", csv);
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to export subscribers.", "error");
+        }
+    }
+
+    private async Task ImportAsync(InputFileChangeEventArgs e)
+    {
+        if (e.FileCount == 0) return;
+        try
+        {
+            using var stream = e.File.OpenReadStream(long.MaxValue);
+            var added = await AdminService.ImportSubscribersCsvAsync(stream);
+            var data = await AdminService.GetSubscribersAsync();
+            _items = data.Select(d => new Item(d.Id, d.Contact, d.IsVerified, d.Type)).ToList();
+            await Toast.ShowToast($"Imported {added} subscribers.", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to import subscribers.", "error");
         }
     }
 

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -122,7 +122,7 @@ window.app = (() => {
         });
     }
     
-    function copyPredictions() {
+      function copyPredictions() {
         const groups = document.querySelectorAll('.fixture-group');
         if (groups.length === 0) {
             showToast('No predictions available to copy.', 'error');
@@ -176,10 +176,10 @@ window.app = (() => {
                 showToast('Failed to copy predictions to clipboard.', 'error');
             }
         });
-    }
+      }
 
-    async function login(data) {
-        const response = await fetch('/login', {
+      async function login(data) {
+          const response = await fetch('/login', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -192,16 +192,28 @@ window.app = (() => {
         }
 
         return await response.text();
-    }
+      }
 
-    return {
-        copyPredictions,
-        registerScoreInputs,
-        registerToastHandler,
-        setCeefax,
-        login
-    };
-})();
+      function downloadFile(name, content) {
+          const blob = new Blob([content], { type: 'text/csv' });
+          const link = document.createElement('a');
+          link.href = URL.createObjectURL(blob);
+          link.download = name;
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(link.href);
+      }
+
+      return {
+          copyPredictions,
+          registerScoreInputs,
+          registerToastHandler,
+          setCeefax,
+          login,
+          downloadFile
+      };
+  })();
 
 document.addEventListener('click', function (e) {
     if (e.target && e.target.parentNode.id === 'copyBtn') {


### PR DESCRIPTION
## Summary
- allow admins to export all subscribers as CSV
- support importing subscribers from CSV, skipping existing
- add JS helper for file downloads
- cover CSV import/export with tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b162e91dc8328b0e1546b3cc5d961