### PR TITLE
Use table storage for gameweeks

### DIFF
--- a/Predictorator.Core/Data/EfGameWeekRepository.cs
+++ b/Predictorator.Core/Data/EfGameWeekRepository.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore;
+using Predictorator.Models;
+
+namespace Predictorator.Data;
+
+public class EfGameWeekRepository : IGameWeekRepository
+{
+    private readonly ApplicationDbContext _db;
+
+    public EfGameWeekRepository(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public Task<List<GameWeek>> GetGameWeeksAsync(string? season = null)
+    {
+        var query = _db.GameWeeks.AsNoTracking().AsQueryable();
+        if (!string.IsNullOrEmpty(season))
+            query = query.Where(g => g.Season == season);
+        return query.OrderBy(g => g.Season).ThenBy(g => g.Number).ToListAsync();
+    }
+
+    public Task<GameWeek?> GetGameWeekAsync(string season, int number) =>
+        _db.GameWeeks.AsNoTracking().FirstOrDefaultAsync(g => g.Season == season && g.Number == number);
+
+    public Task<GameWeek?> GetByIdAsync(int id) =>
+        _db.GameWeeks.AsNoTracking().FirstOrDefaultAsync(g => g.Id == id);
+
+    public Task<GameWeek?> GetNextGameWeekAsync(DateTime date) =>
+        _db.GameWeeks.Where(g => g.EndDate >= date)
+            .OrderBy(g => g.StartDate)
+            .FirstOrDefaultAsync();
+
+    public async Task AddOrUpdateAsync(GameWeek gameWeek)
+    {
+        GameWeek? existing = null;
+        if (gameWeek.Id != 0)
+            existing = await _db.GameWeeks.FindAsync(gameWeek.Id);
+        if (existing == null)
+            existing = await _db.GameWeeks.FirstOrDefaultAsync(g => g.Season == gameWeek.Season && g.Number == gameWeek.Number);
+        if (existing == null)
+        {
+            _db.GameWeeks.Add(gameWeek);
+        }
+        else
+        {
+            existing.Season = gameWeek.Season;
+            existing.Number = gameWeek.Number;
+            existing.StartDate = gameWeek.StartDate;
+            existing.EndDate = gameWeek.EndDate;
+        }
+        await _db.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _db.GameWeeks.FindAsync(id);
+        if (entity != null)
+        {
+            _db.GameWeeks.Remove(entity);
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/Predictorator.Core/Data/IGameWeekRepository.cs
+++ b/Predictorator.Core/Data/IGameWeekRepository.cs
@@ -1,0 +1,13 @@
+using Predictorator.Models;
+
+namespace Predictorator.Data;
+
+public interface IGameWeekRepository
+{
+    Task<List<GameWeek>> GetGameWeeksAsync(string? season = null);
+    Task<GameWeek?> GetGameWeekAsync(string season, int number);
+    Task<GameWeek?> GetByIdAsync(int id);
+    Task<GameWeek?> GetNextGameWeekAsync(DateTime date);
+    Task AddOrUpdateAsync(GameWeek gameWeek);
+    Task DeleteAsync(int id);
+}

--- a/Predictorator.Core/Data/TableGameWeekRepository.cs
+++ b/Predictorator.Core/Data/TableGameWeekRepository.cs
@@ -1,0 +1,156 @@
+using Azure;
+using Azure.Data.Tables;
+using Predictorator.Models;
+
+namespace Predictorator.Data;
+
+public class TableGameWeekRepository : IGameWeekRepository
+{
+    private readonly TableClient _table;
+
+    public TableGameWeekRepository(TableServiceClient client)
+    {
+        _table = client.GetTableClient("GameWeeks");
+        _table.CreateIfNotExists();
+    }
+
+    private static GameWeek ToGameWeek(GameWeekEntity e) => new()
+    {
+        Id = e.Id,
+        Season = e.PartitionKey,
+        Number = int.Parse(e.RowKey),
+        StartDate = e.StartDate,
+        EndDate = e.EndDate
+    };
+
+    private static GameWeekEntity ToEntity(GameWeek g) => new()
+    {
+        PartitionKey = g.Season,
+        RowKey = g.Number.ToString(),
+        Id = g.Id,
+        StartDate = g.StartDate,
+        EndDate = g.EndDate
+    };
+
+    private async Task<int> GetNextIdAsync()
+    {
+        var max = 0;
+        await foreach (var e in _table.QueryAsync<GameWeekEntity>(select: new[] { "Id" }))
+        {
+            if (e.Id > max) max = e.Id;
+        }
+        return max + 1;
+    }
+
+    public async Task<List<GameWeek>> GetGameWeeksAsync(string? season = null)
+    {
+        var list = new List<GameWeek>();
+        var query = string.IsNullOrEmpty(season)
+            ? _table.QueryAsync<GameWeekEntity>()
+            : _table.QueryAsync<GameWeekEntity>(e => e.PartitionKey == season);
+        await foreach (var e in query)
+            list.Add(ToGameWeek(e));
+        return list.OrderBy(g => g.Season).ThenBy(g => g.Number).ToList();
+    }
+
+    public async Task<GameWeek?> GetGameWeekAsync(string season, int number)
+    {
+        try
+        {
+            var e = await _table.GetEntityAsync<GameWeekEntity>(season, number.ToString());
+            return ToGameWeek(e.Value);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task<GameWeek?> GetByIdAsync(int id)
+    {
+        await foreach (var e in _table.QueryAsync<GameWeekEntity>(e => e.Id == id))
+            return ToGameWeek(e);
+        return null;
+    }
+
+    public async Task<GameWeek?> GetNextGameWeekAsync(DateTime date)
+    {
+        var list = new List<GameWeek>();
+        await foreach (var e in _table.QueryAsync<GameWeekEntity>(e => e.EndDate >= date))
+            list.Add(ToGameWeek(e));
+        return list.OrderBy(g => g.StartDate).FirstOrDefault();
+    }
+
+    public async Task AddOrUpdateAsync(GameWeek gameWeek)
+    {
+        GameWeekEntity? existing = null;
+        if (gameWeek.Id != 0)
+        {
+            await foreach (var e in _table.QueryAsync<GameWeekEntity>(e => e.Id == gameWeek.Id))
+            {
+                existing = e;
+                break;
+            }
+        }
+        if (existing == null)
+        {
+            try
+            {
+                var resp = await _table.GetEntityAsync<GameWeekEntity>(gameWeek.Season, gameWeek.Number.ToString());
+                existing = resp.Value;
+            }
+            catch (RequestFailedException ex) when (ex.Status == 404)
+            {
+                existing = null;
+            }
+        }
+        if (existing == null)
+        {
+            gameWeek.Id = await GetNextIdAsync();
+            var entity = ToEntity(gameWeek);
+            await _table.AddEntityAsync(entity);
+        }
+        else
+        {
+            var keyChanged = existing.PartitionKey != gameWeek.Season || existing.RowKey != gameWeek.Number.ToString();
+            existing.PartitionKey = gameWeek.Season;
+            existing.RowKey = gameWeek.Number.ToString();
+            existing.StartDate = gameWeek.StartDate;
+            existing.EndDate = gameWeek.EndDate;
+            if (keyChanged)
+            {
+                await _table.DeleteEntityAsync(existing.PartitionKey, existing.RowKey);
+                await _table.AddEntityAsync(existing);
+            }
+            else
+            {
+                await _table.UpsertEntityAsync(existing, TableUpdateMode.Replace);
+            }
+        }
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        GameWeekEntity? entity = null;
+        await foreach (var e in _table.QueryAsync<GameWeekEntity>(e => e.Id == id))
+        {
+            entity = e;
+            break;
+        }
+        if (entity != null)
+        {
+            await _table.DeleteEntityAsync(entity.PartitionKey, entity.RowKey);
+        }
+    }
+
+    private class GameWeekEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; } = string.Empty;
+        public string RowKey { get; set; } = string.Empty;
+        public int Id { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+    }
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -86,16 +86,19 @@ builder.Services.Configure<ResendClientOptions>(o =>
 builder.Services.AddTransient<IResend, ResendClient>();
 builder.Services.Configure<TwilioOptions>(builder.Configuration.GetSection(TwilioOptions.SectionName));
 builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
-var tableConn = builder.Configuration.GetConnectionString("TableStorage") 
+var tableConn = builder.Configuration.GetConnectionString("TableStorage")
     ?? builder.Configuration["TableStorage:ConnectionString"];
 if (!string.IsNullOrWhiteSpace(tableConn))
 {
-    builder.Services.AddSingleton(new TableServiceClient(tableConn));
+    var tableService = new TableServiceClient(tableConn);
+    builder.Services.AddSingleton(tableService);
     builder.Services.AddScoped<IDataStore, TableDataStore>();
+    builder.Services.AddScoped<IGameWeekRepository, TableGameWeekRepository>();
 }
 else
 {
     builder.Services.AddScoped<IDataStore, EfDataStore>();
+    builder.Services.AddScoped<IGameWeekRepository, EfGameWeekRepository>();
 }
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();


### PR DESCRIPTION
## Summary
- add repository abstraction for game weeks
- persist game weeks to Azure Table Storage with `TableGameWeekRepository`
- refactor `GameWeekService` and wiring to use table storage

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b51388bdc8328b7532bd31c50230c