### PR TITLE
Improve pong gameplay with scoreboard and timer

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -120,7 +120,7 @@ public class HomePageTests
     public async Task TripleTapTeamName_Should_StartPongGame()
     {
         await NavigateWithRetriesAsync(_page!, BaseUrl);
-        await _page!.Locator(".team-name").First.WaitForAsync();
+        var teamName = (await _page!.Locator(".team-name").First.TextContentAsync())?.Trim();
         await _page.EvaluateAsync(@"() => {
             const el = document.querySelector('.team-name');
             const tap = () => {
@@ -132,5 +132,10 @@ public class HomePageTests
             setTimeout(tap, 200);
         }");
         await _page.WaitForSelectorAsync("#pongOverlay");
+        await _page.WaitForSelectorAsync("#pongScore");
+        var scoreText = await _page.TextContentAsync("#pongScore");
+        StringAssert.Contains(teamName, scoreText);
+        var timerText = await _page.TextContentAsync("#pongTimer");
+        Assert.That(int.Parse(timerText), Is.InRange(0, 30));
     }
 }

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -107,6 +107,7 @@ html, body {
     height: 100%;
     background: rgba(0,0,0,0.8);
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     z-index: 1000;
@@ -115,6 +116,12 @@ html, body {
 #pongOverlay canvas {
     background: #000;
     touch-action: none;
+}
+
+#pongScore {
+    color: #fff;
+    font: 16px sans-serif;
+    margin-bottom: 8px;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Slow computer paddle and vary ball bounce so pong is playable
- Show team names with running score and countdown timer
- Test mobile easter egg now verifies scoreboard and timer

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a192ddbf048328b77aa46f62b18f47