### PR TITLE
Report and manage background job errors

### DIFF
--- a/Predictorator.Core/Models/BackgroundJobError.cs
+++ b/Predictorator.Core/Models/BackgroundJobError.cs
@@ -1,0 +1,18 @@
+using Azure;
+using Azure.Data.Tables;
+
+namespace Predictorator.Core.Models;
+
+public class BackgroundJobError : ITableEntity
+{
+    public string PartitionKey { get; set; } = "errors";
+    public string RowKey { get; set; } = Guid.NewGuid().ToString("N");
+    public string JobId { get; set; } = string.Empty;
+    public string JobType { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string StackTrace { get; set; } = string.Empty;
+    public DateTimeOffset OccurredAt { get; set; }
+    public DateTimeOffset? Timestamp { get; set; }
+    public ETag ETag { get; set; }
+}
+

--- a/Predictorator.Core/Services/AdminService.cs
+++ b/Predictorator.Core/Services/AdminService.cs
@@ -41,6 +41,7 @@ public class AdminService
     private readonly CachePrefixService _prefix;
     private readonly INotificationSender<Subscriber> _emailSender;
     private readonly INotificationSender<SmsSubscriber> _smsSender;
+    private readonly IBackgroundJobErrorService _errors;
 
     public AdminService(
         IEmailSubscriberRepository emails,
@@ -52,7 +53,8 @@ public class AdminService
         IDateTimeProvider time,
         CachePrefixService prefix,
         INotificationSender<Subscriber> emailSender,
-        INotificationSender<SmsSubscriber> smsSender)
+        INotificationSender<SmsSubscriber> smsSender,
+        IBackgroundJobErrorService errors)
     {
         _emails = emails;
         _smsSubscribers = smsSubscribers;
@@ -64,6 +66,7 @@ public class AdminService
         _prefix = prefix;
         _emailSender = emailSender;
         _smsSender = smsSender;
+        _errors = errors;
     }
 
     public async Task<List<AdminSubscriberDto>> GetSubscribersAsync()
@@ -332,6 +335,17 @@ public class AdminService
     public Task DeleteJobAsync(string id)
     {
         return _jobs.DeleteAsync(id);
+    }
+
+    public async Task<List<BackgroundJobError>> GetErrorsAsync()
+    {
+        var errors = await _errors.GetErrorsAsync();
+        return errors.ToList();
+    }
+
+    public Task DeleteErrorAsync(string id)
+    {
+        return _errors.DeleteErrorAsync(id);
     }
 
     public Task ClearCachesAsync()

--- a/Predictorator.Core/Services/IBackgroundJobErrorService.cs
+++ b/Predictorator.Core/Services/IBackgroundJobErrorService.cs
@@ -1,0 +1,11 @@
+using Predictorator.Core.Models;
+
+namespace Predictorator.Core.Services;
+
+public interface IBackgroundJobErrorService
+{
+    Task AddErrorAsync(BackgroundJobError error);
+    Task<IReadOnlyList<BackgroundJobError>> GetErrorsAsync();
+    Task DeleteErrorAsync(string id);
+}
+

--- a/Predictorator.Core/Services/TableBackgroundJobErrorService.cs
+++ b/Predictorator.Core/Services/TableBackgroundJobErrorService.cs
@@ -1,0 +1,32 @@
+using Azure.Data.Tables;
+using Predictorator.Core.Models;
+
+namespace Predictorator.Core.Services;
+
+public class TableBackgroundJobErrorService : IBackgroundJobErrorService
+{
+    private readonly TableClient _table;
+
+    public TableBackgroundJobErrorService(TableServiceClient client)
+    {
+        _table = client.GetTableClient("BackgroundJobErrors");
+        _table.CreateIfNotExists();
+    }
+
+    public Task AddErrorAsync(BackgroundJobError error)
+    {
+        return _table.AddEntityAsync(error);
+    }
+
+    public Task<IReadOnlyList<BackgroundJobError>> GetErrorsAsync()
+    {
+        var items = _table.Query<BackgroundJobError>().OrderByDescending(e => e.OccurredAt).ToList();
+        return Task.FromResult<IReadOnlyList<BackgroundJobError>>(items);
+    }
+
+    public Task DeleteErrorAsync(string id)
+    {
+        return _table.DeleteEntityAsync("errors", id);
+    }
+}
+

--- a/Predictorator.Functions/ProcessBackgroundJobsFunction.cs
+++ b/Predictorator.Functions/ProcessBackgroundJobsFunction.cs
@@ -1,11 +1,16 @@
 using System.Text.Json;
 using System.Linq;
+using System.Text;
+using System.Collections.Generic;
 using Azure.Data.Tables;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Timer;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Predictorator.Core.Models;
+using Predictorator.Core.Options;
 using Predictorator.Core.Services;
+using Resend;
 
 namespace Predictorator.Functions;
 
@@ -15,14 +20,33 @@ public class ProcessBackgroundJobsFunction
     private readonly NotificationService _notifications;
     private readonly IDateTimeProvider _time;
     private readonly ILogger<ProcessBackgroundJobsFunction> _logger;
+    private readonly IBackgroundJobErrorService _errors;
+    private readonly IResend _resend;
+    private readonly IConfiguration _config;
+    private readonly EmailCssInliner _inliner;
+    private readonly EmailTemplateRenderer _renderer;
 
-    public ProcessBackgroundJobsFunction(TableServiceClient client, NotificationService notifications, IDateTimeProvider time, ILogger<ProcessBackgroundJobsFunction> logger)
+    public ProcessBackgroundJobsFunction(
+        TableServiceClient client,
+        NotificationService notifications,
+        IDateTimeProvider time,
+        ILogger<ProcessBackgroundJobsFunction> logger,
+        IBackgroundJobErrorService errors,
+        IResend resend,
+        IConfiguration config,
+        EmailCssInliner inliner,
+        EmailTemplateRenderer renderer)
     {
         _table = client.GetTableClient("BackgroundJobs");
         _table.CreateIfNotExists();
         _notifications = notifications;
         _time = time;
         _logger = logger;
+        _errors = errors;
+        _resend = resend;
+        _config = config;
+        _inliner = inliner;
+        _renderer = renderer;
     }
 
     [Function("ProcessBackgroundJobs")]
@@ -32,6 +56,7 @@ public class ProcessBackgroundJobsFunction
         _logger.LogInformation("Processing background jobs at {Time}", now);
         var jobs = _table.Query<BackgroundJob>(j => j.RunAt <= now).ToList();
         _logger.LogInformation("Found {Count} job(s) to process", jobs.Count);
+        var results = new List<JobResult>();
         foreach (var job in jobs)
         {
             try
@@ -54,15 +79,60 @@ public class ProcessBackgroundJobsFunction
                 }
                 await _table.DeleteEntityAsync(job.PartitionKey, job.RowKey);
                 _logger.LogInformation("Job {JobId} processed", job.RowKey);
+                results.Add(new JobResult(job.RowKey, job.JobType, true, null));
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error running background job {JobId}", job.RowKey);
+                results.Add(new JobResult(job.RowKey, job.JobType, false, ex));
+                await _errors.AddErrorAsync(new BackgroundJobError
+                {
+                    JobId = job.RowKey,
+                    JobType = job.JobType,
+                    Message = ex.Message,
+                    StackTrace = ex.ToString(),
+                    OccurredAt = _time.UtcNow
+                });
             }
+        }
+        if (results.Any())
+        {
+            await SendReportAsync(results);
         }
         _logger.LogInformation("Background job processing completed at {Time}", _time.UtcNow);
     }
 
     private record SamplePayload(List<AdminSubscriberDto> Recipients, string Message, string BaseUrl);
     private record KeyPayload(string Key, string BaseUrl);
+
+    private record JobResult(string JobId, string JobType, bool Success, Exception? Error);
+
+    private async Task SendReportAsync(IEnumerable<JobResult> results)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Background job report:");
+        foreach (var r in results)
+        {
+            if (r.Success)
+            {
+                sb.AppendLine($"{r.JobType} ({r.JobId}): Success");
+            }
+            else if (r.Error != null)
+            {
+                sb.AppendLine($"{r.JobType} ({r.JobId}): Failed - {r.Error.Message}");
+                sb.AppendLine(r.Error.StackTrace);
+            }
+        }
+        var body = sb.ToString();
+        var html = _renderer.Render(body, _config["BASE_URL"] ?? string.Empty, null, preheader: body);
+        var message = new EmailMessage
+        {
+            From = _config["Resend:From"] ?? "Prediction Fairy <no-reply@example.com>",
+            Subject = "Background job report",
+            HtmlBody = _inliner.InlineCss(html)
+        };
+        var admin = _config["ADMIN_EMAIL"] ?? _config[$"{AdminUserOptions.SectionName}:Email"] ?? "admin@example.com";
+        message.To.Add(admin);
+        await _resend.EmailSendAsync(message);
+    }
 }

--- a/Predictorator.Functions/Program.cs
+++ b/Predictorator.Functions/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
 builder.Services.AddTransient<SubscriptionService>();
 builder.Services.AddTransient<NotificationService>();
 builder.Services.AddSingleton<IBackgroundJobService, TableBackgroundJobService>();
+builder.Services.AddSingleton<IBackgroundJobErrorService, TableBackgroundJobErrorService>();
 builder.Services.AddSingleton<EmailCssInliner>();
 builder.Services.AddSingleton<EmailTemplateRenderer>();
 builder.Services.AddHybridCache();

--- a/Predictorator.Tests/AdminPageAccessTests.cs
+++ b/Predictorator.Tests/AdminPageAccessTests.cs
@@ -37,6 +37,7 @@ public class AdminPageAccessTests : IClassFixture<WebApplicationFactory<Program>
                 services.AddSingleton<IResend>(_ => Substitute.For<IResend>());
                 services.AddSingleton<ITwilioSmsSender>(_ => Substitute.For<ITwilioSmsSender>());
                 services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
+                services.AddSingleton<IBackgroundJobErrorService>(_ => Substitute.For<IBackgroundJobErrorService>());
             });
         });
     }

--- a/Predictorator.Tests/FunctionAppDiResolutionTests.cs
+++ b/Predictorator.Tests/FunctionAppDiResolutionTests.cs
@@ -55,6 +55,7 @@ public class FunctionAppDiResolutionTests
         services.Configure<TwilioOptions>(configuration.GetSection(TwilioOptions.SectionName));
         services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
         services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
+        services.AddSingleton<IBackgroundJobErrorService>(_ => Substitute.For<IBackgroundJobErrorService>());
         services.AddSingleton<EmailCssInliner>();
         services.AddSingleton<EmailTemplateRenderer>();
         services.AddTransient<INotificationSender<Subscriber>, EmailNotificationSender>();

--- a/Predictorator.Tests/WebAppDiResolutionTests.cs
+++ b/Predictorator.Tests/WebAppDiResolutionTests.cs
@@ -38,12 +38,14 @@ public class WebAppDiResolutionTests : IClassFixture<WebApplicationFactory<Progr
                 services.RemoveAll<TableDataStore>();
                 services.RemoveAll<IGameWeekRepository>();
                 services.RemoveAll<IBackgroundJobService>();
+                services.RemoveAll<IBackgroundJobErrorService>();
                 var store = new InMemoryDataStore();
                 services.AddSingleton<IEmailSubscriberRepository>(store);
                 services.AddSingleton<ISmsSubscriberRepository>(store);
                 services.AddSingleton<ISentNotificationRepository>(store);
                 services.AddSingleton<IGameWeekRepository, InMemoryGameWeekRepository>();
                 services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
+                services.AddSingleton<IBackgroundJobErrorService>(_ => Substitute.For<IBackgroundJobErrorService>());
                 descriptors = services;
             });
         });

--- a/Predictorator/Components/ErrorDialog.razor
+++ b/Predictorator/Components/ErrorDialog.razor
@@ -1,0 +1,20 @@
+@using Predictorator.Core.Models
+
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.subtitle1">@Error.JobType (@Error.JobId)</MudText>
+        <MudText Typo="Typo.body2" Class="mt-2">@Error.Message</MudText>
+        <MudText Typo="Typo.caption" Class="mt-4" Style="white-space: pre-wrap">@Error.StackTrace</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Color="Color.Primary">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance DialogInstance { get; set; } = default!;
+    [Parameter] public BackgroundJobError Error { get; set; } = default!;
+
+    void Close() => DialogInstance.Close();
+}
+

--- a/Predictorator/Components/Pages/Admin/Errors.razor
+++ b/Predictorator/Components/Pages/Admin/Errors.razor
@@ -1,0 +1,56 @@
+@rendermode InteractiveServer
+@inject AdminService AdminService
+@inject ToastInterop Toast
+@inject IDialogService DialogService
+@using Predictorator.Core.Models
+@using Predictorator.Components
+
+<h2>Errors</h2>
+@if (_errors == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <MudTable Items="_errors" Hover="true" Breakpoint="Breakpoint.None">
+        <HeaderContent>
+            <MudTh>Type</MudTh>
+            <MudTh>Occurred At (UTC)</MudTh>
+            <MudTh>Message</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate Context="row">
+            <MudTd>@row.JobType</MudTd>
+            <MudTd>@row.OccurredAt.ToString("u")</MudTd>
+            <MudTd>@row.Message</MudTd>
+            <MudTd>
+                <MudButton Size="Size.Small" OnClick="@(() => ViewAsync(row))">View</MudButton>
+                <MudButton Size="Size.Small" Color="Color.Error" Variant="Variant.Filled" OnClick="@(() => DeleteAsync(row))">Delete</MudButton>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    private List<BackgroundJobError>? _errors;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var data = await AdminService.GetErrorsAsync();
+        _errors = data.ToList();
+    }
+
+    private void ViewAsync(BackgroundJobError error)
+    {
+        var parameters = new DialogParameters { ["Error"] = error };
+        DialogService.Show<ErrorDialog>("Error Details", parameters);
+    }
+
+    private async Task DeleteAsync(BackgroundJobError error)
+    {
+        await AdminService.DeleteErrorAsync(error.RowKey);
+        _errors!.Remove(error);
+        await Toast.ShowToast("Error deleted!", "success");
+    }
+}
+

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -15,6 +15,9 @@
     <MudTabPanel Text="Jobs">
         <Jobs />
     </MudTabPanel>
+    <MudTabPanel Text="Errors">
+        <Errors />
+    </MudTabPanel>
     <MudTabPanel Text="Maintenance">
         <MudPaper Class="pa-2">
             <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="ClearCaches">Clear Caches</MudButton>

--- a/Predictorator/Startup/ServiceCollectionExtensions.cs
+++ b/Predictorator/Startup/ServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<INotificationSender<SmsSubscriber>, SmsNotificationSender>();
         services.AddSingleton<NotificationFeatureService>();
         services.AddSingleton<IBackgroundJobService, TableBackgroundJobService>();
+        services.AddSingleton<IBackgroundJobErrorService, TableBackgroundJobErrorService>();
         services.Configure<AdminUserOptions>(options =>
         {
             configuration.GetSection(AdminUserOptions.SectionName).Bind(options);


### PR DESCRIPTION
## Summary
- send admin email summarising background job outcomes and capture failures with stack traces
- persist job error details in table storage with a new background job error service
- surface job errors in admin UI with a dedicated tab, detail dialog and delete option

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_689f0fa74b688328a3750996b42d9697