### PR TITLE
Fix long-press team name not launching pong game

### DIFF
--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -241,10 +241,11 @@ window.app = (() => {
                 }, 3000);
             };
             const cancel = () => { if (timer) { clearTimeout(timer); timer = null; } };
-            nameEl.addEventListener('touchstart', start);
+            nameEl.addEventListener('touchstart', start, { passive: false });
             nameEl.addEventListener('touchend', cancel);
             nameEl.addEventListener('touchcancel', cancel);
             nameEl.addEventListener('touchmove', cancel);
+            nameEl.addEventListener('contextmenu', e => e.preventDefault());
         });
     }
     


### PR DESCRIPTION
## Summary
- allow long-press on team names to launch pong by using non-passive touchstart and preventing context menus
- emulate mobile context in UI tests and add coverage for pong easter egg

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68a1009f211483289659dc2bef9b5d06