### PR TITLE
Fix missing HttpContext accessor registration

### DIFF
--- a/Predictorator.Functions/Program.cs
+++ b/Predictorator.Functions/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddHttpClient("fixtures", client =>
         client.DefaultRequestHeaders.Add("x-rapidapi-key", key);
 });
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddTransient<IFixtureService, FixtureService>();
 builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
 builder.Services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();

--- a/Predictorator.Tests/FixtureServiceDiTests.cs
+++ b/Predictorator.Tests/FixtureServiceDiTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class FixtureServiceDiTests
+{
+    [Fact]
+    public void Service_provider_resolves_fixture_service()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpContextAccessor();
+        services.AddHybridCache();
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        services.AddSingleton(httpClientFactory);
+        services.AddSingleton<IConfiguration>(Substitute.For<IConfiguration>());
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
+        services.AddSingleton(env);
+        services.AddSingleton<CachePrefixService>();
+        services.AddTransient<IFixtureService, FixtureService>();
+
+        using var provider = services.BuildServiceProvider();
+        var service = provider.GetRequiredService<IFixtureService>();
+
+        Assert.NotNull(service);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AddHttpContextAccessor` to Functions app so `FixtureService` can resolve
- test `FixtureService` dependency injection resolution

## Testing
- `dotnet format --verbosity diagnostic`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689baadabf108328b9c06c2bd8d5c5fe