### PR TITLE
Extract prediction processing into service

### DIFF
--- a/Predictorator.Core/Services/PredictionProcessingService.cs
+++ b/Predictorator.Core/Services/PredictionProcessingService.cs
@@ -1,0 +1,92 @@
+using Predictorator.Core.Models.Fixtures;
+using System.Linq;
+
+namespace Predictorator.Core.Services;
+
+public class PredictionProcessingService
+{
+    private readonly IFixtureService _fixtures;
+    private readonly IDateTimeProvider _time;
+
+    public PredictionProcessingService(IFixtureService fixtures, IDateTimeProvider time)
+    {
+        _fixtures = fixtures;
+        _time = time;
+    }
+
+    public virtual async Task<IReadOnlyList<Prediction>> ProcessAsync(string? text)
+    {
+        var parsed = PredictionEmailParser.Parse(text)
+            .Select(p => new Prediction
+            {
+                Date = p.Date,
+                HomeTeam = p.HomeTeam,
+                HomeScore = p.HomeScore,
+                AwayScore = p.AwayScore,
+                AwayTeam = p.AwayTeam
+            })
+            .ToList();
+
+        if (parsed.Count == 0)
+            return parsed;
+
+        var from = parsed.Min(p => p.Date);
+        var to = parsed.Max(p => p.Date);
+        var fixtures = await _fixtures.GetFixturesAsync(from, to);
+        var lookup = fixtures.Response.ToDictionary(
+            f => (f.Fixture.Date.Date,
+                  f.Teams.Home.Name.ToLowerInvariant(),
+                  f.Teams.Away.Name.ToLowerInvariant()));
+
+        DateTime? lastFixtureTime = null;
+        foreach (var p in parsed)
+        {
+            var key = (p.Date.Date, p.HomeTeam.ToLowerInvariant(), p.AwayTeam.ToLowerInvariant());
+            if (lookup.TryGetValue(key, out var fixture))
+            {
+                var fixtureDate = DateTime.SpecifyKind(fixture.Fixture.Date, DateTimeKind.Utc);
+                if (lastFixtureTime == null || fixtureDate > lastFixtureTime)
+                    lastFixtureTime = fixtureDate;
+            }
+        }
+
+        if (lastFixtureTime.HasValue && _time.UtcNow >= lastFixtureTime.Value.AddHours(3))
+        {
+            foreach (var p in parsed)
+            {
+                var key = (p.Date.Date, p.HomeTeam.ToLowerInvariant(), p.AwayTeam.ToLowerInvariant());
+                if (lookup.TryGetValue(key, out var fixture))
+                {
+                    p.ActualHomeScore = fixture.Score?.Fulltime.Home;
+                    p.ActualAwayScore = fixture.Score?.Fulltime.Away;
+                    if (p.ActualHomeScore.HasValue && p.ActualAwayScore.HasValue)
+                    {
+                        if (p.HomeScore == p.ActualHomeScore && p.AwayScore == p.ActualAwayScore)
+                            p.Points = 3;
+                        else
+                        {
+                            var predictedResult = Math.Sign(p.HomeScore - p.AwayScore);
+                            var actualResult = Math.Sign(p.ActualHomeScore.Value - p.ActualAwayScore.Value);
+                            if (predictedResult == actualResult)
+                                p.Points = 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        return parsed;
+    }
+
+    public class Prediction
+    {
+        public DateTime Date { get; init; }
+        public string HomeTeam { get; init; } = string.Empty;
+        public int HomeScore { get; init; }
+        public int AwayScore { get; init; }
+        public string AwayTeam { get; init; } = string.Empty;
+        public int? ActualHomeScore { get; set; }
+        public int? ActualAwayScore { get; set; }
+        public int Points { get; set; }
+    }
+}

--- a/Predictorator.Tests/ParsePageBUnitTests.cs
+++ b/Predictorator.Tests/ParsePageBUnitTests.cs
@@ -17,8 +17,10 @@ public class ParsePageBUnitTests
         var ctx = new BunitContext();
         ctx.JSInterop.Mode = JSRuntimeMode.Loose;
         ctx.Services.AddMudServices();
-        ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
-        ctx.Services.AddSingleton<IDateTimeProvider>(new FakeDateTimeProvider { UtcNow = now, Today = now.Date });
+        var service = new PredictionProcessingService(
+            new FakeFixtureService(fixtures),
+            new FakeDateTimeProvider { UtcNow = now, Today = now.Date });
+        ctx.Services.AddSingleton(service);
         return ctx;
     }
 

--- a/Predictorator.Tests/PredictionProcessingServiceTests.cs
+++ b/Predictorator.Tests/PredictionProcessingServiceTests.cs
@@ -1,0 +1,124 @@
+using Predictorator.Core.Models.Fixtures;
+using Predictorator.Core.Services;
+using Predictorator.Tests.Helpers;
+
+namespace Predictorator.Tests;
+
+public class PredictionProcessingServiceTests
+{
+    [Fact]
+    public async Task ShowsActualScores_WhenPastThreshold()
+    {
+        var fixtureTime = new DateTime(2024, 1, 1, 15, 0, 0, DateTimeKind.Utc);
+        var fixtures = new FixturesResponse
+        {
+            FromDate = fixtureTime.Date,
+            ToDate = fixtureTime.Date,
+            Response =
+            [
+                new FixtureData
+                {
+                    Fixture = new Fixture { Id = 1, Date = fixtureTime, Venue = new Venue() },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Team A" },
+                        Away = new Team { Name = "Team B" }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = 3, Away = 2 } }
+                }
+            ]
+        };
+        var service = new PredictionProcessingService(
+            new FakeFixtureService(fixtures),
+            new FakeDateTimeProvider { UtcNow = fixtureTime.AddHours(4) });
+        const string text = "Monday, January 1, 2024\nTeam A 1 - 2 Team B";
+
+        var result = await service.ProcessAsync(text);
+
+        var prediction = Assert.Single(result);
+        Assert.Equal(3, prediction.ActualHomeScore);
+        Assert.Equal(2, prediction.ActualAwayScore);
+        Assert.Equal(0, prediction.Points);
+    }
+
+    [Fact]
+    public async Task DoesNotShowScores_BeforeThreshold()
+    {
+        var fixtureTime = new DateTime(2024, 1, 1, 15, 0, 0, DateTimeKind.Utc);
+        var fixtures = new FixturesResponse
+        {
+            FromDate = fixtureTime.Date,
+            ToDate = fixtureTime.Date,
+            Response =
+            [
+                new FixtureData
+                {
+                    Fixture = new Fixture { Id = 1, Date = fixtureTime, Venue = new Venue() },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Team A" },
+                        Away = new Team { Name = "Team B" }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = 3, Away = 2 } }
+                }
+            ]
+        };
+        var service = new PredictionProcessingService(
+            new FakeFixtureService(fixtures),
+            new FakeDateTimeProvider { UtcNow = fixtureTime.AddHours(2) });
+        const string text = "Monday, January 1, 2024\nTeam A 1 - 2 Team B";
+
+        var result = await service.ProcessAsync(text);
+
+        var prediction = Assert.Single(result);
+        Assert.Null(prediction.ActualHomeScore);
+        Assert.Null(prediction.ActualAwayScore);
+        Assert.Equal(0, prediction.Points);
+    }
+
+    [Fact]
+    public async Task CalculatesPointsCorrectly()
+    {
+        var fixtureTime1 = new DateTime(2024, 1, 1, 15, 0, 0, DateTimeKind.Utc);
+        var fixtureTime2 = new DateTime(2024, 1, 1, 17, 0, 0, DateTimeKind.Utc);
+        var fixtures = new FixturesResponse
+        {
+            FromDate = fixtureTime1.Date,
+            ToDate = fixtureTime2.Date,
+            Response =
+            [
+                new FixtureData
+                {
+                    Fixture = new Fixture { Id = 1, Date = fixtureTime1, Venue = new Venue() },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Team A" },
+                        Away = new Team { Name = "Team B" }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = 1, Away = 2 } }
+                },
+                new FixtureData
+                {
+                    Fixture = new Fixture { Id = 2, Date = fixtureTime2, Venue = new Venue() },
+                    Teams = new Teams
+                    {
+                        Home = new Team { Name = "Team C" },
+                        Away = new Team { Name = "Team D" }
+                    },
+                    Score = new Score { Fulltime = new ScoreHomeAway { Home = 2, Away = 1 } }
+                }
+            ]
+        };
+        var service = new PredictionProcessingService(
+            new FakeFixtureService(fixtures),
+            new FakeDateTimeProvider { UtcNow = fixtureTime2.AddHours(4) });
+        const string text = "Monday, January 1, 2024\nTeam A 1 - 2 Team B\nTeam C 1 - 0 Team D";
+
+        var result = await service.ProcessAsync(text);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(3, result[0].Points);
+        Assert.Equal(1, result[1].Points);
+        Assert.Equal(4, result.Sum(p => p.Points));
+    }
+}

--- a/Predictorator/Components/Pages/Parse.razor
+++ b/Predictorator/Components/Pages/Parse.razor
@@ -1,8 +1,7 @@
 @page "/parse"
 @rendermode InteractiveServer
 @inject IJSRuntime Js
-@inject IFixtureService FixtureService
-@inject IDateTimeProvider TimeProvider
+@inject PredictionProcessingService ProcessingService
 @inject ISnackbar Snackbar
 @using System.Text
 @using Predictorator.Core.Services
@@ -53,69 +52,12 @@
 @code {
     private string _name = string.Empty;
     private string _input = string.Empty;
-    private List<Prediction> _predictions = new();
+    private List<PredictionProcessingService.Prediction> _predictions = new();
 
     private async Task ParseText()
     {
         _name = _name.Trim();
-        var parsed = PredictionEmailParser.Parse(_input).ToList();
-        _predictions = parsed.Select(p => new Prediction
-        {
-            Date = p.Date,
-            HomeTeam = p.HomeTeam,
-            HomeScore = p.HomeScore,
-            AwayScore = p.AwayScore,
-            AwayTeam = p.AwayTeam
-        }).ToList();
-
-        if (_predictions.Count == 0)
-            return;
-
-        var from = _predictions.Min(p => p.Date);
-        var to = _predictions.Max(p => p.Date);
-
-        var fixtures = await FixtureService.GetFixturesAsync(from, to);
-        var lookup = fixtures.Response.ToDictionary(
-            f => (f.Fixture.Date.Date,
-                   f.Teams.Home.Name.ToLowerInvariant(),
-                   f.Teams.Away.Name.ToLowerInvariant()));
-
-        DateTime? lastFixtureTime = null;
-        foreach (var p in _predictions)
-        {
-            var key = (p.Date.Date, p.HomeTeam.ToLowerInvariant(), p.AwayTeam.ToLowerInvariant());
-            if (lookup.TryGetValue(key, out var fixture))
-            {
-                var fixtureDate = DateTime.SpecifyKind(fixture.Fixture.Date, DateTimeKind.Utc);
-                if (lastFixtureTime == null || fixtureDate > lastFixtureTime)
-                    lastFixtureTime = fixtureDate;
-            }
-        }
-
-        if (lastFixtureTime.HasValue && TimeProvider.UtcNow >= lastFixtureTime.Value.AddHours(3))
-        {
-            foreach (var p in _predictions)
-            {
-                var key = (p.Date.Date, p.HomeTeam.ToLowerInvariant(), p.AwayTeam.ToLowerInvariant());
-                if (lookup.TryGetValue(key, out var fixture))
-                {
-                    p.ActualHomeScore = fixture.Score?.Fulltime.Home;
-                    p.ActualAwayScore = fixture.Score?.Fulltime.Away;
-                    if (p.ActualHomeScore.HasValue && p.ActualAwayScore.HasValue)
-                    {
-                        if (p.HomeScore == p.ActualHomeScore && p.AwayScore == p.ActualAwayScore)
-                            p.Points = 3;
-                        else
-                        {
-                            var predictedResult = Math.Sign(p.HomeScore - p.AwayScore);
-                            var actualResult = Math.Sign(p.ActualHomeScore.Value - p.ActualAwayScore.Value);
-                            if (predictedResult == actualResult)
-                                p.Points = 1;
-                        }
-                    }
-                }
-            }
-        }
+        _predictions = (await ProcessingService.ProcessAsync(_input)).ToList();
     }
 
     private async Task CopyToClipboard()
@@ -131,17 +73,5 @@
         }
         await Js.InvokeVoidAsync("navigator.clipboard.writeText", sb.ToString());
         Snackbar.Add("Copied to clipboard", Severity.Success);
-    }
-
-    private class Prediction
-    {
-        public DateTime Date { get; init; }
-        public string HomeTeam { get; init; } = string.Empty;
-        public int HomeScore { get; init; }
-        public int AwayScore { get; init; }
-        public string AwayTeam { get; init; } = string.Empty;
-        public int? ActualHomeScore { get; set; }
-        public int? ActualAwayScore { get; set; }
-        public int Points { get; set; }
     }
 }

--- a/Predictorator/Startup/ServiceCollectionExtensions.cs
+++ b/Predictorator/Startup/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
         services.AddRouteLimiting(configuration);
         services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
+        services.AddTransient<PredictionProcessingService>();
         services.AddHybridCache();
         services.AddSingleton<CachePrefixService>();
         services.Configure<GameWeekCacheOptions>(configuration.GetSection(GameWeekCacheOptions.SectionName));


### PR DESCRIPTION
## Summary
- encapsulate parsing, fixture lookup, and scoring logic in new `PredictionProcessingService`
- inject processing service into `Parse.razor` so component only handles UI
- register service with DI and add unit tests for processing logic

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c868b944083289a65d7600d3d4012