### PR TITLE
Add unit tests for notification features and utilities

### DIFF
--- a/Predictorator.Tests/CachePrefixServiceTests.cs
+++ b/Predictorator.Tests/CachePrefixServiceTests.cs
@@ -1,0 +1,27 @@
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class CachePrefixServiceTests
+{
+    [Fact]
+    public void Prefix_is_empty_until_cleared()
+    {
+        var svc = new CachePrefixService();
+        Assert.Equal(string.Empty, svc.Prefix);
+    }
+
+    [Fact]
+    public void Clear_generates_new_prefix_each_time()
+    {
+        var svc = new CachePrefixService();
+        svc.Clear();
+        var first = svc.Prefix;
+        svc.Clear();
+        var second = svc.Prefix;
+        Assert.NotEqual(string.Empty, first);
+        Assert.EndsWith("_", first);
+        Assert.EndsWith("_", second);
+        Assert.NotEqual(first, second);
+    }
+}

--- a/Predictorator.Tests/EmailCssInlinerTests.cs
+++ b/Predictorator.Tests/EmailCssInlinerTests.cs
@@ -1,0 +1,37 @@
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+
+namespace Predictorator.Tests;
+
+public class EmailCssInlinerTests
+{
+    [Fact]
+    public void InlineCss_returns_input_when_file_missing()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(root);
+        var env = new FakeWebHostEnvironment { WebRootPath = root };
+        var inliner = new EmailCssInliner(env);
+        var html = "<p>Hello</p>";
+
+        var result = inliner.InlineCss(html);
+
+        Assert.Equal(html, result);
+    }
+
+    [Fact]
+    public void InlineCss_inlines_styles_from_css_file()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(root, "css"));
+        File.WriteAllText(Path.Combine(root, "css", "email.css"), "p{color:red;}");
+        var env = new FakeWebHostEnvironment { WebRootPath = root };
+        var inliner = new EmailCssInliner(env);
+        var html = "<p>Hello</p>";
+
+        var result = inliner.InlineCss(html);
+        var normalized = result.Replace(" ", "");
+
+        Assert.Contains("style=\"color:red", normalized);
+    }
+}

--- a/Predictorator.Tests/NotificationFeatureServiceTests.cs
+++ b/Predictorator.Tests/NotificationFeatureServiceTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Configuration;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class NotificationFeatureServiceTests
+{
+    private static NotificationFeatureService CreateService(Dictionary<string, string?>? values = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(values ?? new())
+            .Build();
+        return new NotificationFeatureService(config);
+    }
+
+    [Fact]
+    public void EmailEnabled_true_with_token()
+    {
+        var svc = CreateService(new Dictionary<string, string?> { ["Resend:ApiToken"] = "token" });
+        Assert.True(svc.EmailEnabled);
+    }
+
+    [Fact]
+    public void EmailEnabled_false_without_token()
+    {
+        var svc = CreateService();
+        Assert.False(svc.EmailEnabled);
+    }
+
+    [Fact]
+    public void SmsEnabled_true_when_all_settings_present()
+    {
+        var svc = CreateService(new Dictionary<string, string?>
+        {
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:AuthToken"] = "tok",
+            ["Twilio:FromNumber"] = "+1"
+        });
+        Assert.True(svc.SmsEnabled);
+    }
+
+    [Fact]
+    public void SmsEnabled_false_when_any_setting_missing()
+    {
+        var svc = CreateService(new Dictionary<string, string?>
+        {
+            ["Twilio:AccountSid"] = "sid",
+            ["Twilio:FromNumber"] = "+1"
+        });
+        Assert.False(svc.SmsEnabled);
+    }
+
+    [Fact]
+    public void SubscriptionDisabled_defaults_false()
+    {
+        var svc = CreateService();
+        Assert.False(svc.SubscriptionDisabled);
+    }
+
+    [Fact]
+    public void SubscriptionDisabledMessage_returns_configured_value()
+    {
+        var svc = CreateService(new Dictionary<string, string?> { ["Subscription:DisabledMessage"] = "msg" });
+        Assert.Equal("msg", svc.SubscriptionDisabledMessage);
+    }
+
+    [Fact]
+    public void SubscriptionDisabledMessage_returns_default_when_missing()
+    {
+        var svc = CreateService();
+        Assert.Equal(
+            "This functionality is temporarily unavailable due to maintenance. Please check back soon.",
+            svc.SubscriptionDisabledMessage);
+    }
+
+    [Fact]
+    public void AnyEnabled_true_when_either_email_or_sms_enabled()
+    {
+        var svc = CreateService(new Dictionary<string, string?> { ["Resend:ApiToken"] = "token" });
+        Assert.True(svc.AnyEnabled);
+    }
+
+    [Fact]
+    public void AnyEnabled_false_when_all_disabled()
+    {
+        var svc = CreateService();
+        Assert.False(svc.AnyEnabled);
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for NotificationFeatureService email/SMS flags and subscription settings
- verify EmailCssInliner behavior when stylesheet is present or missing
- test CachePrefixService prefix initialization and regeneration

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689bad734c388328ab7be440ecb265da