### PR TITLE
Add in-memory database fallback for seeding admin user

### DIFF
--- a/Predictorator/Predictorator.csproj
+++ b/Predictorator/Predictorator.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Hangfire.SqlServer" Version="1.8.20" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.7" />
     <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />

--- a/Predictorator/Startup/StartupExitCode.cs
+++ b/Predictorator/Startup/StartupExitCode.cs
@@ -2,6 +2,5 @@ namespace Predictorator.Startup;
 
 public enum StartupExitCode
 {
-    MissingRapidApiKey = 1,
-    MissingConnectionString = 2
+    MissingRapidApiKey = 1
 }

--- a/Predictorator/Startup/StartupValidator.cs
+++ b/Predictorator/Startup/StartupValidator.cs
@@ -10,10 +10,6 @@ public static class StartupValidator
         if (string.IsNullOrWhiteSpace(builder.Configuration["ApiSettings:RapidApiKey"]))
             return StartupExitCode.MissingRapidApiKey;
 
-        var connection = builder.Configuration.GetConnectionString("DefaultConnection");
-        if (string.IsNullOrWhiteSpace(connection))
-            return StartupExitCode.MissingConnectionString;
-
         return null;
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You can override these values by setting the `ADMIN_EMAIL` and
 logged in as an administrator you can view background jobs via the Hangfire
 dashboard at `/hangfire`. Administrators can also export and import game weeks as
 CSV files from the admin interface.
+If `ConnectionStrings:DefaultConnection` is not configured the application uses an in-memory database instead of SQL Server. The admin account is recreated on each start and all data is lost when the app stops, which is useful for demos or testing.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 Email delivery is handled by [Resend](https://resend.com). Configure the


### PR DESCRIPTION
## Summary
- allow running without SQL by falling back to EF Core in-memory provider
- seed admin user from configuration and skip Hangfire when using in-memory store
- document in-memory mode and remove unused startup validation

## Testing
- `dotnet format Predictorator.sln -v diag`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_689b5929a33c83289921100246412f74