### PR TITLE
Log function errors

### DIFF
--- a/Predictorator.Functions/ClearExpiredSubscriptionsFunction.cs
+++ b/Predictorator.Functions/ClearExpiredSubscriptionsFunction.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Timer;
 using Microsoft.Extensions.Logging;
+using Predictorator.Core.Models;
 using Predictorator.Core.Services;
 
 namespace Predictorator.Functions;
@@ -9,18 +10,41 @@ public class ClearExpiredSubscriptionsFunction
 {
     private readonly SubscriptionService _service;
     private readonly ILogger<ClearExpiredSubscriptionsFunction> _logger;
+    private readonly IBackgroundJobErrorService _errors;
+    private readonly IDateTimeProvider _time;
 
-    public ClearExpiredSubscriptionsFunction(SubscriptionService service, ILogger<ClearExpiredSubscriptionsFunction> logger)
+    public ClearExpiredSubscriptionsFunction(
+        SubscriptionService service,
+        ILogger<ClearExpiredSubscriptionsFunction> logger,
+        IBackgroundJobErrorService errors,
+        IDateTimeProvider time)
     {
         _service = service;
         _logger = logger;
+        _errors = errors;
+        _time = time;
     }
 
     [Function("ClearExpiredSubscriptions")]
     public async Task Run([TimerTrigger("%ClearExpiredSubscriptionsSchedule%")]
         TimerInfo timer)
     {
-        var count = await _service.ClearExpiredUnverifiedAsync();
-        _logger.LogInformation("Removed {Count} expired subscriptions", count);
+        try
+        {
+            var count = await _service.ClearExpiredUnverifiedAsync();
+            _logger.LogInformation("Removed {Count} expired subscriptions", count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error clearing expired subscriptions");
+            await _errors.AddErrorAsync(new BackgroundJobError
+            {
+                JobId = "ClearExpiredSubscriptions",
+                JobType = "ClearExpiredSubscriptions",
+                Message = ex.Message,
+                StackTrace = ex.ToString(),
+                OccurredAt = _time.UtcNow
+            });
+        }
     }
 }

--- a/Predictorator.Functions/FixtureNotificationsFunction.cs
+++ b/Predictorator.Functions/FixtureNotificationsFunction.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.Timer;
 using Microsoft.Extensions.Logging;
+using Predictorator.Core.Models;
 using Predictorator.Core.Services;
 
 namespace Predictorator.Functions;
@@ -9,19 +10,42 @@ public class FixtureNotificationsFunction
 {
     private readonly NotificationService _service;
     private readonly ILogger<FixtureNotificationsFunction> _logger;
+    private readonly IBackgroundJobErrorService _errors;
+    private readonly IDateTimeProvider _time;
 
-    public FixtureNotificationsFunction(NotificationService service, ILogger<FixtureNotificationsFunction> logger)
+    public FixtureNotificationsFunction(
+        NotificationService service,
+        ILogger<FixtureNotificationsFunction> logger,
+        IBackgroundJobErrorService errors,
+        IDateTimeProvider time)
     {
         _service = service;
         _logger = logger;
+        _errors = errors;
+        _time = time;
     }
 
     [Function("FixtureNotifications")]
     public async Task Run([TimerTrigger("%FixtureNotificationsSchedule%")]
         TimerInfo timer)
     {
-        _logger.LogInformation("Fixture notifications check started at {Time}", DateTime.UtcNow);
-        await _service.CheckFixturesAsync();
-        _logger.LogInformation("Fixture notifications check completed");
+        try
+        {
+            _logger.LogInformation("Fixture notifications check started at {Time}", DateTime.UtcNow);
+            await _service.CheckFixturesAsync();
+            _logger.LogInformation("Fixture notifications check completed");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error running fixture notifications");
+            await _errors.AddErrorAsync(new BackgroundJobError
+            {
+                JobId = "FixtureNotifications",
+                JobType = "FixtureNotifications",
+                Message = ex.Message,
+                StackTrace = ex.ToString(),
+                OccurredAt = _time.UtcNow
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- wrap fixture notification, subscription cleanup, and background job functions in try/catch
- record unhandled function errors in BackgroundJobErrors table

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689f2375e7908328ac78c37b9dd40f1e