### PR TITLE
Add manual function app deployment workflow

### DIFF
--- a/.github/workflows/function-app.yml
+++ b/.github/workflows/function-app.yml
@@ -1,0 +1,53 @@
+name: Deploy Function App
+
+on:
+  workflow_dispatch:
+
+# Required for Azure login using OIDC
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    if: ${{ github.actor == github.repository_owner }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+          include-prerelease: true
+      - name: Build
+        run: dotnet build Predictorator.sln --configuration Release
+      - name: Publish
+        run: dotnet publish Predictorator.Functions/Predictorator.Functions.csproj -c Release -o publish
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: functionapp
+          path: publish
+          retention-days: 1
+
+  deploy_prod:
+    if: ${{ github.actor == github.repository_owner }}
+    runs-on: ubuntu-latest
+    needs: build
+    environment: Production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: functionapp
+          path: ./functionapp
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_FUNCTIONAPP_CLIENTID }}
+          tenant-id: ${{ secrets.AZURE_FUNCTIONAPP_TENANTID }}
+          subscription-id: ${{ secrets.AZURE_FUNCTIONAPP_SUBSCRIPTIONID }}
+      - name: Deploy to production
+        uses: Azure/functions-action@v1
+        with:
+          app-name: 'predictorator-functions'
+          slot-name: 'Production'
+          package: ./functionapp


### PR DESCRIPTION
## Summary
- add a manually triggered workflow to build and deploy the Predictorator Function App using Azure Functions action

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b169437688328a5d9b19200882ac9