### PR TITLE
Color pong paddles and timer placement

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -120,8 +120,12 @@ public class HomePageTests
     public async Task TripleTapTeamName_Should_StartPongGame()
     {
         await NavigateWithRetriesAsync(_page!, BaseUrl);
-        var teamName = (await _page!.Locator(".team-name").First.TextContentAsync())?.Trim();
-        await _page.EvaluateAsync(@"() => {
+        await _page!.EvaluateAsync(@"() => {
+            document.querySelector('.home-name').textContent = 'Aston Villa';
+            document.querySelector('.away-name').textContent = 'Newcastle';
+        }");
+        var teamName = "Aston Villa";
+        await _page!.EvaluateAsync(@"() => {
             const el = document.querySelector('.team-name');
             const tap = () => {
                 const touch = new Touch({ identifier: Date.now(), target: el, clientX: 0, clientY: 0 });
@@ -131,11 +135,20 @@ public class HomePageTests
             setTimeout(tap, 100);
             setTimeout(tap, 200);
         }");
-        await _page.WaitForSelectorAsync("#pongOverlay");
-        await _page.WaitForSelectorAsync("#pongScore");
-        var scoreText = await _page.TextContentAsync("#pongScore");
-        StringAssert.Contains(teamName, scoreText);
-        var timerText = await _page.TextContentAsync("#pongTimer");
-        Assert.That(int.Parse(timerText), Is.InRange(0, 30));
+        await _page!.WaitForSelectorAsync("#pongOverlay");
+        await _page!.WaitForSelectorAsync("#pongScore");
+        await _page!.WaitForSelectorAsync("#pongTimer");
+        var scoreText = await _page!.TextContentAsync("#pongScore");
+        StringAssert.Contains(teamName, scoreText!);
+        var timerText = await _page!.TextContentAsync("#pongTimer");
+        Assert.That(int.Parse(timerText!), Is.InRange(0, 30));
+        var prevId = await _page!.EvaluateAsync<string>("document.querySelector('#pongTimer').previousElementSibling.id");
+        Assert.That(prevId, Is.EqualTo("pongScore"));
+        var playerFirst = await _page!.EvaluateAsync<string>("document.querySelector('#pongPlayerName').children[0].style.color");
+        var playerSecond = await _page!.EvaluateAsync<string>("document.querySelector('#pongPlayerName').children[1].style.color");
+        Assert.That(playerFirst, Is.Not.EqualTo(playerSecond));
+        var compFirst = await _page!.EvaluateAsync<string>("document.querySelector('#pongComputerName').children[0].style.color");
+        var compSecond = await _page!.EvaluateAsync<string>("document.querySelector('#pongComputerName').children[1].style.color");
+        Assert.That(compFirst, Is.Not.EqualTo(compSecond));
     }
 }

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -124,6 +124,12 @@ html, body {
     margin-bottom: 8px;
 }
 
+#pongTimer {
+    color: #fff;
+    font: 16px sans-serif;
+    margin-bottom: 8px;
+}
+
 @media (max-width: 600px) {
     .fixture-line {
         grid-template-columns: 1fr 20px 2rem 0.5rem 2rem 20px 1fr;

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -135,6 +135,46 @@ window.app = (() => {
         const awayName = row.querySelector('.away-name')?.textContent.trim() || 'Away';
         const playerName = playerIsHome ? homeName : awayName;
         const computerName = playerIsHome ? awayName : homeName;
+
+        const teamColors = {
+            'arsenal': ['#ef0107', '#ffffff'],
+            'aston villa': ['#7a003c', '#95bfe5'],
+            'bournemouth': ['#da291c', '#000000'],
+            'brentford': ['#e30613', '#ffffff'],
+            'brighton': ['#0057b8', '#ffffff'],
+            'burnley': ['#6c1d45', '#99badd'],
+            'chelsea': ['#034694', '#ffffff'],
+            'crystal palace': ['#c4122e', '#1b458f'],
+            'everton': ['#003399', '#ffffff'],
+            'fulham': ['#000000', '#ffffff'],
+            'liverpool': ['#c8102e', '#ffffff'],
+            'luton': ['#ff8200', '#002f6c'],
+            'manchester city': ['#6cabdd', '#1c2c5b'],
+            'manchester united': ['#da291c', '#fbe122'],
+            'newcastle': ['#000000', '#ffffff'],
+            'nottingham forest': ['#dd0000', '#ffffff'],
+            'sheffield united': ['#ee2737', '#ffffff'],
+            'tottenham': ['#132257', '#ffffff'],
+            'west ham': ['#7a263a', '#1bb1e7'],
+            'wolverhampton': ['#fdb913', '#231f20']
+        };
+
+        const getTeamColors = name => teamColors[name.toLowerCase()] || ['#fff'];
+        const playerColors = getTeamColors(playerName);
+        const computerColors = getTeamColors(computerName);
+        const playerColor = playerColors[0];
+        const computerColor = computerColors[0];
+
+        function colorizeName(el, name, colors) {
+            el.innerHTML = '';
+            name.split('').forEach((ch, i) => {
+                const span = document.createElement('span');
+                span.textContent = ch;
+                span.style.color = colors[i % colors.length];
+                el.appendChild(span);
+            });
+        }
+
         overlay.innerHTML = `
             <div id="pongScore">
                 <span id="pongPlayerName"></span>
@@ -142,8 +182,8 @@ window.app = (() => {
                 -
                 <span id="pongComputerScore">0</span>
                 <span id="pongComputerName"></span>
-                <span id="pongTimer">30</span>
             </div>
+            <div id="pongTimer">30</div>
             <canvas id="pongCanvas" width="300" height="150"></canvas>`;
         document.body.appendChild(overlay);
 
@@ -167,8 +207,8 @@ window.app = (() => {
         const compNameEl = overlay.querySelector('#pongComputerName');
         const compScoreEl = overlay.querySelector('#pongComputerScore');
         const timerEl = overlay.querySelector('#pongTimer');
-        playerNameEl.textContent = playerName;
-        compNameEl.textContent = computerName;
+        colorizeName(playerNameEl, playerName, playerColors);
+        colorizeName(compNameEl, computerName, computerColors);
         timerEl.textContent = '30';
 
         let timeLeft = 30;
@@ -245,10 +285,12 @@ window.app = (() => {
         function draw() {
             ctx.fillStyle = 'black';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.fillStyle = 'white';
+            ctx.fillStyle = playerColor;
             ctx.fillRect(0, playerY, paddleWidth, paddleHeight);
+            ctx.fillStyle = computerColor;
             ctx.fillRect(canvas.width - paddleWidth, computerY, paddleWidth, paddleHeight);
             ctx.beginPath();
+            ctx.fillStyle = '#fff';
             ctx.arc(ballX, ballY, 3, 0, Math.PI * 2);
             ctx.fill();
         }


### PR DESCRIPTION
## Summary
- Place pong timer below score display
- Show team colors on score names and paddles
- Alternate colors for team names with multiple kit colors
- Verify timer placement, color setup, and alternating colors in UI test

## Testing
- `dotnet format Predictorator.sln --verbosity minimal`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a197cda73083288b40ad734359f10d