### PR TITLE
Refactor subscriber handling

### DIFF
--- a/Predictorator.Core/Services/EmailSubscriberHandler.cs
+++ b/Predictorator.Core/Services/EmailSubscriberHandler.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Predictorator.Core.Data;
+using Predictorator.Core.Models;
+
+namespace Predictorator.Core.Services;
+
+public class EmailSubscriberHandler : ISubscriberHandler
+{
+    private readonly IDataStore _store;
+    private readonly IDateTimeProvider _time;
+
+    public EmailSubscriberHandler(IDataStore store, IDateTimeProvider time)
+    {
+        _store = store;
+        _time = time;
+    }
+
+    public string Type => "Email";
+
+    public async Task ConfirmAsync(int id)
+    {
+        var entity = await _store.GetEmailSubscriberByIdAsync(id);
+        if (entity != null)
+        {
+            entity.IsVerified = true;
+            await _store.UpdateEmailSubscriberAsync(entity);
+        }
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _store.GetEmailSubscriberByIdAsync(id);
+        if (entity != null)
+        {
+            await _store.RemoveEmailSubscriberAsync(entity);
+        }
+    }
+
+    public async Task<AdminSubscriberDto?> AddSubscriberAsync(string contact)
+    {
+        if (await _store.EmailSubscriberExistsAsync(contact))
+            return null;
+        var sub = new Subscriber
+        {
+            Email = contact,
+            IsVerified = true,
+            VerificationToken = Guid.NewGuid().ToString("N"),
+            UnsubscribeToken = Guid.NewGuid().ToString("N"),
+            CreatedAt = _time.UtcNow
+        };
+        await _store.AddEmailSubscriberAsync(sub);
+        return new AdminSubscriberDto(sub.Id, sub.Email, sub.IsVerified, Type);
+    }
+}
+

--- a/Predictorator.Core/Services/ISubscriberHandler.cs
+++ b/Predictorator.Core/Services/ISubscriberHandler.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace Predictorator.Core.Services;
+
+public interface ISubscriberHandler
+{
+    string Type { get; }
+    Task ConfirmAsync(int id);
+    Task DeleteAsync(int id);
+    Task<AdminSubscriberDto?> AddSubscriberAsync(string contact);
+}
+

--- a/Predictorator.Core/Services/SmsSubscriberHandler.cs
+++ b/Predictorator.Core/Services/SmsSubscriberHandler.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using Predictorator.Core.Data;
+using Predictorator.Core.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Predictorator.Core.Services;
+
+public class SmsSubscriberHandler : ISubscriberHandler
+{
+    private readonly IDataStore _store;
+    private readonly IDateTimeProvider _time;
+    private readonly ILogger<SmsSubscriberHandler> _logger;
+
+    public SmsSubscriberHandler(IDataStore store, IDateTimeProvider time, ILogger<SmsSubscriberHandler> logger)
+    {
+        _store = store;
+        _time = time;
+        _logger = logger;
+    }
+
+    public string Type => "SMS";
+
+    public async Task ConfirmAsync(int id)
+    {
+        _logger.LogInformation("Confirming SMS subscriber {Id}", id);
+        var entity = await _store.GetSmsSubscriberByIdAsync(id);
+        if (entity != null)
+        {
+            entity.IsVerified = true;
+            await _store.UpdateSmsSubscriberAsync(entity);
+        }
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        _logger.LogInformation("Deleting SMS subscriber {Id}", id);
+        var entity = await _store.GetSmsSubscriberByIdAsync(id);
+        if (entity != null)
+        {
+            await _store.RemoveSmsSubscriberAsync(entity);
+        }
+    }
+
+    public async Task<AdminSubscriberDto?> AddSubscriberAsync(string contact)
+    {
+        if (await _store.SmsSubscriberExistsAsync(contact))
+            return null;
+        var sub = new SmsSubscriber
+        {
+            PhoneNumber = contact,
+            IsVerified = true,
+            VerificationToken = Guid.NewGuid().ToString("N"),
+            UnsubscribeToken = Guid.NewGuid().ToString("N"),
+            CreatedAt = _time.UtcNow
+        };
+        await _store.AddSmsSubscriberAsync(sub);
+        return new AdminSubscriberDto(sub.Id, sub.PhoneNumber, sub.IsVerified, Type);
+    }
+}
+

--- a/Predictorator.Tests/AdminServiceTests.cs
+++ b/Predictorator.Tests/AdminServiceTests.cs
@@ -39,7 +39,12 @@ public class AdminServiceTests
         var notifications = new NotificationService(store, resend, sms, config, fixtures, gameWeeks, range, features, provider, jobs, inliner, renderer, nLogger);
         var aLogger = NullLogger<AdminService>.Instance;
         var prefix = new CachePrefixService();
-        return new AdminService(store, resend, sms, config, inliner, renderer, notifications, aLogger, jobs, provider, prefix);
+        var handlers = new ISubscriberHandler[]
+        {
+            new EmailSubscriberHandler(store, provider),
+            new SmsSubscriberHandler(store, provider, NullLogger<SmsSubscriberHandler>.Instance)
+        };
+        return new AdminService(store, resend, sms, config, inliner, renderer, notifications, aLogger, jobs, provider, prefix, handlers);
     }
 
     [Fact]

--- a/Predictorator/Startup/ServiceCollectionExtensions.cs
+++ b/Predictorator/Startup/ServiceCollectionExtensions.cs
@@ -56,6 +56,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IGameWeekRepository, TableGameWeekRepository>();
         services.AddTransient<SubscriptionService>();
         services.AddTransient<NotificationService>();
+        services.AddTransient<ISubscriberHandler, EmailSubscriberHandler>();
+        services.AddTransient<ISubscriberHandler, SmsSubscriberHandler>();
         services.AddTransient<AdminService>();
         services.AddTransient<IGameWeekService, GameWeekService>();
         services.AddSingleton<EmailCssInliner>();


### PR DESCRIPTION
## Summary
- add `ISubscriberHandler` abstraction with confirm, delete, and add operations
- implement email and SMS handlers
- delegate AdminService subscriber operations to handlers and register them

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`
- `dotnet format Predictorator.sln` *(failed: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_689c8671c61083289a4b7e99574d3d67