### PR TITLE
Fix admin role lookup for in-memory store

### DIFF
--- a/Predictorator.Tests/AdminUserSeedingTests.cs
+++ b/Predictorator.Tests/AdminUserSeedingTests.cs
@@ -48,5 +48,20 @@ public class AdminUserSeedingTests
         Assert.NotNull(user);
         Assert.True(await userManager.CheckPasswordAsync(user!, password));
     }
+
+    [Fact]
+    public async Task Seeded_admin_user_has_admin_role()
+    {
+        const string email = "admin@example.com";
+        const string password = "Admin123!";
+        using var provider = BuildServices(null, email, password);
+        await ApplicationDbInitializer.SeedAdminUserAsync(provider);
+
+        using var scope = provider.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<IdentityUser>>();
+        var user = await userManager.FindByEmailAsync(email);
+        Assert.NotNull(user);
+        Assert.True(await userManager.IsInRoleAsync(user!, "Admin"));
+    }
 }
 

--- a/Predictorator/Data/InMemoryUserStore.cs
+++ b/Predictorator/Data/InMemoryUserStore.cs
@@ -113,7 +113,7 @@ public class InMemoryUserStore :
 
     public Task AddToRoleAsync(IdentityUser user, string roleName, CancellationToken cancellationToken)
     {
-        var roles = _userRoles.GetOrAdd(user.Id, _ => new HashSet<string>());
+        var roles = _userRoles.GetOrAdd(user.Id, _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
         roles.Add(roleName);
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- make in-memory role assignments case-insensitive so the seeded admin user retains the Admin role
- add regression test verifying the seeded user is assigned the Admin role

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_689b7bf29e548328bc07d78626512059