### PR TITLE
Add Safari clipboard fallback

### DIFF
--- a/Predictorator.Tests/ParsePageBUnitTests.cs
+++ b/Predictorator.Tests/ParsePageBUnitTests.cs
@@ -176,6 +176,7 @@ public class ParsePageBUnitTests
 
         const string text = "Monday, January 1, 2024\nTeam A 1 - 2 Team B";
         await using var ctx = CreateContext(fixtures, fixtureTime.AddHours(4));
+        ctx.JSInterop.Setup<bool>("app.copyToClipboardText", _ => true).SetResult(true);
         var provider = ctx.Render<MudSnackbarProvider>();
         var cut = ctx.Render<Parse>();
 
@@ -184,7 +185,7 @@ public class ParsePageBUnitTests
         cut.FindAll("button").First(b => b.TextContent == "Parse").Click();
         cut.FindAll("button").First(b => b.TextContent == "Copy to Clipboard").Click();
 
-        var invocation = ctx.JSInterop.Invocations.Single(i => i.Identifier == "navigator.clipboard.writeText");
+        var invocation = ctx.JSInterop.Invocations.Single(i => i.Identifier == "app.copyToClipboardText");
         var lines = invocation.Arguments[0]?.ToString()?.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal("Name\tDate\tHome Team\tHome Prediction\tHome Actual\tAway Prediction\tAway Actual\tAway Team\tPoints", lines![0]);
         Assert.Equal("Bob\t01/01/2024\tTeam A\t1\t3\t2\t2\tTeam B\t0", lines[1]);

--- a/Predictorator/Components/Pages/Parse.razor
+++ b/Predictorator/Components/Pages/Parse.razor
@@ -71,7 +71,14 @@
         {
             sb.AppendLine($"{_name}\t{p.Date:dd/MM/yyyy}\t{p.HomeTeam}\t{p.HomeScore}\t{p.ActualHomeScore?.ToString() ?? string.Empty}\t{p.AwayScore}\t{p.ActualAwayScore?.ToString() ?? string.Empty}\t{p.AwayTeam}\t{(p.ActualHomeScore.HasValue && p.ActualAwayScore.HasValue ? p.Points.ToString() : string.Empty)}");
         }
-        await Js.InvokeVoidAsync("navigator.clipboard.writeText", sb.ToString());
-        Snackbar.Add("Copied to clipboard", Severity.Success);
+        var copied = await Js.InvokeAsync<bool>("app.copyToClipboardText", sb.ToString());
+        if (copied)
+        {
+            Snackbar.Add("Copied to clipboard", Severity.Success);
+        }
+        else
+        {
+            Snackbar.Add("Failed to copy to clipboard", Severity.Error);
+        }
     }
 }

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -19,8 +19,13 @@ window.app = (() => {
         }
     }
 
+    function isSafari() {
+        const ua = navigator.userAgent;
+        return ua.includes('Safari') && !ua.includes('Chrome') && !ua.includes('Chromium');
+    }
+
     function copyToClipboardText(text) {
-        if (navigator.clipboard && navigator.clipboard.writeText) {
+        if (!isSafari() && navigator.clipboard && navigator.clipboard.writeText) {
             return navigator.clipboard.writeText(text)
                 .then(() => true)
                 .catch(err => {
@@ -29,7 +34,7 @@ window.app = (() => {
                 });
         }
 
-        return fallbackCopyText(text);
+        return Promise.resolve(fallbackCopyText(text));
     }
 
     function fallbackCopyHtml(html) {
@@ -46,7 +51,7 @@ window.app = (() => {
     }
 
     function copyToClipboardHtml(html) {
-        if (navigator.clipboard && window.ClipboardItem) {
+        if (!isSafari() && navigator.clipboard && window.ClipboardItem) {
             const item = new ClipboardItem({
                 'text/html': new Blob([html], { type: 'text/html' })
             });
@@ -58,7 +63,7 @@ window.app = (() => {
                 });
         }
 
-        return fallbackCopyHtml(html);
+        return Promise.resolve(fallbackCopyHtml(html));
     }
 
     let ceefaxTimer = null;
@@ -207,6 +212,8 @@ window.app = (() => {
 
       return {
           copyPredictions,
+          copyToClipboardText,
+          copyToClipboardHtml,
           registerScoreInputs,
           registerToastHandler,
           setCeefax,


### PR DESCRIPTION
## Summary
- handle Safari clipboard limitations with user-agent detection and execCommand fallback
- expose generic copy helpers and use them on the Parse page
- adjust tests for new clipboard helper

## Testing
- `dotnet format Predictorator.sln --include Predictorator.Tests/ParsePageBUnitTests.cs Predictorator/Components/Pages/Parse.razor`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_689f91810dac8328834d58d5a4e15e4a