### PR TITLE
Register notification senders in functions

### DIFF
--- a/Predictorator.Functions/Program.cs
+++ b/Predictorator.Functions/Program.cs
@@ -2,16 +2,11 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Predictorator.Core.Data;
-using Predictorator.Core.Options;
-using Predictorator.Core.Services;
-using Resend;
 using Microsoft.Extensions.Hosting;
-using Azure.Data.Tables;
-using Microsoft.Extensions.Caching.Hybrid;
 using System.IO;
 using Serilog;
 using Serilog.Events;
+using Predictorator.Functions;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -35,44 +30,6 @@ builder.Services.ConfigureFunctionsApplicationInsights();
 
 var configuration = builder.Configuration;
 
-builder.Services.AddHttpClient("fixtures", client =>
-{
-    client.BaseAddress = new Uri("https://api-football-v1.p.rapidapi.com/v3/");
-    client.DefaultRequestHeaders.Add("x-rapidapi-host", "api-football-v1.p.rapidapi.com");
-    var key = configuration["ApiSettings:RapidApiKey"];
-    if (!string.IsNullOrWhiteSpace(key))
-        client.DefaultRequestHeaders.Add("x-rapidapi-key", key);
-});
-
-builder.Services.AddHttpContextAccessor();
-builder.Services.AddTransient<IFixtureService, FixtureService>();
-builder.Services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
-builder.Services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
-builder.Services.AddSingleton<NotificationFeatureService>();
-builder.Services.AddHttpClient<ResendClient>();
-builder.Services.Configure<ResendClientOptions>(o => o.ApiToken = configuration["Resend:ApiToken"] ?? string.Empty);
-builder.Services.AddTransient<IResend, ResendClient>();
-builder.Services.Configure<TwilioOptions>(configuration.GetSection(TwilioOptions.SectionName));
-builder.Services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
-builder.Services.AddTransient<SubscriptionService>();
-builder.Services.AddTransient<NotificationService>();
-builder.Services.AddSingleton<IBackgroundJobService, TableBackgroundJobService>();
-builder.Services.AddSingleton<IBackgroundJobErrorService, TableBackgroundJobErrorService>();
-builder.Services.AddSingleton<EmailCssInliner>();
-builder.Services.AddSingleton<EmailTemplateRenderer>();
-builder.Services.AddHybridCache();
-builder.Services.Configure<GameWeekCacheOptions>(configuration.GetSection(GameWeekCacheOptions.SectionName));
-builder.Services.AddSingleton<CachePrefixService>();
-builder.Services.AddTransient<IGameWeekService, GameWeekService>();
-
-var tableConn = configuration.GetConnectionString("TableStorage")
-    ?? configuration["TableStorage:ConnectionString"];
-var tableService = new TableServiceClient(tableConn ?? throw new InvalidOperationException("Table storage connection string not configured"));
-builder.Services.AddSingleton(tableService);
-builder.Services.AddScoped<TableDataStore>();
-builder.Services.AddScoped<IEmailSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
-builder.Services.AddScoped<ISmsSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
-builder.Services.AddScoped<ISentNotificationRepository>(sp => sp.GetRequiredService<TableDataStore>());
-builder.Services.AddScoped<IGameWeekRepository, TableGameWeekRepository>();
+builder.Services.AddPredictoratorFunctionServices(configuration);
 
 builder.Build().Run();

--- a/Predictorator.Functions/ServiceCollectionExtensions.cs
+++ b/Predictorator.Functions/ServiceCollectionExtensions.cs
@@ -1,0 +1,67 @@
+using System;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Hybrid;
+using Predictorator.Core.Data;
+using Predictorator.Core.Models;
+using Predictorator.Core.Options;
+using Predictorator.Core.Services;
+using Resend;
+
+namespace Predictorator.Functions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddPredictoratorFunctionServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddHttpClient("fixtures", client =>
+        {
+            client.BaseAddress = new Uri("https://api-football-v1.p.rapidapi.com/v3/");
+            client.DefaultRequestHeaders.Add("x-rapidapi-host", "api-football-v1.p.rapidapi.com");
+            var key = configuration["ApiSettings:RapidApiKey"];
+            if (!string.IsNullOrWhiteSpace(key))
+                client.DefaultRequestHeaders.Add("x-rapidapi-key", key);
+        });
+
+        services.AddHttpContextAccessor();
+        services.AddTransient<IFixtureService, FixtureService>();
+        services.AddSingleton<IDateRangeCalculator, DateRangeCalculator>();
+        services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
+        services.AddSingleton<NotificationFeatureService>();
+
+        services.AddHttpClient<ResendClient>();
+        services.Configure<ResendClientOptions>(o => o.ApiToken = configuration["Resend:ApiToken"] ?? string.Empty);
+        services.AddTransient<IResend, ResendClient>();
+
+        services.Configure<TwilioOptions>(configuration.GetSection(TwilioOptions.SectionName));
+        services.AddTransient<ITwilioSmsSender, TwilioSmsSender>();
+
+        services.AddTransient<SubscriptionService>();
+        services.AddTransient<NotificationService>();
+        services.AddTransient<INotificationSender<Subscriber>, EmailNotificationSender>();
+        services.AddTransient<INotificationSender<SmsSubscriber>, SmsNotificationSender>();
+
+        services.AddSingleton<IBackgroundJobService, TableBackgroundJobService>();
+        services.AddSingleton<IBackgroundJobErrorService, TableBackgroundJobErrorService>();
+        services.AddSingleton<EmailCssInliner>();
+        services.AddSingleton<EmailTemplateRenderer>();
+        services.AddHybridCache();
+        services.Configure<GameWeekCacheOptions>(configuration.GetSection(GameWeekCacheOptions.SectionName));
+        services.AddSingleton<CachePrefixService>();
+        services.AddTransient<IGameWeekService, GameWeekService>();
+
+        var tableConn = configuration.GetConnectionString("TableStorage")
+            ?? configuration["TableStorage:ConnectionString"];
+        var tableService = new TableServiceClient(tableConn ?? throw new InvalidOperationException("Table storage connection string not configured"));
+        services.AddSingleton(tableService);
+        services.AddScoped<TableDataStore>();
+        services.AddScoped<IEmailSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
+        services.AddScoped<ISmsSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
+        services.AddScoped<ISentNotificationRepository>(sp => sp.GetRequiredService<TableDataStore>());
+        services.AddScoped<IGameWeekRepository, TableGameWeekRepository>();
+
+        return services;
+    }
+}
+

--- a/Predictorator.Tests/Predictorator.Tests.csproj
+++ b/Predictorator.Tests/Predictorator.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Predictorator\Predictorator.csproj" />
+    <ProjectReference Include="..\Predictorator.Functions\Predictorator.Functions.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- ensure NotificationService dependencies are registered for Azure Functions
- centralize function service registration and update DI resolution tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689f28057a2c8328937f36f555ded246