### PR TITLE
Make rate limiter optional

### DIFF
--- a/Predictorator.Core/Options/RateLimitingOptions.cs
+++ b/Predictorator.Core/Options/RateLimitingOptions.cs
@@ -4,5 +4,6 @@ public class RateLimitingOptions
 {
     public const string SectionName = "RateLimiting";
 
+    public bool Enabled { get; set; }
     public string[] ExcludedIPs { get; set; } = Array.Empty<string>();
 }

--- a/Predictorator.Tests/RateLimitingOptionsTests.cs
+++ b/Predictorator.Tests/RateLimitingOptionsTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Predictorator.Core.Options;
+using Predictorator.Startup;
+
+namespace Predictorator.Tests;
+
+public class RateLimitingOptionsTests
+{
+    [Fact]
+    public void Disabled_by_default()
+    {
+        var options = new RateLimitingOptions();
+        Assert.False(options.Enabled);
+    }
+
+    [Fact]
+    public void Services_not_registered_when_disabled()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                {"ApiSettings:RapidApiKey", "key"},
+                {"Resend:ApiToken", "token"},
+                {"TableStorage:ConnectionString", "UseDevelopmentStorage=true"},
+                {"RateLimiting:Enabled", "false"}
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddPredictoratorCore(config);
+
+        Assert.DoesNotContain(services, s => s.ServiceType == typeof(IConfigureOptions<RateLimiterOptions>));
+    }
+
+    [Fact]
+    public void Services_registered_when_enabled()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                {"ApiSettings:RapidApiKey", "key"},
+                {"Resend:ApiToken", "token"},
+                {"TableStorage:ConnectionString", "UseDevelopmentStorage=true"},
+                {"RateLimiting:Enabled", "true"}
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddPredictoratorCore(config);
+
+        Assert.Contains(services, s => s.ServiceType == typeof(IConfigureOptions<RateLimiterOptions>));
+    }
+}
+

--- a/Predictorator.Tests/RateLimitingTests.cs
+++ b/Predictorator.Tests/RateLimitingTests.cs
@@ -27,6 +27,7 @@ public class RateLimitingTests : IClassFixture<WebApplicationFactory<Program>>
                 services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
                 services.AddSingleton<IDateTimeProvider>(new SystemDateTimeProvider());
                 services.PostConfigure<RouteLimitingOptions>(o => o.UniqueRouteLimit = 1);
+                services.PostConfigure<RateLimitingOptions>(o => o.Enabled = true);
                 services.AddTransient<IFixtureService>(_ => new FakeFixtureService(
                     new FixturesResponse { Response = new List<FixtureData>() }));
 
@@ -59,7 +60,11 @@ public class RateLimitingTests : IClassFixture<WebApplicationFactory<Program>>
             builder.ConfigureServices(services =>
             {
                 services.PostConfigure<RouteLimitingOptions>(o => o.UniqueRouteLimit = 1);
-                services.PostConfigure<RateLimitingOptions>(o => o.ExcludedIPs = new[] { "unknown" });
+                services.PostConfigure<RateLimitingOptions>(o =>
+                {
+                    o.Enabled = true;
+                    o.ExcludedIPs = new[] { "unknown" };
+                });
             });
         });
 
@@ -78,7 +83,11 @@ public class RateLimitingTests : IClassFixture<WebApplicationFactory<Program>>
             builder.ConfigureServices(services =>
             {
                 services.PostConfigure<RouteLimitingOptions>(o => o.UniqueRouteLimit = 1);
-                services.PostConfigure<RateLimitingOptions>(o => o.ExcludedIPs = new[] { "1.2.3.4" });
+                services.PostConfigure<RateLimitingOptions>(o =>
+                {
+                    o.Enabled = true;
+                    o.ExcludedIPs = new[] { "1.2.3.4" };
+                });
             });
         });
 

--- a/Predictorator/Program.cs
+++ b/Predictorator/Program.cs
@@ -9,6 +9,8 @@ using Predictorator.Data;
 using Serilog;
 using Serilog.Events;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+using Predictorator.Core.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -62,7 +64,11 @@ var app = builder.Build();
 
 app.UseRequestLocalization(localizationOptions);
 app.UseForwardedHeaders();
-app.UseRateLimiter();
+var rateOptions = app.Services.GetRequiredService<IOptions<RateLimitingOptions>>().Value;
+if (rateOptions.Enabled)
+{
+    app.UseRateLimiter();
+}
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/Predictorator/appsettings.json
+++ b/Predictorator/appsettings.json
@@ -6,6 +6,7 @@
     }
   },
   "RateLimiting": {
+    "Enabled": false,
     "ExcludedIPs": []
   },
   "GameWeekCache": {

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ List any email addresses that should receive extra text in prediction emails und
 `PredictionEmail:SpecialRecipients`.
 Set `BASE_URL` to the public address of the site so scheduled notifications
 contain valid links.
-Each IP address is limited to 50 requests per day. The threshold can be adjusted
-with the `RouteLimiting:UniqueRouteLimit` setting. Specific IP addresses can be
-excluded via `RateLimiting:ExcludedIPs` or environment variables such as
+Rate limiting is disabled by default. Enable it by setting
+`RateLimiting:Enabled` to `true`. When enabled, each IP address is limited to 50
+requests per day. The threshold can be adjusted with the
+`RouteLimiting:UniqueRouteLimit` setting. Specific IP addresses can be excluded
+via `RateLimiting:ExcludedIPs` or environment variables such as
 `RateLimiting__ExcludedIPs__0=127.0.0.1`.
 
 Game week data is cached to reduce database load. The duration defaults to two


### PR DESCRIPTION
## Summary
- add an `Enabled` flag to RateLimitingOptions and disable by default
- only register and activate the rate limiter when enabled
- document and test rate limiting configuration

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`
- `dotnet format --verify-no-changes` *(fails: command hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689cb4cede58832882846d191ad0469c