### PR TITLE
Fix announcement save error by storing expiry as UTC

### DIFF
--- a/Predictorator.Core/Services/AnnouncementService.cs
+++ b/Predictorator.Core/Services/AnnouncementService.cs
@@ -29,6 +29,12 @@ public class AnnouncementService
     {
         if (announcement.Id == Guid.Empty)
             announcement.Id = Guid.NewGuid();
+
+        // Azure Table storage requires DateTime values to be in UTC. Convert the
+        // expiry to UTC to avoid serialization errors when persisting the
+        // announcement.
+        announcement.ExpiresAt = announcement.ExpiresAt.ToUniversalTime();
+
         await _repo.UpsertAsync(announcement);
     }
 }

--- a/Predictorator.Tests/AnnouncementServiceTests.cs
+++ b/Predictorator.Tests/AnnouncementServiceTests.cs
@@ -65,4 +65,25 @@ public class AnnouncementServiceTests
         var result = await svc.GetCurrentAsync();
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task SaveAsync_assigns_id_and_converts_expiry_to_utc()
+    {
+        var repo = new InMemoryAnnouncementRepository();
+        var time = new FakeDateTimeProvider { UtcNow = DateTime.UtcNow };
+        var svc = new AnnouncementService(repo, time);
+        var ann = new Announcement
+        {
+            Title = "Title",
+            Message = "Message",
+            IsEnabled = true,
+            ExpiresAt = DateTime.Now
+        };
+
+        await svc.SaveAsync(ann);
+
+        Assert.NotNull(repo.Announcement);
+        Assert.NotEqual(Guid.Empty, repo.Announcement!.Id);
+        Assert.Equal(DateTimeKind.Utc, repo.Announcement!.ExpiresAt.Kind);
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure announcement expiry is stored in UTC to satisfy Azure Table requirements
- Add unit test verifying save assigns ID and converts expiry to UTC

## Testing
- `dotnet format Predictorator.Core/Predictorator.Core.csproj`
- `dotnet format Predictorator.Tests/Predictorator.Tests.csproj`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a83e6f4a8083288011ac589f9343ff