### PR TITLE
Add limerick option to prediction email preface

### DIFF
--- a/Predictorator.Tests/IndexPageBUnitTests.cs
+++ b/Predictorator.Tests/IndexPageBUnitTests.cs
@@ -528,6 +528,9 @@ public class IndexPageBUnitTests
         var bodyEncoded = uri.Split("&body=")[1];
         var bodyText = Uri.UnescapeDataString(bodyEncoded);
         Assert.StartsWith("Hello Helen Lyttle,", bodyText);
+        var jokeLine = "Here is a funny joke I heard recently that I thought you might enjoy...";
+        var limerickLine = "Here is a limerick I recently composed, I apologize in advance for its mildly ribald tone...";
+        Assert.True(bodyText.Contains(jokeLine) || bodyText.Contains(limerickLine));
         var preIndex = bodyText.IndexOf("My predictions are as follows...");
         var tableIndex = bodyText.IndexOf("Home 1 - 0 Away");
         var postIndex = bodyText.IndexOf("Yours sincerely,");

--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -12,6 +12,7 @@
 @inject IConfiguration Config
 @using Predictorator.Components.Layout
 @using Predictorator.Core.Models
+@using Predictorator.Core.Services
 @using System.Text
 @using System.Linq
 @using Microsoft.Extensions.Configuration
@@ -348,7 +349,10 @@ else if (_fixtures.Response.Any())
         sbPre.AppendLine("");
         sbPre.AppendLine("I would like to take this opportunity to put on record my continuing gratitude for your tireless efforts in administering the Premier League Prediction League.");
         sbPre.AppendLine("");
-        sbPre.AppendLine("Here is a funny joke I heard recently that I thought you might enjoy...");
+        sbPre.AppendLine(StringProbabilityHelper.Choose(
+            "Here is a funny joke I heard recently that I thought you might enjoy...",
+            "Here is a limerick I recently composed, I apologize in advance for its mildly ribald tone...",
+            0.04));
         sbPre.AppendLine("");
         sbPre.AppendLine("<insert joke>.");
         sbPre.AppendLine("");


### PR DESCRIPTION
## Summary
- Use `StringProbabilityHelper` to occasionally swap the joke in special prediction emails with a limerick (4% chance)
- Allow tests to accept either joke or limerick in generated email body

## Testing
- `dotnet format Predictorator.sln`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68a85e25656c832887e72a536d0e163f