### PR TITLE
Fix environment dependency for FixtureService

### DIFF
--- a/Predictorator.Core/Services/FixtureService.cs
+++ b/Predictorator.Core/Services/FixtureService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Hosting;
 using Predictorator.Models.Fixtures;
 
 namespace Predictorator.Services
@@ -12,7 +13,7 @@ namespace Predictorator.Services
         private readonly CachePrefixService _prefix;
         private readonly IHttpContextAccessor _contextAccessor;
         private readonly IConfiguration _configuration;
-        private readonly IWebHostEnvironment _environment;
+        private readonly IHostEnvironment _environment;
         private readonly TimeSpan _cacheDuration = TimeSpan.FromHours(12);
 
         public FixtureService(
@@ -21,7 +22,7 @@ namespace Predictorator.Services
             CachePrefixService prefix,
             IHttpContextAccessor contextAccessor,
             IConfiguration configuration,
-            IWebHostEnvironment environment)
+            IHostEnvironment environment)
         {
             _httpClient = httpClientFactory.CreateClient("fixtures");
             _cache = cache;

--- a/Predictorator.Tests/FixtureServiceDiTests.cs
+++ b/Predictorator.Tests/FixtureServiceDiTests.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Hybrid;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using NSubstitute;
 using Predictorator.Services;
@@ -19,7 +19,7 @@ public class FixtureServiceDiTests
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
         services.AddSingleton(httpClientFactory);
         services.AddSingleton<IConfiguration>(Substitute.For<IConfiguration>());
-        var env = Substitute.For<IWebHostEnvironment>();
+        var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
         services.AddSingleton(env);
         services.AddSingleton<CachePrefixService>();

--- a/Predictorator.Tests/FixtureServiceTestTokenTests.cs
+++ b/Predictorator.Tests/FixtureServiceTestTokenTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Configuration;
@@ -15,7 +15,7 @@ public class FixtureServiceTestTokenTests
     [Fact]
     public async Task Returns_mock_data_when_token_matches()
     {
-        var env = Substitute.For<IWebHostEnvironment>();
+        var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
 
         var config = new ConfigurationBuilder()
@@ -50,7 +50,7 @@ public class FixtureServiceTestTokenTests
     [Fact]
     public async Task Fetches_from_http_when_token_does_not_match()
     {
-        var env = Substitute.For<IWebHostEnvironment>();
+        var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
 
         var config = new ConfigurationBuilder()

--- a/Predictorator.Tests/FixtureServiceTests.cs
+++ b/Predictorator.Tests/FixtureServiceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Configuration;
@@ -26,7 +26,7 @@ public class FixtureServiceTests
         var prefix = new CachePrefixService();
         var accessor = Substitute.For<IHttpContextAccessor>();
         var config = Substitute.For<IConfiguration>();
-        var env = Substitute.For<IWebHostEnvironment>();
+        var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
         var service = new FixtureService(httpClientFactory, cache, prefix, accessor, config, env);
 

--- a/Predictorator.Tests/FunctionAppDiResolutionTests.cs
+++ b/Predictorator.Tests/FunctionAppDiResolutionTests.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -35,10 +35,9 @@ public class FunctionAppDiResolutionTests
         var services = new ServiceCollection();
         services.AddSingleton<IConfiguration>(configuration);
 
-        var env = Substitute.For<IWebHostEnvironment>();
+        var env = Substitute.For<IHostEnvironment>();
         env.ContentRootPath.Returns(Directory.GetCurrentDirectory());
-        env.WebRootPath.Returns(Directory.GetCurrentDirectory());
-        services.AddSingleton<IWebHostEnvironment>(env);
+        services.AddSingleton<IHostEnvironment>(env);
 
         services.AddHttpClient("fixtures", client =>
         {

--- a/Predictorator.Tests/Helpers/FakeHostEnvironment.cs
+++ b/Predictorator.Tests/Helpers/FakeHostEnvironment.cs
@@ -1,14 +1,12 @@
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 
 namespace Predictorator.Tests.Helpers;
 
-public class FakeWebHostEnvironment : IWebHostEnvironment
+public class FakeHostEnvironment : IHostEnvironment
 {
-    public string WebRootPath { get; set; } = ".";
-    public string ContentRootPath { get; set; } = ".";
     public string EnvironmentName { get; set; } = "Development";
     public string ApplicationName { get; set; } = "Test";
-    public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    public string ContentRootPath { get; set; } = ".";
     public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
 }


### PR DESCRIPTION
## Summary
- resolve FixtureService using `IHostEnvironment` instead of `IWebHostEnvironment`
- update tests to use `IHostEnvironment`

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c4aeee5588328be7d91846230d67f