### PR TITLE
Add admin UI to manage queued jobs

### DIFF
--- a/Predictorator.Core/Services/AdminService.cs
+++ b/Predictorator.Core/Services/AdminService.cs
@@ -326,6 +326,17 @@ public class AdminService
             delay);
     }
 
+    public async Task<List<BackgroundJob>> GetJobsAsync()
+    {
+        var jobs = await _jobs.GetJobsAsync();
+        return jobs.ToList();
+    }
+
+    public Task DeleteJobAsync(string id)
+    {
+        return _jobs.DeleteAsync(id);
+    }
+
     public Task ClearCachesAsync()
     {
         _prefix.Clear();

--- a/Predictorator.Core/Services/IBackgroundJobService.cs
+++ b/Predictorator.Core/Services/IBackgroundJobService.cs
@@ -1,7 +1,13 @@
 namespace Predictorator.Services;
 
+using Predictorator.Models;
+
 public interface IBackgroundJobService
 {
     Task ScheduleAsync(string jobType, object payload, TimeSpan delay);
+
+    Task<IReadOnlyList<BackgroundJob>> GetJobsAsync();
+
+    Task DeleteAsync(string id);
 }
 

--- a/Predictorator.Core/Services/TableBackgroundJobService.cs
+++ b/Predictorator.Core/Services/TableBackgroundJobService.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using Azure.Data.Tables;
 using Predictorator.Models;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Predictorator.Services;
 
@@ -25,6 +27,17 @@ public class TableBackgroundJobService : IBackgroundJobService
             RunAt = _time.UtcNow.Add(delay)
         };
         return _table.AddEntityAsync(job);
+    }
+
+    public Task<IReadOnlyList<BackgroundJob>> GetJobsAsync()
+    {
+        var jobs = _table.Query<BackgroundJob>().ToList();
+        return Task.FromResult<IReadOnlyList<BackgroundJob>>(jobs);
+    }
+
+    public Task DeleteAsync(string id)
+    {
+        return _table.DeleteEntityAsync("jobs", id);
     }
 }
 

--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -209,4 +209,27 @@ public class AdminServiceTests
         Assert.Single(store.EmailSubscribers);
         Assert.Single(store.SmsSubscribers);
     }
+
+    [Fact]
+    public async Task GetJobsAsync_returns_jobs()
+    {
+        var service = CreateService(out _, out _, out _, out var jobs, out _);
+        var list = new List<BackgroundJob> { new() { RowKey = "1", JobType = "Test", RunAt = DateTimeOffset.UtcNow } };
+        jobs.GetJobsAsync().Returns(list);
+
+        var result = await service.GetJobsAsync();
+
+        Assert.Single(result);
+        Assert.Equal("Test", result[0].JobType);
+    }
+
+    [Fact]
+    public async Task DeleteJobAsync_calls_service()
+    {
+        var service = CreateService(out _, out _, out _, out var jobs, out _);
+
+        await service.DeleteJobAsync("abc");
+
+        await jobs.Received().DeleteAsync("abc");
+    }
 }

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -12,6 +12,9 @@
     <MudTabPanel Text="Game Weeks">
         <GameWeeks />
     </MudTabPanel>
+    <MudTabPanel Text="Jobs">
+        <Jobs />
+    </MudTabPanel>
     <MudTabPanel Text="Maintenance">
         <MudPaper Class="pa-2">
             <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="ClearCaches">Clear Caches</MudButton>

--- a/Predictorator/Components/Pages/Admin/Jobs.razor
+++ b/Predictorator/Components/Pages/Admin/Jobs.razor
@@ -1,0 +1,44 @@
+@rendermode InteractiveServer
+@inject AdminService AdminService
+@inject ToastInterop Toast
+@using Predictorator.Models
+
+<h2>Queued Jobs</h2>
+@if (_jobs == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <MudTable Items="_jobs" Hover="true" Breakpoint="Breakpoint.None">
+        <HeaderContent>
+            <MudTh>Type</MudTh>
+            <MudTh>Run At (UTC)</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate Context="row">
+            <MudTd>@row.JobType</MudTd>
+            <MudTd>@row.RunAt.ToString("u")</MudTd>
+            <MudTd>
+                <MudButton Size="Size.Small" Color="Color.Error" Variant="Variant.Filled" OnClick="@(() => DeleteAsync(row))">Delete</MudButton>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    private List<BackgroundJob>? _jobs;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var data = await AdminService.GetJobsAsync();
+        _jobs = data.ToList();
+    }
+
+    private async Task DeleteAsync(BackgroundJob job)
+    {
+        await AdminService.DeleteJobAsync(job.RowKey);
+        _jobs!.Remove(job);
+        await Toast.ShowToast("Job deleted!", "success");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application. Once
 Administrators can export and import game weeks as CSV files from the admin
-interface.
+interface. Administrators can also view and delete queued background jobs.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 Email delivery is handled by [Resend](https://resend.com). Configure the


### PR DESCRIPTION
## Summary
- extend background job service to list and delete jobs
- add admin service endpoints and UI tab to manage queued jobs
- document and test queued job management

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b8e3d89e48328aba5efc4d21b58eb