### PR TITLE
Schedule background jobs a minute early

### DIFF
--- a/Predictorator.Core/Services/NotificationService.cs
+++ b/Predictorator.Core/Services/NotificationService.cs
@@ -104,7 +104,7 @@ public class NotificationService
                 if (futureUk.Date == nowUk.Date)
                 {
                     var sendTimeUk = futureUk.Date.AddHours(10);
-                    var sendTimeUtc = TimeZoneInfo.ConvertTimeToUtc(sendTimeUk, UkTimeZone);
+                    var sendTimeUtc = TimeZoneInfo.ConvertTimeToUtc(sendTimeUk, UkTimeZone).AddMinutes(-1);
                     var delay = TimeExtensions.ClampDelay(sendTimeUtc, _time);
                     _logger.LogInformation("Scheduling new fixtures notification for {Date} with delay {Delay}", futureUk.Date, delay);
                     await _jobs.ScheduleAsync(
@@ -123,7 +123,7 @@ public class NotificationService
             var sent = await _sentNotifications.SentNotificationExistsAsync("FixturesStartingSoon", key);
             if (!sent)
             {
-                var sendTimeUtc = first.Fixture.Date.AddHours(-2);
+                var sendTimeUtc = first.Fixture.Date.AddHours(-2).AddMinutes(-1);
                 var delay = TimeExtensions.ClampDelay(sendTimeUtc, _time);
                 _logger.LogInformation("Scheduling fixtures starting soon notification for {Date} with delay {Delay}", firstUk, delay);
                 await _jobs.ScheduleAsync(

--- a/Predictorator.Tests/NotificationServiceTests.cs
+++ b/Predictorator.Tests/NotificationServiceTests.cs
@@ -68,7 +68,7 @@ public class NotificationServiceTests
         await jobs.Received().ScheduleAsync(
             "SendNewFixturesAvailable",
             Arg.Any<object>(),
-            Arg.Any<TimeSpan>());
+            Arg.Is<TimeSpan>(d => d == TimeSpan.FromMinutes(59)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure nightly notifications schedule jobs one minute early so they are processed on time
- test verifies new fixtures notification is queued 59 minutes ahead of run

## Testing
- `dotnet format --no-restore --verbosity diagnostic Predictorator.sln`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_689f2b3116b483288bc6b2ecf0f4cd95