### PR TITLE
Add configurable feature announcement popup

### DIFF
--- a/Predictorator.Core/Data/IAnnouncementRepository.cs
+++ b/Predictorator.Core/Data/IAnnouncementRepository.cs
@@ -1,0 +1,9 @@
+using Predictorator.Core.Models;
+
+namespace Predictorator.Core.Data;
+
+public interface IAnnouncementRepository
+{
+    Task<Announcement?> GetAsync();
+    Task UpsertAsync(Announcement announcement);
+}

--- a/Predictorator.Core/Data/TableAnnouncementRepository.cs
+++ b/Predictorator.Core/Data/TableAnnouncementRepository.cs
@@ -1,0 +1,70 @@
+using Azure;
+using Azure.Data.Tables;
+using Predictorator.Core.Models;
+
+namespace Predictorator.Core.Data;
+
+public class TableAnnouncementRepository : IAnnouncementRepository
+{
+    private readonly TableClient _table;
+    private const string PartitionKey = "A";
+    private const string RowKey = "settings";
+
+    public TableAnnouncementRepository(TableServiceClient client)
+    {
+        _table = client.GetTableClient("Announcements");
+        _table.CreateIfNotExists();
+    }
+
+    public async Task<Announcement?> GetAsync()
+    {
+        try
+        {
+            var entity = await _table.GetEntityAsync<AnnouncementEntity>(PartitionKey, RowKey);
+            return ToModel(entity.Value);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public Task UpsertAsync(Announcement announcement)
+    {
+        var entity = ToEntity(announcement);
+        entity.PartitionKey = PartitionKey;
+        entity.RowKey = RowKey;
+        return _table.UpsertEntityAsync(entity);
+    }
+
+    private static Announcement ToModel(AnnouncementEntity e) => new()
+    {
+        Id = Guid.Parse(e.Id),
+        Title = e.Title,
+        Message = e.Message,
+        IsEnabled = e.IsEnabled,
+        ExpiresAt = e.ExpiresAt
+    };
+
+    private static AnnouncementEntity ToEntity(Announcement m) => new()
+    {
+        Id = m.Id.ToString(),
+        Title = m.Title,
+        Message = m.Message,
+        IsEnabled = m.IsEnabled,
+        ExpiresAt = m.ExpiresAt
+    };
+
+    private class AnnouncementEntity : ITableEntity
+    {
+        public string PartitionKey { get; set; } = string.Empty;
+        public string RowKey { get; set; } = string.Empty;
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public bool IsEnabled { get; set; }
+        public DateTime ExpiresAt { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
+    }
+}

--- a/Predictorator.Core/Models/Announcement.cs
+++ b/Predictorator.Core/Models/Announcement.cs
@@ -1,0 +1,10 @@
+namespace Predictorator.Core.Models;
+
+public class Announcement
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; }
+    public DateTime ExpiresAt { get; set; }
+}

--- a/Predictorator.Core/Services/AnnouncementService.cs
+++ b/Predictorator.Core/Services/AnnouncementService.cs
@@ -1,0 +1,34 @@
+using Predictorator.Core.Data;
+using Predictorator.Core.Models;
+
+namespace Predictorator.Core.Services;
+
+public class AnnouncementService
+{
+    private readonly IAnnouncementRepository _repo;
+    private readonly IDateTimeProvider _time;
+
+    public AnnouncementService(IAnnouncementRepository repo, IDateTimeProvider time)
+    {
+        _repo = repo;
+        _time = time;
+    }
+
+    public Task<Announcement?> GetAsync() => _repo.GetAsync();
+
+    public async Task<Announcement?> GetCurrentAsync()
+    {
+        var ann = await _repo.GetAsync();
+        if (ann == null) return null;
+        if (!ann.IsEnabled) return null;
+        if (ann.ExpiresAt <= _time.UtcNow) return null;
+        return ann;
+    }
+
+    public async Task SaveAsync(Announcement announcement)
+    {
+        if (announcement.Id == Guid.Empty)
+            announcement.Id = Guid.NewGuid();
+        await _repo.UpsertAsync(announcement);
+    }
+}

--- a/Predictorator.Functions/ServiceCollectionExtensions.cs
+++ b/Predictorator.Functions/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ServiceCollectionExtensions
 
         services.AddTransient<SubscriptionService>();
         services.AddTransient<NotificationService>();
+        services.AddTransient<AnnouncementService>();
         services.AddTransient<INotificationSender<Subscriber>, EmailNotificationSender>();
         services.AddTransient<INotificationSender<SmsSubscriber>, SmsNotificationSender>();
 
@@ -59,6 +60,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IEmailSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
         services.AddScoped<ISmsSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
         services.AddScoped<ISentNotificationRepository>(sp => sp.GetRequiredService<TableDataStore>());
+        services.AddScoped<IAnnouncementRepository, TableAnnouncementRepository>();
         services.AddScoped<IGameWeekRepository, TableGameWeekRepository>();
 
         return services;

--- a/Predictorator.Tests/AnnouncementServiceTests.cs
+++ b/Predictorator.Tests/AnnouncementServiceTests.cs
@@ -1,0 +1,68 @@
+using Predictorator.Core.Models;
+using Predictorator.Core.Services;
+using Predictorator.Tests.Helpers;
+
+namespace Predictorator.Tests;
+
+public class AnnouncementServiceTests
+{
+    [Fact]
+    public async Task GetCurrentAsync_returns_announcement_when_enabled_and_not_expired()
+    {
+        var repo = new InMemoryAnnouncementRepository
+        {
+            Announcement = new Announcement
+            {
+                Id = Guid.NewGuid(),
+                Title = "Title",
+                Message = "Message",
+                IsEnabled = true,
+                ExpiresAt = DateTime.UtcNow.AddDays(1)
+            }
+        };
+        var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
+        var svc = new AnnouncementService(repo, time);
+        var result = await svc.GetCurrentAsync();
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_returns_null_when_disabled()
+    {
+        var repo = new InMemoryAnnouncementRepository
+        {
+            Announcement = new Announcement
+            {
+                Id = Guid.NewGuid(),
+                Title = "Title",
+                Message = "Message",
+                IsEnabled = false,
+                ExpiresAt = DateTime.UtcNow.AddDays(1)
+            }
+        };
+        var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
+        var svc = new AnnouncementService(repo, time);
+        var result = await svc.GetCurrentAsync();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_returns_null_when_expired()
+    {
+        var repo = new InMemoryAnnouncementRepository
+        {
+            Announcement = new Announcement
+            {
+                Id = Guid.NewGuid(),
+                Title = "Title",
+                Message = "Message",
+                IsEnabled = true,
+                ExpiresAt = DateTime.UtcNow.AddDays(-1)
+            }
+        };
+        var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
+        var svc = new AnnouncementService(repo, time);
+        var result = await svc.GetCurrentAsync();
+        Assert.Null(result);
+    }
+}

--- a/Predictorator.Tests/CeefaxModeBUnitTests.cs
+++ b/Predictorator.Tests/CeefaxModeBUnitTests.cs
@@ -14,6 +14,7 @@ using Predictorator.Core.Models.Fixtures;
 using Predictorator.Services;
 using Predictorator.Core.Services;
 using Predictorator.Tests.Helpers;
+using Predictorator.Core.Data;
 
 namespace Predictorator.Tests;
 
@@ -35,6 +36,7 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
         ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
         var provider = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider);
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
 
         var settings = new Dictionary<string, string?>
@@ -47,6 +49,8 @@ public class CeefaxModeBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
         return ctx;
     }
 
@@ -178,7 +182,9 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
         ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
-        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
+        var provider2 = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider2);
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider2));
 
         var settings = new Dictionary<string, string?>
         {
@@ -190,6 +196,8 @@ public class CeefaxModeBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
 
         var cut = ctx.Render<App>();
         var layout = cut.FindComponent<MainLayout>();
@@ -217,7 +225,9 @@ public class CeefaxModeBUnitTests
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
         ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
-        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
+        var provider3 = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider3);
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider3));
 
         var settings = new Dictionary<string, string?>
         {
@@ -229,6 +239,8 @@ public class CeefaxModeBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
 
         var cut = ctx.Render<App>();
         var layout = cut.FindComponent<MainLayout>();
@@ -271,8 +283,9 @@ public class CeefaxModeBUnitTests
         };
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(fixtures));
         ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
-        var provider = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
-        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
+        var provider4 = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider4);
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider4));
 
         var settings = new Dictionary<string, string?>
         {
@@ -284,6 +297,8 @@ public class CeefaxModeBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
 
         var cut = ctx.Render<App>();
         var inputs = cut.FindAll("[data-testid=score-input]");

--- a/Predictorator.Tests/DarkModeBUnitTests.cs
+++ b/Predictorator.Tests/DarkModeBUnitTests.cs
@@ -13,6 +13,7 @@ using Predictorator.Services;
 using ThemeStyles = Predictorator.Themes.Themes;
 using Predictorator.Core.Services;
 using Predictorator.Tests.Helpers;
+using Predictorator.Core.Data;
 
 namespace Predictorator.Tests;
 
@@ -36,6 +37,7 @@ public class DarkModeBUnitTests
             Today = new DateTime(2024, 1, 1),
             UtcNow = new DateTime(2024, 1, 1)
         };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider);
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
 
@@ -49,6 +51,8 @@ public class DarkModeBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
         return ctx;
     }
 
@@ -94,7 +98,9 @@ public class DarkModeBUnitTests
         ctx.Services.AddSingleton(Substitute.For<IDialogService>());
         ctx.Services.AddSingleton<IFixtureService>(new FakeFixtureService(new FixturesResponse { Response = [] }));
         ctx.Services.AddSingleton<IGameWeekService>(new FakeGameWeekService());
-        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) }));
+        var provider2 = new FakeDateTimeProvider { Today = new DateTime(2024, 1, 1), UtcNow = new DateTime(2024, 1, 1) };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider2);
+        ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider2));
 
         var settings = new Dictionary<string, string?>
         {
@@ -106,6 +112,8 @@ public class DarkModeBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
 
         var cut = ctx.Render<App>();
         var layout = cut.FindComponent<MainLayout>();

--- a/Predictorator.Tests/FunctionAppDiResolutionTests.cs
+++ b/Predictorator.Tests/FunctionAppDiResolutionTests.cs
@@ -50,6 +50,7 @@ public class FunctionAppDiResolutionTests
         services.RemoveAll<IGameWeekRepository>();
         services.RemoveAll<IBackgroundJobService>();
         services.RemoveAll<IBackgroundJobErrorService>();
+        services.RemoveAll<IAnnouncementRepository>();
 
         var store = new InMemoryDataStore();
         services.AddSingleton<IEmailSubscriberRepository>(store);
@@ -58,6 +59,7 @@ public class FunctionAppDiResolutionTests
         services.AddSingleton<IGameWeekRepository, InMemoryGameWeekRepository>();
         services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
         services.AddSingleton<IBackgroundJobErrorService>(_ => Substitute.For<IBackgroundJobErrorService>());
+        services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
 
         _provider = services.BuildServiceProvider();
         _services = services;

--- a/Predictorator.Tests/Helpers/InMemoryAnnouncementRepository.cs
+++ b/Predictorator.Tests/Helpers/InMemoryAnnouncementRepository.cs
@@ -1,0 +1,17 @@
+using Predictorator.Core.Data;
+using Predictorator.Core.Models;
+
+namespace Predictorator.Tests.Helpers;
+
+public class InMemoryAnnouncementRepository : IAnnouncementRepository
+{
+    public Announcement? Announcement { get; set; }
+
+    public Task<Announcement?> GetAsync() => Task.FromResult(Announcement);
+
+    public Task UpsertAsync(Announcement announcement)
+    {
+        Announcement = announcement;
+        return Task.CompletedTask;
+    }
+}

--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -12,6 +12,7 @@ using Predictorator.Tests.Helpers;
 using IndexPage = Predictorator.Components.Pages.Index;
 using System.Linq;
 using System.Collections.Generic;
+using Predictorator.Core.Data;
 
 namespace Predictorator.Tests;
 
@@ -41,6 +42,7 @@ public class IndexPageBUnitTests
             Today = new DateTime(2024, 1, 1),
             UtcNow = new DateTime(2024, 1, 1)
         };
+        ctx.Services.AddSingleton<IDateTimeProvider>(provider);
         ctx.Services.AddSingleton<IDateRangeCalculator>(new DateRangeCalculator(provider));
 
         var settings = new Dictionary<string, string?>
@@ -61,6 +63,8 @@ public class IndexPageBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<AnnouncementService>();
         return ctx;
     }
 

--- a/Predictorator.Tests/MainLayoutBUnitTests.cs
+++ b/Predictorator.Tests/MainLayoutBUnitTests.cs
@@ -13,6 +13,7 @@ using Predictorator.Tests.Helpers;
 using Predictorator.Components.Pages.Subscription;
 using Predictorator.Services;
 using Predictorator.Core.Services;
+using Predictorator.Core.Data;
 
 namespace Predictorator.Tests;
 
@@ -43,6 +44,9 @@ public class MainLayoutBUnitTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         ctx.Services.AddSingleton<IConfiguration>(config);
         ctx.Services.AddSingleton<NotificationFeatureService>();
+        ctx.Services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
+        ctx.Services.AddSingleton<IDateTimeProvider>(new FakeDateTimeProvider { Today = DateTime.Today, UtcNow = DateTime.UtcNow });
+        ctx.Services.AddSingleton<AnnouncementService>();
         return ctx;
     }
 

--- a/Predictorator.Tests/WebAppDiResolutionTests.cs
+++ b/Predictorator.Tests/WebAppDiResolutionTests.cs
@@ -39,6 +39,7 @@ public class WebAppDiResolutionTests : IClassFixture<WebApplicationFactory<Progr
                 services.RemoveAll<IGameWeekRepository>();
                 services.RemoveAll<IBackgroundJobService>();
                 services.RemoveAll<IBackgroundJobErrorService>();
+                services.RemoveAll<IAnnouncementRepository>();
                 var store = new InMemoryDataStore();
                 services.AddSingleton<IEmailSubscriberRepository>(store);
                 services.AddSingleton<ISmsSubscriberRepository>(store);
@@ -46,6 +47,7 @@ public class WebAppDiResolutionTests : IClassFixture<WebApplicationFactory<Progr
                 services.AddSingleton<IGameWeekRepository, InMemoryGameWeekRepository>();
                 services.AddSingleton<IBackgroundJobService>(_ => Substitute.For<IBackgroundJobService>());
                 services.AddSingleton<IBackgroundJobErrorService>(_ => Substitute.For<IBackgroundJobErrorService>());
+                services.AddSingleton<IAnnouncementRepository, InMemoryAnnouncementRepository>();
                 descriptors = services;
             });
         });

--- a/Predictorator/Components/AnnouncementDialog.razor
+++ b/Predictorator/Components/AnnouncementDialog.razor
@@ -1,0 +1,16 @@
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@Title</MudText>
+        <MudText>@Message</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Color="Color.Primary" Variant="Variant.Filled">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string Message { get; set; } = string.Empty;
+    private void Close() => MudDialog.Close();
+}

--- a/Predictorator/Components/Layout/MainLayout.razor
+++ b/Predictorator/Components/Layout/MainLayout.razor
@@ -6,6 +6,7 @@
 @inject UiModeService UiMode
 @inject IDialogService DialogService
 @inject NotificationFeatureService NotificationFeatures
+@inject IServiceProvider Services
 @using Predictorator.Components.Pages.Subscription
 @using Predictorator.Components.Privacy
 
@@ -236,8 +237,33 @@
             await SetCookie("ceefaxMode", IsCeefax);
 
             await Js.InvokeVoidAsync("app.setCeefax", IsCeefax);
+            await ShowAnnouncementAsync();
             await InvokeAsync(StateHasChanged);
         }
+    }
+
+    private async Task ShowAnnouncementAsync()
+    {
+        var svc = Services.GetService<AnnouncementService>();
+        if (svc == null)
+            return;
+        var ann = await svc.GetCurrentAsync();
+        if (ann == null)
+            return;
+
+        var seen = await Js.InvokeAsync<string?>("localStorage.getItem", "announcementSeen");
+        if (seen == ann.Id.ToString())
+            return;
+
+        var parameters = new DialogParameters
+        {
+            ["Title"] = ann.Title,
+            ["Message"] = ann.Message
+        };
+        var options = new DialogOptions { CloseButton = true };
+        var dialog = DialogService.Show<AnnouncementDialog>(ann.Title, parameters, options);
+        await dialog.Result;
+        await Js.InvokeVoidAsync("localStorage.setItem", "announcementSeen", ann.Id.ToString());
     }
 
     private async Task ToggleDarkModeAsync()

--- a/Predictorator/Components/Pages/Admin/Announcements.razor
+++ b/Predictorator/Components/Pages/Admin/Announcements.razor
@@ -1,0 +1,53 @@
+@rendermode InteractiveServer
+@inject AnnouncementService AnnouncementService
+@inject ToastInterop Toast
+
+<h2>Announcements</h2>
+@if (_model == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <EditForm Model="_model" OnValidSubmit="SaveAsync">
+        <MudStack Spacing="2">
+            <MudCheckBox T="bool" @bind-Value="_model.IsEnabled" Label="Display message" />
+            <MudTextField @bind-Value="_model.Title" Label="Title" />
+            <MudTextField @bind-Value="_model.Message" Label="Message" Lines="5" />
+            <MudDatePicker @bind-Date="_expires" Label="Expires" />
+            <MudButton ButtonType="ButtonType.Submit" Color="Color.Primary" Variant="Variant.Filled">Save</MudButton>
+        </MudStack>
+    </EditForm>
+}
+
+@code {
+    private Announcement? _model;
+    private DateTime? _expires;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _model = await AnnouncementService.GetAsync() ?? new Announcement { ExpiresAt = DateTime.Today };
+        _expires = _model.ExpiresAt;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (_model == null)
+            return;
+        if (!_expires.HasValue)
+        {
+            await Toast.ShowToast("Please choose an expiry date.", "error");
+            return;
+        }
+        _model.ExpiresAt = _expires.Value;
+        try
+        {
+            await AnnouncementService.SaveAsync(_model);
+            await Toast.ShowToast("Announcement saved!", "success");
+        }
+        catch
+        {
+            await Toast.ShowToast("Failed to save announcement.", "error");
+        }
+    }
+}

--- a/Predictorator/Components/Pages/Admin/Index.razor
+++ b/Predictorator/Components/Pages/Admin/Index.razor
@@ -18,6 +18,9 @@
     <MudTabPanel Text="Errors">
         <Errors />
     </MudTabPanel>
+    <MudTabPanel Text="Announcements">
+        <Announcements />
+    </MudTabPanel>
     <MudTabPanel Text="Maintenance">
         <MudPaper Class="pa-2">
             <MudButton Color="Color.Error" Variant="Variant.Filled" OnClick="ClearCaches">Clear Caches</MudButton>

--- a/Predictorator/Startup/ServiceCollectionExtensions.cs
+++ b/Predictorator/Startup/ServiceCollectionExtensions.cs
@@ -90,9 +90,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IEmailSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
         services.AddScoped<ISmsSubscriberRepository>(sp => sp.GetRequiredService<TableDataStore>());
         services.AddScoped<ISentNotificationRepository>(sp => sp.GetRequiredService<TableDataStore>());
+        services.AddScoped<IAnnouncementRepository, TableAnnouncementRepository>();
         services.AddScoped<IGameWeekRepository, TableGameWeekRepository>();
         services.AddTransient<SubscriptionService>();
         services.AddTransient<NotificationService>();
+        services.AddTransient<AnnouncementService>();
         services.AddTransient<AdminService>();
         services.AddTransient<IGameWeekService, GameWeekService>();
         services.AddSingleton<EmailCssInliner>();


### PR DESCRIPTION
## Summary
- add table-backed announcement model and service
- allow admins to edit announcements in new admin tab
- show announcement pop-up on load until viewed or expired

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a81aff0b148328a4351dd21d5fa8d4