### PR TITLE
Fix gameweek redirect with table storage

### DIFF
--- a/Predictorator.Core/Data/TableGameWeekRepository.cs
+++ b/Predictorator.Core/Data/TableGameWeekRepository.cs
@@ -75,9 +75,15 @@ public class TableGameWeekRepository : IGameWeekRepository
 
     public async Task<GameWeek?> GetNextGameWeekAsync(DateTime date)
     {
+        // Azure Table queries require DateTime values to be in UTC, otherwise the
+        // filter will not match any entities. Ensure the supplied date is
+        // explicitly marked as UTC before querying.
+        var utcDate = DateTime.SpecifyKind(date, DateTimeKind.Utc);
+
         var list = new List<GameWeek>();
-        await foreach (var e in _table.QueryAsync<GameWeekEntity>(e => e.EndDate >= date))
+        await foreach (var e in _table.QueryAsync<GameWeekEntity>(e => e.EndDate >= utcDate))
             list.Add(ToGameWeek(e));
+
         return list.OrderBy(g => g.StartDate).FirstOrDefault();
     }
 

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -29,9 +29,10 @@ public class IndexPageBUnitTests
         var fixtures = new FixturesResponse { Response = [] };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
         var gwService = new FakeGameWeekService();
+        var today = DateTime.UtcNow.Date;
         gwService.Items.AddRange([
-            new Predictorator.Models.GameWeek { Season = "24-25", Number = 1, StartDate = DateTime.Today, EndDate = DateTime.Today.AddDays(6) },
-            new Predictorator.Models.GameWeek { Season = "24-25", Number = 2, StartDate = DateTime.Today.AddDays(7), EndDate = DateTime.Today.AddDays(13) }
+            new Predictorator.Models.GameWeek { Season = "24-25", Number = 1, StartDate = today, EndDate = today.AddDays(6) },
+            new Predictorator.Models.GameWeek { Season = "24-25", Number = 2, StartDate = today.AddDays(7), EndDate = today.AddDays(13) }
         ]);
         ctx.Services.AddSingleton<IGameWeekService>(gwService);
         var provider = new FakeDateTimeProvider
@@ -76,6 +77,20 @@ public class IndexPageBUnitTests
         var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
         var picker = cut.Find("#dateRangePicker");
         Assert.NotNull(picker);
+    }
+
+    [Fact]
+    public async Task Redirects_To_Next_GameWeek_When_Not_Specified()
+    {
+        await using var ctx = CreateContext();
+        var navMan = ctx.Services.GetRequiredService<NavigationManager>();
+        RenderFragment body = b =>
+        {
+            b.OpenComponent<IndexPage>(0);
+            b.CloseComponent();
+        };
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        cut.WaitForAssertion(() => Assert.Contains("/24-25/gw1", navMan.Uri));
     }
 
     [Fact]

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -136,7 +136,7 @@ else if (_fixtures.Response.Any())
 
         if (string.IsNullOrEmpty(Season) || !Week.HasValue)
         {
-            var next = await GameWeekService.GetNextGameWeekAsync(DateTime.Today);
+            var next = await GameWeekService.GetNextGameWeekAsync(DateTime.UtcNow.Date);
             if (next != null)
             {
                 NavigationManager.NavigateTo($"/{next.Season}/gw{next.Number}", true);


### PR DESCRIPTION
## Summary
- ensure table queries use UTC dates to find next gameweek
- fetch next gameweek using UTC date on the index page
- add test covering redirect to next gameweek when none specified

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_689b579d74cc8328864ad09c3e2d6ba4