### PR TITLE
Enable Pong on desktop

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -117,7 +117,7 @@ public class HomePageTests
     }
 
     [Test]
-    public async Task TripleTapTeamName_Should_StartPongGame()
+    public async Task TripleClickTeamName_Should_StartPongGame()
     {
         await NavigateWithRetriesAsync(_page!, BaseUrl);
         await _page!.EvaluateAsync(@"() => {
@@ -127,13 +127,12 @@ public class HomePageTests
         var teamName = "Aston Villa";
         await _page!.EvaluateAsync(@"() => {
             const el = document.querySelector('.team-name');
-            const tap = () => {
-                const touch = new Touch({ identifier: Date.now(), target: el, clientX: 0, clientY: 0 });
-                el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], bubbles: true, cancelable: true }));
+            const click = () => {
+                el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
             };
-            tap();
-            setTimeout(tap, 100);
-            setTimeout(tap, 200);
+            click();
+            setTimeout(click, 100);
+            setTimeout(click, 200);
         }");
         await _page!.WaitForSelectorAsync("#pongOverlay");
         await _page!.WaitForSelectorAsync("#pongScore");
@@ -162,13 +161,12 @@ public class HomePageTests
         }");
         await _page!.EvaluateAsync(@"() => {
             const el = document.querySelector('.team-name');
-            const tap = () => {
-                const touch = new Touch({ identifier: Date.now(), target: el, clientX: 0, clientY: 0 });
-                el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch], bubbles: true, cancelable: true }));
+            const click = () => {
+                el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
             };
-            tap();
-            setTimeout(tap, 100);
-            setTimeout(tap, 200);
+            click();
+            setTimeout(click, 100);
+            setTimeout(click, 200);
         }");
         await _page!.WaitForSelectorAsync("#pongOverlay");
         var playerHeight = await _page!.GetAttributeAsync("#pongOverlay", "data-player-paddle-height");

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -333,7 +333,6 @@ window.app = (() => {
     }
 
     function registerPongEasterEgg() {
-        if (!isMobileDevice()) return;
         document.querySelectorAll('.team-name').forEach(nameEl => {
             let tapCount = 0;
             let tapTimer = null;
@@ -351,6 +350,7 @@ window.app = (() => {
                 tapTimer = setTimeout(() => { tapCount = 0; }, 600);
             };
             nameEl.addEventListener('touchstart', onTap, { passive: false });
+            nameEl.addEventListener('click', onTap);
             nameEl.addEventListener('contextmenu', e => e.preventDefault());
         });
     }


### PR DESCRIPTION
## Summary
- let Pong Easter egg work on desktop devices by listening for click events
- adjust UI tests to simulate triple-click instead of touch events

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`
- `dotnet format Predictorator.sln --verify-no-changes -v:diag`


------
https://chatgpt.com/codex/tasks/task_e_68a81d6d1dd8832896fe9fe17fc394cc