### PR TITLE
Fix admin login with singleton identity store

### DIFF
--- a/Predictorator.Tests/AdminUserSeedingTests.cs
+++ b/Predictorator.Tests/AdminUserSeedingTests.cs
@@ -11,9 +11,9 @@ public class AdminUserSeedingTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddIdentity<IdentityUser, IdentityRole>(identityOpts ?? (_ => { }))
-            .AddUserStore<InMemoryUserStore>()
-            .AddRoleStore<InMemoryRoleStore>();
+        services.AddIdentity<IdentityUser, IdentityRole>(identityOpts ?? (_ => { }));
+        services.AddSingleton<IUserStore<IdentityUser>, InMemoryUserStore>();
+        services.AddSingleton<IRoleStore<IdentityRole>, InMemoryRoleStore>();
         services.Configure<AdminUserOptions>(o => { o.Email = email; o.Password = password; });
         return services.BuildServiceProvider();
     }
@@ -34,5 +34,19 @@ public class AdminUserSeedingTests
             () => ApplicationDbInitializer.SeedAdminUserAsync(provider));
     }
 
+    [Fact]
+    public async Task Can_sign_in_with_seeded_admin_user()
+    {
+        const string email = "admin@example.com";
+        const string password = "Admin123!";
+        using var provider = BuildServices(null, email, password);
+        await ApplicationDbInitializer.SeedAdminUserAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+        Assert.NotNull(user);
+        Assert.True(await userManager.CheckPasswordAsync(user!, password));
+    }
 }
 

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -105,10 +105,10 @@ builder.Services.Configure<AdminUserOptions>(options =>
     options.Password = builder.Configuration["ADMIN_PASSWORD"] ?? options.Password;
 });
 builder.Services.AddIdentity<IdentityUser, IdentityRole>()
-    .AddUserStore<InMemoryUserStore>()
-    .AddRoleStore<InMemoryRoleStore>()
     .AddDefaultUI()
     .AddDefaultTokenProviders();
+builder.Services.AddSingleton<IUserStore<IdentityUser>, InMemoryUserStore>();
+builder.Services.AddSingleton<IRoleStore<IdentityRole>, InMemoryRoleStore>();
 
 builder.Services.ConfigureApplicationCookie(options =>
 {


### PR DESCRIPTION
## Summary
- use singleton in-memory user and role stores so seeded admin user persists across scopes
- add regression test ensuring seeded admin credentials can be verified

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689b70dc2ea88328959a56bba4357e77