### PR TITLE
Add DI resolution tests for web and function apps

### DIFF
--- a/Predictorator.Tests/FunctionAppDiResolutionTests.cs
+++ b/Predictorator.Tests/FunctionAppDiResolutionTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Predictorator.Data;
+using Predictorator.Options;
+using Predictorator.Services;
+using Predictorator.Tests.Helpers;
+using Resend;
+
+namespace Predictorator.Tests;
+
+public class FunctionAppDiResolutionTests
+{
+    private readonly IServiceCollection _services;
+    private readonly ServiceProvider _provider;
+
+    public FunctionAppDiResolutionTests()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ApiSettings:RapidApiKey"] = "test",
+                ["Resend:ApiToken"] = "test",
+                ["Twilio:FromNumber"] = "+1000000000",
+                ["Twilio:AccountSid"] = "sid",
+                ["Twilio:AuthToken"] = "token",
+                ["GameWeekCache:CacheDurationHours"] = "1"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var env = Substitute.For<IWebHostEnvironment>();
+        env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
+        env.WebRootPath.Returns(Directory.GetCurrentDirectory());
+        services.AddSingleton(env);
+
+        services.AddHttpClient("fixtures", client =>
+        {
+            client.BaseAddress = new Uri("https://api-football-v1.p.rapidapi.com/v3/");
+        });
+        services.AddHttpContextAccessor();
+        services.AddTransient<IFixtureService, FixtureService>();
+        services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
+        services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
+        services.AddSingleton<NotificationFeatureService>();
+        services.AddHttpClient<ResendClient>();
+        services.Configure<ResendClientOptions>(o => o.ApiToken = configuration["Resend:ApiToken"]!);
+        services.AddTransient<IResend, ResendClient>();
+        services.Configure<TwilioOptions>(configuration.GetSection(TwilioOptions.SectionName));
+        services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
+        services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
+        services.AddSingleton<EmailCssInliner>();
+        services.AddSingleton<EmailTemplateRenderer>();
+        services.AddHybridCache();
+        services.Configure<GameWeekCacheOptions>(configuration.GetSection(GameWeekCacheOptions.SectionName));
+        services.AddSingleton<CachePrefixService>();
+        services.AddTransient<IGameWeekService, GameWeekService>();
+        services.AddSingleton<IDataStore, InMemoryDataStore>();
+        services.AddSingleton<IGameWeekRepository, InMemoryGameWeekRepository>();
+        services.AddTransient<SubscriptionService>();
+        services.AddTransient<NotificationService>();
+
+        _provider = services.BuildServiceProvider();
+        _services = services;
+    }
+
+    [Fact]
+    public void All_services_can_be_resolved()
+    {
+        using var scope = _provider.CreateScope();
+        foreach (var descriptor in _services.Where(d => d.ServiceType.Namespace?.StartsWith("Predictorator") == true))
+        {
+            if (descriptor.ServiceType.IsGenericTypeDefinition) continue;
+            var service = scope.ServiceProvider.GetService(descriptor.ServiceType);
+            Assert.NotNull(service);
+        }
+    }
+}
+

--- a/Predictorator.Tests/WebAppDiResolutionTests.cs
+++ b/Predictorator.Tests/WebAppDiResolutionTests.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+using Predictorator.Data;
+using Predictorator.Tests.Helpers;
+using Predictorator.Services;
+
+namespace Predictorator.Tests;
+
+public class WebAppDiResolutionTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly IServiceCollection _services;
+
+    public WebAppDiResolutionTests(WebApplicationFactory<Program> factory)
+    {
+        Environment.SetEnvironmentVariable("ConnectionStrings__TableStorage", "UseDevelopmentStorage=true");
+        Environment.SetEnvironmentVariable("ApiSettings__RapidApiKey", "test");
+        Environment.SetEnvironmentVariable("Resend__ApiToken", "test");
+        Environment.SetEnvironmentVariable("Twilio__FromNumber", "+1000000000");
+        Environment.SetEnvironmentVariable("Twilio__AccountSid", "sid");
+        Environment.SetEnvironmentVariable("Twilio__AuthToken", "token");
+
+        IServiceCollection? descriptors = null;
+        var tempFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Testing");
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IHostedService>();
+                services.RemoveAll<IDataStore>();
+                services.RemoveAll<IGameWeekRepository>();
+                services.RemoveAll<IBackgroundJobService>();
+                services.AddSingleton<IDataStore, InMemoryDataStore>();
+                services.AddSingleton<IGameWeekRepository, InMemoryGameWeekRepository>();
+                services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
+                descriptors = services;
+            });
+        });
+        tempFactory.CreateClient();
+        _factory = tempFactory;
+        _services = descriptors!;
+    }
+
+    [Fact]
+    public void All_services_can_be_resolved()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var coreAssembly = typeof(IFixtureService).Assembly;
+        foreach (var descriptor in _services.Where(d =>
+            d.ServiceType.Namespace?.StartsWith("Predictorator") == true &&
+            (d.ServiceType.Assembly == coreAssembly || d.ImplementationType?.Assembly == coreAssembly)))
+        {
+            if (descriptor.ServiceType.IsGenericTypeDefinition) continue;
+            var service = scope.ServiceProvider.GetService(descriptor.ServiceType);
+            Assert.NotNull(service);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure web app services resolve by building a test host and checking core service registrations
- verify function app DI configuration by constructing a service provider and resolving all core services

## Testing
- `dotnet format Predictorator.sln --include Predictorator.Tests/WebAppDiResolutionTests.cs Predictorator.Tests/FunctionAppDiResolutionTests.cs -v diag`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689baceeca3483288a3cf238125cd4bb