### PR TITLE
Add probabilistic string selector helper

### DIFF
--- a/Predictorator.Core/Services/StringProbabilityHelper.cs
+++ b/Predictorator.Core/Services/StringProbabilityHelper.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Predictorator.Core.Services;
+
+public static class StringProbabilityHelper
+{
+    public static string Choose(string first, string second, double probability, Random? random = null)
+    {
+        if (probability <= 0) return first;
+        if (probability >= 1) return second;
+
+        var rng = random ?? Random.Shared;
+        return rng.NextDouble() < probability ? second : first;
+    }
+}

--- a/Predictorator.Tests/StringProbabilityHelperTests.cs
+++ b/Predictorator.Tests/StringProbabilityHelperTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Predictorator.Core.Services;
+
+namespace Predictorator.Tests;
+
+public class StringProbabilityHelperTests
+{
+    private class FixedRandom : Random
+    {
+        private readonly Queue<double> _values;
+        public FixedRandom(params double[] values)
+        {
+            _values = new Queue<double>(values);
+        }
+
+        public override double NextDouble()
+        {
+            return _values.Dequeue();
+        }
+    }
+
+    [Fact]
+    public void Choose_ReturnsSecond_When_Random_Less_Than_Probability()
+    {
+        var rng = new FixedRandom(0.1);
+        var result = StringProbabilityHelper.Choose("a", "b", 0.2, rng);
+        Assert.Equal("b", result);
+    }
+
+    [Fact]
+    public void Choose_ReturnsFirst_When_Random_Greater_Than_Probability()
+    {
+        var rng = new FixedRandom(0.5);
+        var result = StringProbabilityHelper.Choose("a", "b", 0.2, rng);
+        Assert.Equal("a", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `StringProbabilityHelper` to choose between two strings by probability
- cover selection behavior with deterministic tests

## Testing
- `dotnet format Predictorator.sln`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2dfc73883288a15ca451c4ed620