### PR TITLE
Add hidden Pong game on mobile team long press

### DIFF
--- a/Predictorator.Tests/AuthenticationTests.cs
+++ b/Predictorator.Tests/AuthenticationTests.cs
@@ -16,7 +16,7 @@ public class AuthenticationTests : IClassFixture<WebApplicationFactory<Program>>
         });
     }
 
-    [Fact(Skip="Requires table storage connection")]
+    [Fact(Skip = "Requires table storage connection")]
     public async Task Register_Page_Should_Return_NotFound()
     {
         var client = _factory.CreateClient();
@@ -24,7 +24,7 @@ public class AuthenticationTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
-    [Fact(Skip="Requires table storage connection")]
+    [Fact(Skip = "Requires table storage connection")]
     public async Task Login_Endpoint_Returns_BadRequest_When_Body_Missing()
     {
         var client = _factory.CreateClient();

--- a/Predictorator.Tests/HomePageTests.cs
+++ b/Predictorator.Tests/HomePageTests.cs
@@ -67,7 +67,7 @@ public class HomePageTests : IClassFixture<WebApplicationFactory<Program>>
         });
     }
 
-    [Fact(Skip="Requires table storage connection")]
+    [Fact(Skip = "Requires table storage connection")]
     public async Task Index_returns_view_with_buttons()
     {
         var client = _factory.CreateClient();

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -137,6 +137,24 @@ public class IndexPageBUnitTests
     }
 
     [Fact]
+    public async Task Registers_Pong_EasterEgg_On_First_Render()
+    {
+        await using var ctx = CreateContext();
+        RenderFragment body = b =>
+        {
+            b.OpenComponent<IndexPage>(0);
+            b.AddAttribute(1, "Season", "24-25");
+            b.AddAttribute(2, "Week", 1);
+            b.CloseComponent();
+        };
+        var cut = ctx.Render<MainLayout>(p => p.Add(l => l.Body, body));
+        cut.WaitForAssertion(() =>
+        {
+            ctx.JSInterop.Invocations.Single(i => i.Identifier == "app.registerPongEasterEgg");
+        });
+    }
+
+    [Fact]
     public async Task FixtureRow_Should_Render_With_Alignment_Classes()
     {
         await using var ctx = CreateContext();

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -361,6 +361,7 @@ else if (_fixtures.Response.Any())
         {
             var delay = Config.GetValue<int?>("ScoreInputFocusDelayMs") ?? 500;
             await Js.InvokeVoidAsync("app.registerScoreInputs", delay);
+            await Js.InvokeVoidAsync("app.registerPongEasterEgg");
         }
     }
 }

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -96,6 +96,24 @@ html, body {
     flex-direction: row;
 }
 
+#pongOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+#pongOverlay canvas {
+    background: #000;
+    touch-action: none;
+}
+
 @media (max-width: 600px) {
     .fixture-line {
         grid-template-columns: 1fr 20px 2rem 0.5rem 2rem 20px 1fr;


### PR DESCRIPTION
## Summary
- trigger Pong mini-game with a 3s long-press on a team (mobile only)
- populate score inputs with 30s game result
- cover new JS registration with unit test

## Testing
- `dotnet format Predictorator.sln --verify-no-changes`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f4f3cc408328b2afab5824d97334