### PR TITLE
Move background jobs to Azure Functions

### DIFF
--- a/Predictorator.Functions/CheckUnverifiedExpiredFunction.cs
+++ b/Predictorator.Functions/CheckUnverifiedExpiredFunction.cs
@@ -17,7 +17,8 @@ public class CheckUnverifiedExpiredFunction
     }
 
     [Function("CheckUnverifiedExpired")]
-    public async Task Run([TimerTrigger("0 1 * * 1")] TimerInfo timer)
+    public async Task Run([TimerTrigger("%CheckUnverifiedExpiredSchedule%")]
+        TimerInfo timer)
     {
         var count = await _service.CountExpiredUnverifiedAsync();
         _logger.LogInformation("Expired unverified subscriptions: {Count}", count);

--- a/Predictorator.Functions/ClearExpiredSubscriptionsFunction.cs
+++ b/Predictorator.Functions/ClearExpiredSubscriptionsFunction.cs
@@ -1,0 +1,26 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.Timer;
+using Microsoft.Extensions.Logging;
+using Predictorator.Services;
+
+namespace Predictorator.Functions;
+
+public class ClearExpiredSubscriptionsFunction
+{
+    private readonly SubscriptionService _service;
+    private readonly ILogger<ClearExpiredSubscriptionsFunction> _logger;
+
+    public ClearExpiredSubscriptionsFunction(SubscriptionService service, ILogger<ClearExpiredSubscriptionsFunction> logger)
+    {
+        _service = service;
+        _logger = logger;
+    }
+
+    [Function("ClearExpiredSubscriptions")]
+    public async Task Run([TimerTrigger("%ClearExpiredSubscriptionsSchedule%")]
+        TimerInfo timer)
+    {
+        var count = await _service.ClearExpiredUnverifiedAsync();
+        _logger.LogInformation("Removed {Count} expired subscriptions", count);
+    }
+}

--- a/Predictorator.Functions/FixtureNotificationsFunction.cs
+++ b/Predictorator.Functions/FixtureNotificationsFunction.cs
@@ -14,7 +14,8 @@ public class FixtureNotificationsFunction
     }
 
     [Function("FixtureNotifications")]
-    public async Task Run([TimerTrigger("0 1 * * *")] TimerInfo timer)
+    public async Task Run([TimerTrigger("%FixtureNotificationsSchedule%")]
+        TimerInfo timer)
     {
         await _service.CheckFixturesAsync();
     }

--- a/Predictorator.Functions/Predictorator.Functions.csproj
+++ b/Predictorator.Functions/Predictorator.Functions.csproj
@@ -23,4 +23,10 @@
     <ProjectReference Include="..\Predictorator.Core\Predictorator.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Predictorator.Functions/ProcessBackgroundJobsFunction.cs
+++ b/Predictorator.Functions/ProcessBackgroundJobsFunction.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using System.Linq;
+using Azure.Data.Tables;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.Timer;
+using Microsoft.Extensions.Logging;
+using Predictorator.Models;
+using Predictorator.Services;
+
+namespace Predictorator.Functions;
+
+public class ProcessBackgroundJobsFunction
+{
+    private readonly TableClient _table;
+    private readonly NotificationService _notifications;
+    private readonly IDateTimeProvider _time;
+    private readonly ILogger<ProcessBackgroundJobsFunction> _logger;
+
+    public ProcessBackgroundJobsFunction(TableServiceClient client, NotificationService notifications, IDateTimeProvider time, ILogger<ProcessBackgroundJobsFunction> logger)
+    {
+        _table = client.GetTableClient("BackgroundJobs");
+        _table.CreateIfNotExists();
+        _notifications = notifications;
+        _time = time;
+        _logger = logger;
+    }
+
+    [Function("ProcessBackgroundJobs")]
+    public async Task Run([TimerTrigger("%ProcessBackgroundJobsSchedule%")] TimerInfo timer)
+    {
+        var now = _time.UtcNow;
+        var jobs = _table.Query<BackgroundJob>(j => j.RunAt <= now).ToList();
+        foreach (var job in jobs)
+        {
+            try
+            {
+                switch (job.JobType)
+                {
+                    case "SendSample":
+                        var sample = JsonSerializer.Deserialize<SamplePayload>(job.Payload)!;
+                        await _notifications.SendSampleAsync(sample.Recipients, sample.Message, sample.BaseUrl);
+                        break;
+                    case "SendNewFixturesAvailable":
+                        var nf = JsonSerializer.Deserialize<KeyPayload>(job.Payload)!;
+                        await _notifications.SendNewFixturesAvailableAsync(nf.Key, nf.BaseUrl);
+                        break;
+                    case "SendFixturesStartingSoon":
+                        var fs = JsonSerializer.Deserialize<KeyPayload>(job.Payload)!;
+                        await _notifications.SendFixturesStartingSoonAsync(fs.Key, fs.BaseUrl);
+                        break;
+                }
+                await _table.DeleteEntityAsync(job.PartitionKey, job.RowKey);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error running background job {JobId}", job.RowKey);
+            }
+        }
+    }
+
+    private record SamplePayload(List<AdminSubscriberDto> Recipients, string Message, string BaseUrl);
+    private record KeyPayload(string Key, string BaseUrl);
+}

--- a/Predictorator.Functions/Program.cs
+++ b/Predictorator.Functions/Program.cs
@@ -37,6 +37,7 @@ builder.Services.Configure<TwilioOptions>(configuration.GetSection(TwilioOptions
 builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();
+builder.Services.AddSingleton<IBackgroundJobService, TableBackgroundJobService>();
 builder.Services.AddSingleton<EmailCssInliner>();
 builder.Services.AddSingleton<EmailTemplateRenderer>();
 builder.Services.AddHybridCache();

--- a/Predictorator.Functions/appsettings.json
+++ b/Predictorator.Functions/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "ProcessBackgroundJobsSchedule": "0 */5 10-21 * * *",
+  "ClearExpiredSubscriptionsSchedule": "0 0 * * * *",
+  "FixtureNotificationsSchedule": "0 0 1 * * *",
+  "CheckUnverifiedExpiredSchedule": "0 0 1 * * 1"
+}

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -96,8 +96,12 @@ builder.Services.AddSingleton<EmailCssInliner>();
 builder.Services.AddSingleton<EmailTemplateRenderer>();
 builder.Services.AddSingleton<NotificationFeatureService>();
 builder.Services.AddSingleton<IBackgroundJobService, TableBackgroundJobService>();
-builder.Services.AddHostedService<BackgroundJobProcessor>();
-builder.Services.AddHostedService<RecurringJobProcessor>();
+var useFunctionJobs = builder.Configuration.GetValue<bool>("UseFunctionAppForJobs");
+if (!useFunctionJobs)
+{
+    builder.Services.AddHostedService<BackgroundJobProcessor>();
+    builder.Services.AddHostedService<RecurringJobProcessor>();
+}
 builder.Services.Configure<AdminUserOptions>(options =>
 {
     builder.Configuration.GetSection(AdminUserOptions.SectionName).Bind(options);

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -15,5 +15,6 @@
     "Disabled": false,
     "DisabledMessage": "This functionality is temporarily unavailable due to maintenance. Please check back soon."
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "UseFunctionAppForJobs": false
 }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,23 @@ as needed before running the containers.
 Verification links sent to subscribers are valid for one hour. A background job
 runs weekly to calculate unverified subscriptions that have expired.
 
+### Background job processing
+
+By default the web app processes queued background jobs. To offload this work
+to the Azure Functions project set `UseFunctionAppForJobs` to `true` in
+configuration. When enabled, the web app will still schedule jobs but the
+functions app is responsible for executing them. The admin Jobs view reads
+from the same table storage queue that the function app uses, so it continues
+to list pending jobs regardless of where they are processed.
+
+Timer schedules for the functions can be overridden in configuration using the
+following keys (values shown are defaults):
+
+- `ProcessBackgroundJobsSchedule` = `0 */5 10-21 * * *`
+- `FixtureNotificationsSchedule` = `0 0 1 * * *`
+- `ClearExpiredSubscriptionsSchedule` = `0 0 * * * *`
+- `CheckUnverifiedExpiredSchedule` = `0 0 1 * * 1`
+
 To temporarily disable new subscriptions, set `Subscription:Disabled` to `true`.
 The notice shown in the subscribe dialog can be customized with
 `Subscription:DisabledMessage`.


### PR DESCRIPTION
## Summary
- expose timer schedules for all Azure Functions in configuration
- clarify that the admin Jobs page lists entries from the shared table queue

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`
- `dotnet format --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_689b9869a34c8328b253402e8189b3ad