### PR TITLE
Explain subscription and email dialogs

### DIFF
--- a/Predictorator/Components/EmailDialog.razor
+++ b/Predictorator/Components/EmailDialog.razor
@@ -1,5 +1,6 @@
 <MudDialog>
     <DialogContent>
+        <MudText Class="mb-4">This will launch your mail client and pre-fill an email with your predictions.</MudText>
         <MudForm @ref="_form" Model="_model">
             <MudTextField @bind-Value="_model.Email" For="@(() => _model.Email)" Label="Email" InputType="InputType.Email" Required="true" />
             <MudCheckBox T="bool" @bind-Value="_remember" Label="Remember email" Class="mt-4" />

--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -20,6 +20,7 @@
     }
     else
     {
+        <p>We'll send emails on the morning of the first GW fixtures and two hours before the first fixture.</p>
         <MudTabs>
             @if (Features.EmailEnabled)
             {


### PR DESCRIPTION
## Summary
- clarify subscription dialog with upcoming email schedule
- describe email dialog behaviour when sending predictions

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a4449fd034832882a8edea382ee90f