### PR TITLE
Remove Hangfire from subscription workflow

### DIFF
--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -42,7 +42,6 @@ public class SubscribeComponentBUnitTests
         var store = new EfDataStore(db);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
-        var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
         var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
@@ -51,7 +50,7 @@ public class SubscribeComponentBUnitTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, jobs, inliner, renderer, logger));
+        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, inliner, renderer, logger));
         return ctx;
     }
 

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -3,9 +3,6 @@ using Microsoft.Extensions.Configuration;
 using NSubstitute;
 using Predictorator.Data;
 using Predictorator.Models;
-using Hangfire;
-using Hangfire.Common;
-using Hangfire.States;
 using Predictorator.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Predictorator.Tests.Helpers;
@@ -16,7 +13,8 @@ namespace Predictorator.Tests;
 
 public class SubscriptionServiceTests
 {
-    private static SubscriptionService CreateService(out ApplicationDbContext db, out IResend resend, out ITwilioSmsSender sms, out IBackgroundJobClient jobs, IDateTimeProvider? provider = null)
+    private static SubscriptionService CreateService(out ApplicationDbContext db, out IResend resend, out ITwilioSmsSender sms,
+        IDateTimeProvider? provider = null)
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -25,7 +23,6 @@ public class SubscriptionServiceTests
         var store = new EfDataStore(db);
         resend = Substitute.For<IResend>();
         sms = Substitute.For<ITwilioSmsSender>();
-        jobs = Substitute.For<IBackgroundJobClient>();
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Resend:From"] = "from@example.com" })
             .Build();
@@ -34,16 +31,14 @@ public class SubscriptionServiceTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        return new SubscriptionService(store, resend, config, sms, provider, jobs, inliner, renderer, logger);
+        return new SubscriptionService(store, resend, config, sms, provider, inliner, renderer, logger);
     }
 
     [Fact]
     public async Task SubscribeAsync_with_email_sends_email_with_links()
     {
-        var service = CreateService(out var db, out var resend, out _, out var jobs);
+        var service = CreateService(out var db, out var resend, out _);
         await service.SubscribeAsync("user@example.com", null, "http://localhost");
-        jobs.Received().Create(Arg.Is<Job>(j => j.Method.Name == nameof(SubscriptionService.AddEmailSubscriberAsync)), Arg.Any<IState>());
-        await service.AddEmailSubscriberAsync("user@example.com", "http://localhost");
 
         await resend.Received().EmailSendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
         var subscriber = await db.Subscribers.SingleAsync();
@@ -53,7 +48,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task VerifyAsync_marks_subscriber_verified()
     {
-        var service = CreateService(out var db, out var resend, out _, out _);
+        var service = CreateService(out var db, out var resend, out _);
         var subscriber = new Subscriber { Email = "a", VerificationToken = "token", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.Subscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -68,7 +63,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeAsync_removes_subscriber()
     {
-        var service = CreateService(out var db, out _, out _, out _);
+        var service = CreateService(out var db, out _, out _);
         var subscriber = new Subscriber { Email = "a", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.Subscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -82,10 +77,8 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task SubscribeAsync_with_phone_sends_sms()
     {
-        var service = CreateService(out var db, out var resend, out var sms, out var jobs);
+        var service = CreateService(out var db, out var resend, out var sms);
         await service.SubscribeAsync(null, "+123", "http://localhost");
-        jobs.Received().Create(Arg.Is<Job>(j => j.Method.Name == nameof(SubscriptionService.AddSmsSubscriberAsync)), Arg.Any<IState>());
-        await service.AddSmsSubscriberAsync("+123", "http://localhost");
 
         await sms.Received().SendSmsAsync("+123", Arg.Any<string>());
         await resend.Received().EmailSendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>());
@@ -96,14 +89,14 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task SubscribeAsync_throws_when_both_email_and_phone_provided()
     {
-        var service = CreateService(out _, out _, out _, out _);
+        var service = CreateService(out _, out _, out _);
         await Assert.ThrowsAsync<ArgumentException>(() => service.SubscribeAsync("e@example.com", "+1", "http://localhost"));
     }
 
     [Fact]
     public async Task VerifyAsync_marks_sms_subscriber_verified()
     {
-        var service = CreateService(out var db, out var resend, out _, out _);
+        var service = CreateService(out var db, out var resend, out _);
         var subscriber = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "t", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.SmsSubscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -118,7 +111,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeAsync_removes_sms_subscriber()
     {
-        var service = CreateService(out var db, out _, out _, out _);
+        var service = CreateService(out var db, out _, out _);
         var subscriber = new SmsSubscriber { PhoneNumber = "+1", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow };
         db.SmsSubscribers.Add(subscriber);
         await db.SaveChangesAsync();
@@ -133,7 +126,7 @@ public class SubscriptionServiceTests
     public async Task CountExpiredUnverifiedAsync_counts_old_records()
     {
         var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
-        var service = CreateService(out var db, out _, out _, out _, provider);
+        var service = CreateService(out var db, out _, out _, provider);
         db.Subscribers.Add(new Subscriber { Email = "old@example.com", CreatedAt = provider.UtcNow.AddHours(-2), VerificationToken = "a", UnsubscribeToken = "b" });
         db.SmsSubscribers.Add(new SmsSubscriber { PhoneNumber = "+1", CreatedAt = provider.UtcNow.AddHours(-2), VerificationToken = "c", UnsubscribeToken = "d" });
         await db.SaveChangesAsync();
@@ -149,7 +142,7 @@ public class SubscriptionServiceTests
     public async Task CountExpiredUnverifiedAsync_excludes_recent_or_verified()
     {
         var provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
-        var service = CreateService(out var db, out _, out _, out _, provider);
+        var service = CreateService(out var db, out _, out _, provider);
         var recent = new Subscriber { Email = "new@example.com", CreatedAt = provider.UtcNow.AddMinutes(-30), VerificationToken = "a", UnsubscribeToken = "b" };
         var verified = new SmsSubscriber { PhoneNumber = "+1", CreatedAt = provider.UtcNow.AddHours(-2), IsVerified = true, VerificationToken = "c", UnsubscribeToken = "d" };
         db.Subscribers.Add(recent);
@@ -166,7 +159,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeByContactAsync_email_case_insensitive()
     {
-        var service = CreateService(out var db, out _, out _, out _);
+        var service = CreateService(out var db, out _, out _);
         db.Subscribers.Add(new Subscriber { Email = "User@Example.com", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow });
         await db.SaveChangesAsync();
 
@@ -179,7 +172,7 @@ public class SubscriptionServiceTests
     [Fact]
     public async Task UnsubscribeByContactAsync_matches_phone_formats()
     {
-        var service = CreateService(out var db, out _, out _, out _);
+        var service = CreateService(out var db, out _, out _);
         db.SmsSubscribers.Add(new SmsSubscriber { PhoneNumber = "5551234567", VerificationToken = "v", UnsubscribeToken = "u", CreatedAt = DateTime.UtcNow });
         await db.SaveChangesAsync();
 

--- a/Predictorator.Tests/UnsubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/UnsubscribeComponentBUnitTests.cs
@@ -45,7 +45,6 @@ public class UnsubscribeComponentBUnitTests
         var store = new EfDataStore(db);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
-        var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
         var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
@@ -54,7 +53,7 @@ public class UnsubscribeComponentBUnitTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, jobs, inliner, renderer, logger));
+        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, inliner, renderer, logger));
         return ctx;
     }
 

--- a/Predictorator.Tests/VerifyComponentBUnitTests.cs
+++ b/Predictorator.Tests/VerifyComponentBUnitTests.cs
@@ -45,7 +45,6 @@ public class VerifyComponentBUnitTests
         var store = new EfDataStore(db);
         var resend = Substitute.For<IResend>();
         var sms = Substitute.For<ITwilioSmsSender>();
-        var jobs = Substitute.For<Hangfire.IBackgroundJobClient>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
         var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
@@ -54,7 +53,7 @@ public class VerifyComponentBUnitTests
         var inliner = new EmailCssInliner(env);
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
-        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, jobs, inliner, renderer, logger));
+        ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, inliner, renderer, logger));
         return ctx;
     }
 


### PR DESCRIPTION
## Summary
- process subscriptions directly without queuing Hangfire jobs
- update unit and component tests for new subscription flow

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b5b8f35b88328bd7ec1fb9cb6e0d5