### PR TITLE
Add delay clamping helper

### DIFF
--- a/Predictorator.Core/Services/AdminService.cs
+++ b/Predictorator.Core/Services/AdminService.cs
@@ -294,8 +294,7 @@ public class AdminService
     public Task ScheduleFixturesStartingSoonSampleAsync(IEnumerable<AdminSubscriberDto> recipients, DateTime sendUtc)
     {
         var baseUrl = _config["BASE_URL"] ?? "http://localhost";
-        var delay = sendUtc - _time.UtcNow;
-        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        var delay = TimeExtensions.ClampDelay(sendUtc, _time);
         return _jobs.ScheduleAsync(
             "SendSample",
             new { Recipients = recipients, Message = "Fixtures start in 2 hours!", BaseUrl = baseUrl },
@@ -306,8 +305,7 @@ public class AdminService
     {
         var baseUrl = _config["BASE_URL"] ?? "http://localhost";
         var key = sendUtc.ToString("yyyy-MM-dd");
-        var delay = sendUtc - _time.UtcNow;
-        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        var delay = TimeExtensions.ClampDelay(sendUtc, _time);
         return _jobs.ScheduleAsync(
             "SendNewFixturesAvailable",
             new { Key = key, BaseUrl = baseUrl },
@@ -318,8 +316,7 @@ public class AdminService
     {
         var baseUrl = _config["BASE_URL"] ?? "http://localhost";
         var key = sendUtc.ToString("O");
-        var delay = sendUtc - _time.UtcNow;
-        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        var delay = TimeExtensions.ClampDelay(sendUtc, _time);
         return _jobs.ScheduleAsync(
             "SendFixturesStartingSoon",
             new { Key = key, BaseUrl = baseUrl },

--- a/Predictorator.Core/Services/NotificationService.cs
+++ b/Predictorator.Core/Services/NotificationService.cs
@@ -94,8 +94,7 @@ public class NotificationService
                 {
                     var sendTimeUk = futureUk.Date.AddHours(10);
                     var sendTimeUtc = TimeZoneInfo.ConvertTimeToUtc(sendTimeUk, UkTimeZone);
-                    var delay = sendTimeUtc - nowUtc;
-                    if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+                    var delay = TimeExtensions.ClampDelay(sendTimeUtc, _time);
                     await _jobs.ScheduleAsync(
                         "SendNewFixturesAvailable",
                         new { Key = key, BaseUrl = baseUrl },
@@ -113,8 +112,7 @@ public class NotificationService
             if (!sent)
             {
                 var sendTimeUtc = first.Fixture.Date.AddHours(-2);
-                var delay = sendTimeUtc - nowUtc;
-                if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+                var delay = TimeExtensions.ClampDelay(sendTimeUtc, _time);
                 await _jobs.ScheduleAsync(
                     "SendFixturesStartingSoon",
                     new { Key = key, BaseUrl = baseUrl },

--- a/Predictorator.Core/Services/TimeExtensions.cs
+++ b/Predictorator.Core/Services/TimeExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Predictorator.Core.Services;
+
+public static class TimeExtensions
+{
+    public static TimeSpan ClampDelay(DateTime target, IDateTimeProvider now)
+    {
+        var delay = target - now.UtcNow;
+        return delay < TimeSpan.Zero ? TimeSpan.Zero : delay;
+    }
+}
+

--- a/Predictorator.Tests/TimeExtensionsTests.cs
+++ b/Predictorator.Tests/TimeExtensionsTests.cs
@@ -1,0 +1,32 @@
+using Predictorator.Core.Services;
+using Predictorator.Tests.Helpers;
+
+namespace Predictorator.Tests;
+
+public class TimeExtensionsTests
+{
+    [Fact]
+    public void ClampDelay_FutureDate_ReturnsDifference()
+    {
+        var now = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var provider = new FakeDateTimeProvider { UtcNow = now };
+        var target = now.AddMinutes(5);
+
+        var delay = TimeExtensions.ClampDelay(target, provider);
+
+        Assert.Equal(TimeSpan.FromMinutes(5), delay);
+    }
+
+    [Fact]
+    public void ClampDelay_PastDate_ReturnsZero()
+    {
+        var now = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var provider = new FakeDateTimeProvider { UtcNow = now };
+        var target = now.AddMinutes(-5);
+
+        var delay = TimeExtensions.ClampDelay(target, provider);
+
+        Assert.Equal(TimeSpan.Zero, delay);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helper to clamp negative delays
- use helper in admin and notification services
- test delay clamping for past and future dates

## Testing
- `dotnet format Predictorator.sln`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c867f5de083288508d5c89f08b41a