### PR TITLE
Clarify subscribe modal notification wording

### DIFF
--- a/Predictorator/Components/Pages/Subscription/Subscribe.razor
+++ b/Predictorator/Components/Pages/Subscription/Subscribe.razor
@@ -20,7 +20,7 @@
     }
     else
     {
-        <p>We'll send emails on the morning of the first GW fixtures and two hours before the first fixture.</p>
+        <p>We'll send notifications on the morning of the first GW fixtures and two hours before the first fixture.</p>
         <MudTabs>
             @if (Features.EmailEnabled)
             {


### PR DESCRIPTION
## Summary
- generalize subscribe dialog copy to say "notifications" instead of "emails"

## Testing
- `dotnet format Predictorator.sln --no-restore --verify-no-changes --verbosity normal --include Predictorator/Components/Pages/Subscription/Subscribe.razor`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a81c79b7d08328b5c4ab76a5a87719