### PR TITLE
Add gameweek CSV import and export

### DIFF
--- a/Predictorator.Core/Services/IGameWeekService.cs
+++ b/Predictorator.Core/Services/IGameWeekService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Predictorator.Models;
 
 namespace Predictorator.Services;
@@ -9,4 +10,6 @@ public interface IGameWeekService
     Task<GameWeek?> GetNextGameWeekAsync(DateTime date);
     Task AddOrUpdateAsync(GameWeek gameWeek);
     Task DeleteAsync(int id);
+    Task<string> ExportCsvAsync();
+    Task<int> ImportCsvAsync(Stream csv);
 }

--- a/Predictorator/Components/Pages/Admin/GameWeeks.razor
+++ b/Predictorator/Components/Pages/Admin/GameWeeks.razor
@@ -1,8 +1,18 @@
 @rendermode InteractiveServer
 @inject IGameWeekService Service
 @inject ToastInterop Toast
+@inject IJSRuntime JS
 
 <h2>Game Weeks</h2>
+
+<MudPaper Class="pa-2 mb-2">
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="@ExportAsync">Export CSV</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" HtmlTag="label">Import CSV
+            <InputFile OnChange="@ImportAsync" style="display:none" />
+        </MudButton>
+    </MudStack>
+</MudPaper>
 
 <MudPaper Class="pa-2" Elevation="1">
     <EditForm Model="_model" OnValidSubmit="SaveAsync">
@@ -71,6 +81,35 @@ else
     {
         _items = await Service.GetGameWeeksAsync();
         StateHasChanged();
+    }
+
+    private async Task ExportAsync()
+    {
+        try
+        {
+            var csv = await Service.ExportCsvAsync();
+            await JS.InvokeVoidAsync("app.downloadFile", $"gameweeks-{DateTime.UtcNow:yyyyMMddHHmmss}.csv", csv);
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to export game weeks.", "error");
+        }
+    }
+
+    private async Task ImportAsync(InputFileChangeEventArgs e)
+    {
+        if (e.FileCount == 0) return;
+        try
+        {
+            using var stream = e.File.OpenReadStream(long.MaxValue);
+            var added = await Service.ImportCsvAsync(stream);
+            await LoadAsync();
+            await Toast.ShowToast($"Imported {added} game weeks.", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to import game weeks.", "error");
+        }
     }
 
     private async Task SaveAsync()

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application. Once
 logged in as an administrator you can view background jobs via the Hangfire
-dashboard at `/hangfire`.
+dashboard at `/hangfire`. Administrators can also export and import game weeks as
+CSV files from the admin interface.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 Email delivery is handled by [Resend](https://resend.com). Configure the


### PR DESCRIPTION
## Summary
- add export/import methods to the game week service and interface
- expose CSV import/export controls on the admin game weeks page
- document new admin capability and cover feature with tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b4bd4f2c48328b9e04be4860ccf8d