### PR TITLE
Prevent text selection from blocking pong easter egg

### DIFF
--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -51,6 +51,9 @@ html, body {
 .team-name {
     white-space: normal;
     padding: 0 0.5rem;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 .ceefax-logo

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -232,7 +232,8 @@ window.app = (() => {
         if (!isMobileDevice()) return;
         document.querySelectorAll('.team-name').forEach(nameEl => {
             let timer = null;
-            const start = () => {
+            const start = (e) => {
+                e.preventDefault();
                 timer = setTimeout(() => {
                     const row = nameEl.closest('.fixture-row');
                     const playerIsHome = nameEl.classList.contains('home-name');


### PR DESCRIPTION
## Summary
- disable text selection and touch callout on team names
- cancel default touchstart behavior when triggering long-press pong game

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8d429ac83288d1bf8c166ad2c74