### PR TITLE
Fix admin access role mapping and add integration test

### DIFF
--- a/Predictorator.Tests/AdminPageAccessTests.cs
+++ b/Predictorator.Tests/AdminPageAccessTests.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Predictorator.Models;
+using Predictorator.Data;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+using Resend;
+using NSubstitute;
+
+namespace Predictorator.Tests;
+
+public class AdminPageAccessTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AdminPageAccessTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Testing");
+            builder.UseSetting("TableStorage:ConnectionString", "UseDevelopmentStorage=true");
+            builder.UseSetting("AdminUser:Email", "admin@example.com");
+            builder.UseSetting("AdminUser:Password", "Admin123!");
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IDataStore, InMemoryDataStore>();
+                services.AddSingleton<IGameWeekService, FakeGameWeekService>();
+                services.AddSingleton<IResend>(_ => Substitute.For<IResend>());
+                services.AddSingleton<ITwilioSmsSender>(_ => Substitute.For<ITwilioSmsSender>());
+                services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
+                // remove hosted services
+                var toRemove = services.Where(d => d.ImplementationType == typeof(BackgroundJobProcessor) || d.ImplementationType == typeof(RecurringJobProcessor)).ToList();
+                foreach (var d in toRemove) services.Remove(d);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Can_access_admin_page_after_login()
+    {
+        using var scope = _factory.Services.CreateScope();
+        await ApplicationDbInitializer.SeedAdminUserAsync(scope.ServiceProvider);
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        var loginResponse = await client.PostAsJsonAsync("/login", new LoginRequest("admin@example.com", "Admin123!"));
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+
+        var adminResponse = await client.GetAsync("/admin");
+        Assert.Equal(HttpStatusCode.OK, adminResponse.StatusCode);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure InMemoryUserStore preserves role names when adding to roles so admin claims resolve
- cover login and admin page access flow in integration test

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b84ac29748328b3e46a8e2ae36c27