### PR TITLE
Embed email CSS string

### DIFF
--- a/Predictorator.Core/Services/EmailCssInliner.cs
+++ b/Predictorator.Core/Services/EmailCssInliner.cs
@@ -1,17 +1,20 @@
-using Microsoft.AspNetCore.Hosting;
 using PreMailer.Net;
 
 namespace Predictorator.Services;
 
 public class EmailCssInliner
 {
-    private readonly string? _css;
+    private readonly string _css;
 
-    public EmailCssInliner(IWebHostEnvironment env)
+    private const string DefaultCss = "body { font-family: Arial, sans-serif; }\na { color: #1e88e5; }\n";
+
+    public EmailCssInliner() : this(DefaultCss)
     {
-        var path = Path.Combine(env.WebRootPath, "css", "email.css");
-        if (File.Exists(path))
-            _css = File.ReadAllText(path);
+    }
+
+    public EmailCssInliner(string css)
+    {
+        _css = css;
     }
 
     public string InlineCss(string html)

--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -7,7 +7,6 @@ using Predictorator.Tests.Helpers;
 using Predictorator.Models.Fixtures;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
-using System.IO;
 using System;
 using System.Text;
 
@@ -27,10 +26,7 @@ public class AdminServiceTests
                 ["BASE_URL"] = "http://localhost"
             })
             .Build();
-        var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
-        Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
-        File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner();
         var renderer = new EmailTemplateRenderer();
         provider = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
         var fixtures = new FakeFixtureService(new FixturesResponse());

--- a/Predictorator.Tests/EmailCssInlinerTests.cs
+++ b/Predictorator.Tests/EmailCssInlinerTests.cs
@@ -1,17 +1,13 @@
 using Predictorator.Services;
-using Predictorator.Tests.Helpers;
 
 namespace Predictorator.Tests;
 
 public class EmailCssInlinerTests
 {
     [Fact]
-    public void InlineCss_returns_input_when_file_missing()
+    public void InlineCss_returns_input_when_css_empty()
     {
-        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(root);
-        var env = new FakeWebHostEnvironment { WebRootPath = root };
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner(string.Empty);
         var html = "<p>Hello</p>";
 
         var result = inliner.InlineCss(html);
@@ -20,13 +16,9 @@ public class EmailCssInlinerTests
     }
 
     [Fact]
-    public void InlineCss_inlines_styles_from_css_file()
+    public void InlineCss_inlines_styles_from_css_string()
     {
-        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(Path.Combine(root, "css"));
-        File.WriteAllText(Path.Combine(root, "css", "email.css"), "p{color:red;}");
-        var env = new FakeWebHostEnvironment { WebRootPath = root };
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner("p{color:red;}");
         var html = "<p>Hello</p>";
 
         var result = inliner.InlineCss(html);

--- a/Predictorator.Tests/FunctionAppDiResolutionTests.cs
+++ b/Predictorator.Tests/FunctionAppDiResolutionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,7 +38,7 @@ public class FunctionAppDiResolutionTests
         var env = Substitute.For<IWebHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
         env.WebRootPath.Returns(Directory.GetCurrentDirectory());
-        services.AddSingleton(env);
+        services.AddSingleton<IWebHostEnvironment>(env);
 
         services.AddHttpClient("fixtures", client =>
         {

--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -6,7 +6,6 @@ using Predictorator.Services;
 using Predictorator.Tests.Helpers;
 using Resend;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.IO;
 
 namespace Predictorator.Tests;
 
@@ -49,10 +48,7 @@ public class NotificationServiceTests
                 }
             }
         });
-        var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
-        Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
-        File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner();
         var renderer = new EmailTemplateRenderer();
         var gameWeeks = new FakeGameWeekService();
         gameWeeks.Items.Add(new GameWeek { Season = "25-26", Number = 1, StartDate = nowUtc.Date, EndDate = nowUtc.Date.AddDays(6) });

--- a/Predictorator.Tests/SubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/SubscribeComponentBUnitTests.cs
@@ -8,8 +8,6 @@ using NSubstitute;
 using Predictorator.Components.Pages.Subscription;
 using Predictorator.Services;
 using Predictorator.Tests.Helpers;
-using System.IO;
-using System;
 using Resend;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -38,10 +36,7 @@ public class SubscribeComponentBUnitTests
         var sms = Substitute.For<ITwilioSmsSender>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
-        var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
-        Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
-        File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner();
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
         ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, inliner, renderer, logger));

--- a/Predictorator.Tests/SubscriptionServiceTests.cs
+++ b/Predictorator.Tests/SubscriptionServiceTests.cs
@@ -4,7 +4,6 @@ using Predictorator.Models;
 using Predictorator.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Predictorator.Tests.Helpers;
-using System.IO;
 using Resend;
 
 namespace Predictorator.Tests;
@@ -21,8 +20,7 @@ public class SubscriptionServiceTests
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Resend:From"] = "from@example.com" })
             .Build();
         provider ??= new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
-        var env = new FakeWebHostEnvironment { WebRootPath = Path.GetTempPath() };
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner();
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
         return new SubscriptionService(store, resend, config, sms, provider, inliner, renderer, logger);

--- a/Predictorator.Tests/UnsubscribeComponentBUnitTests.cs
+++ b/Predictorator.Tests/UnsubscribeComponentBUnitTests.cs
@@ -12,7 +12,6 @@ using Predictorator.Services;
 using Predictorator.Tests.Helpers;
 using Resend;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.IO;
 
 namespace Predictorator.Tests;
 
@@ -41,10 +40,7 @@ public class UnsubscribeComponentBUnitTests
         var sms = Substitute.For<ITwilioSmsSender>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
-        var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
-        Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
-        File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner();
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
         ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, inliner, renderer, logger));

--- a/Predictorator.Tests/VerifyComponentBUnitTests.cs
+++ b/Predictorator.Tests/VerifyComponentBUnitTests.cs
@@ -12,7 +12,6 @@ using Predictorator.Services;
 using Predictorator.Tests.Helpers;
 using Resend;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.IO;
 
 namespace Predictorator.Tests;
 
@@ -41,10 +40,7 @@ public class VerifyComponentBUnitTests
         var sms = Substitute.For<ITwilioSmsSender>();
         var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow, Today = DateTime.Today };
         ctx.Services.AddSingleton<IDateTimeProvider>(time);
-        var env = new FakeWebHostEnvironment { WebRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) };
-        Directory.CreateDirectory(Path.Combine(env.WebRootPath, "css"));
-        File.WriteAllText(Path.Combine(env.WebRootPath, "css", "email.css"), "p{color:red;}");
-        var inliner = new EmailCssInliner(env);
+        var inliner = new EmailCssInliner();
         var renderer = new EmailTemplateRenderer();
         var logger = NullLogger<SubscriptionService>.Instance;
         ctx.Services.AddSingleton(new SubscriptionService(store, resend, config, sms, time, inliner, renderer, logger));


### PR DESCRIPTION
## Summary
- embed default email CSS as a string to remove host environment dependency
- simplify DI tests and component/service tests to construct EmailCssInliner without file system

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c3196aaa88328ab78da89076873fc