### PR TITLE
Update CSV import to upsert gameweeks

### DIFF
--- a/Predictorator.Core/Services/GameWeekService.cs
+++ b/Predictorator.Core/Services/GameWeekService.cs
@@ -134,12 +134,6 @@ public class GameWeekService : IGameWeekService
             if (!DateTime.TryParse(parts[2], null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var start)) continue;
             if (!DateTime.TryParse(parts[3], null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var end)) continue;
 
-            var existing = await _repo.GetGameWeekAsync(season, number);
-            if (existing != null)
-            {
-                continue;
-            }
-
             var gw = new GameWeek
             {
                 Season = season,

--- a/Predictorator.Tests/GameWeekServiceTests.cs
+++ b/Predictorator.Tests/GameWeekServiceTests.cs
@@ -156,7 +156,7 @@ public class GameWeekServiceTests
     }
 
     [Fact]
-    public async Task ImportCsvAsync_adds_only_new_gameweeks()
+    public async Task ImportCsvAsync_adds_and_updates_gameweeks()
     {
         var service = CreateService(out var inner, out var repo);
         var now = DateTime.UtcNow.Date;
@@ -169,10 +169,10 @@ public class GameWeekServiceTests
 
         var added = await service.ImportCsvAsync(ms);
 
-        Assert.Equal(1, added);
+        Assert.Equal(2, added);
         Assert.Equal(2, inner.Items.Count);
         var gw1 = inner.Items.Single(g => g.Number == 1);
-        Assert.Equal(now, gw1.StartDate);
-        Assert.Equal(now.AddDays(6), gw1.EndDate);
+        Assert.Equal(now.AddDays(1), gw1.StartDate);
+        Assert.Equal(now.AddDays(7), gw1.EndDate);
     }
 }

--- a/Predictorator.Tests/Helpers/FakeGameWeekService.cs
+++ b/Predictorator.Tests/Helpers/FakeGameWeekService.cs
@@ -91,13 +91,7 @@ public class FakeGameWeekService : IGameWeekService
             if (!DateTime.TryParse(parts[2], out var start)) continue;
             if (!DateTime.TryParse(parts[3], out var end)) continue;
 
-            var existing = Items.FirstOrDefault(g => g.Season == season && g.Number == number);
-            if (existing != null)
-            {
-                continue;
-            }
-
-            Items.Add(new GameWeek { Season = season, Number = number, StartDate = start, EndDate = end });
+            await AddOrUpdateAsync(new GameWeek { Season = season, Number = number, StartDate = start, EndDate = end });
             added++;
         }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The seeded admin account credentials are configured via `AdminUser` settings.
 You can override these values by setting the `ADMIN_EMAIL` and
 `ADMIN_PASSWORD` environment variables before running the application. Once
 Administrators can export and import game weeks as CSV files from the admin
-interface. Importing a CSV skips any game weeks that already exist. Administrators can also view and delete queued background jobs.
+interface. Importing a CSV updates existing game weeks and adds new ones. Administrators can also view and delete queued background jobs.
 SMS notifications use Twilio. Set `Twilio__AccountSid`, `Twilio__AuthToken`, and
 `Twilio__FromNumber` environment variables with your Twilio credentials.
 Email delivery is handled by [Resend](https://resend.com). Configure the


### PR DESCRIPTION
## Summary
- Update gameweek CSV import to update existing rows instead of skipping
- Adjust fake service and tests for new import behavior
- Document that CSV import now adds and updates game weeks

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689caa39bc5c83288a777586aea62b1e