### PR TITLE
Skip existing gameweeks during import

### DIFF
--- a/Predictorator.Core/Services/GameWeekService.cs
+++ b/Predictorator.Core/Services/GameWeekService.cs
@@ -135,19 +135,21 @@ public class GameWeekService : IGameWeekService
             if (!DateTime.TryParse(parts[3], null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var end)) continue;
 
             var existing = await _repo.GetGameWeekAsync(season, number);
-            if (existing == null)
+            if (existing != null)
             {
-                added++;
+                continue;
             }
+
             var gw = new GameWeek
             {
-                Id = existing?.Id ?? 0,
                 Season = season,
                 Number = number,
                 StartDate = start,
                 EndDate = end
             };
+
             await AddOrUpdateAsync(gw);
+            added++;
         }
         return added;
     }

--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -156,7 +156,7 @@ public class GameWeekServiceTests
     }
 
     [Fact]
-    public async Task ImportCsvAsync_adds_and_updates()
+    public async Task ImportCsvAsync_adds_only_new_gameweeks()
     {
         var service = CreateService(out var inner, out var repo);
         var now = DateTime.UtcNow.Date;
@@ -172,6 +172,7 @@ public class GameWeekServiceTests
         Assert.Equal(1, added);
         Assert.Equal(2, inner.Items.Count);
         var gw1 = inner.Items.Single(g => g.Number == 1);
-        Assert.Equal(now.AddDays(1), gw1.StartDate);
+        Assert.Equal(now, gw1.StartDate);
+        Assert.Equal(now.AddDays(6), gw1.EndDate);
     }
 }

--- a/Predictorator.Tests/Helpers/FakeGameWeekService.cs
+++ b/Predictorator.Tests/Helpers/FakeGameWeekService.cs
@@ -92,16 +92,13 @@ public class FakeGameWeekService : IGameWeekService
             if (!DateTime.TryParse(parts[3], out var end)) continue;
 
             var existing = Items.FirstOrDefault(g => g.Season == season && g.Number == number);
-            if (existing == null)
+            if (existing != null)
             {
-                Items.Add(new GameWeek { Season = season, Number = number, StartDate = start, EndDate = end });
-                added++;
+                continue;
             }
-            else
-            {
-                existing.StartDate = start;
-                existing.EndDate = end;
-            }
+
+            Items.Add(new GameWeek { Season = season, Number = number, StartDate = start, EndDate = end });
+            added++;
         }
 
         return added;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application. Once
 Administrators can export and import game weeks as CSV files from the admin
-interface. Administrators can also view and delete queued background jobs.
+interface. Importing a CSV skips any game weeks that already exist. Administrators can also view and delete queued background jobs.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 Email delivery is handled by [Resend](https://resend.com). Configure the


### PR DESCRIPTION
## Summary
- ignore gameweeks that already exist when importing from CSV
- update fake and unit tests for no-op behavior
- document that imports skip existing gameweeks

## Testing
- `dotnet format Predictorator.sln`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_689c863e7408832891e8b29f61662a78