### PR TITLE
Use triple tap to launch pong easter egg on mobile

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -117,14 +117,19 @@ public class HomePageTests
     }
 
     [Test]
-    public async Task LongPressTeamName_Should_StartPongGame()
+    public async Task TripleTapTeamName_Should_StartPongGame()
     {
         await NavigateWithRetriesAsync(_page!, BaseUrl);
         await _page!.Locator(".team-name").First.WaitForAsync();
         await _page.EvaluateAsync(@"() => {
             const el = document.querySelector('.team-name');
-            const touch = new Touch({ identifier: 0, target: el, clientX: 0, clientY: 0 });
-            el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], bubbles: true, cancelable: true }));
+            const tap = () => {
+                const touch = new Touch({ identifier: Date.now(), target: el, clientX: 0, clientY: 0 });
+                el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], bubbles: true, cancelable: true }));
+            };
+            tap();
+            setTimeout(tap, 100);
+            setTimeout(tap, 200);
         }");
         await _page.WaitForSelectorAsync("#pongOverlay");
     }

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -231,20 +231,22 @@ window.app = (() => {
     function registerPongEasterEgg() {
         if (!isMobileDevice()) return;
         document.querySelectorAll('.team-name').forEach(nameEl => {
-            let timer = null;
-            const start = (e) => {
+            let tapCount = 0;
+            let tapTimer = null;
+            const onTap = (e) => {
                 e.preventDefault();
-                timer = setTimeout(() => {
+                tapCount++;
+                if (tapTimer) clearTimeout(tapTimer);
+                if (tapCount === 3) {
                     const row = nameEl.closest('.fixture-row');
                     const playerIsHome = nameEl.classList.contains('home-name');
                     startPongGame(row, playerIsHome);
-                }, 3000);
+                    tapCount = 0;
+                    return;
+                }
+                tapTimer = setTimeout(() => { tapCount = 0; }, 600);
             };
-            const cancel = () => { if (timer) { clearTimeout(timer); timer = null; } };
-            nameEl.addEventListener('touchstart', start, { passive: false });
-            nameEl.addEventListener('touchend', cancel);
-            nameEl.addEventListener('touchcancel', cancel);
-            nameEl.addEventListener('touchmove', cancel);
+            nameEl.addEventListener('touchstart', onTap, { passive: false });
             nameEl.addEventListener('contextmenu', e => e.preventDefault());
         });
     }


### PR DESCRIPTION
## Summary
- Replace unreliable 3s long press with triple tap to start the hidden pong game on mobile
- Update Playwright UI test to triple tap team name and verify game overlay appears

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`
- `dotnet format Predictorator.sln -v minimal` *(no output, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68a18ef7b4488328894de6588f430b75