### PR TITLE
Improve pong ball visibility and rally pacing

### DIFF
--- a/Predictorator.UiTests/HomePageTests.cs
+++ b/Predictorator.UiTests/HomePageTests.cs
@@ -121,10 +121,10 @@ public class HomePageTests
     {
         await NavigateWithRetriesAsync(_page!, BaseUrl);
         await _page!.EvaluateAsync(@"() => {
-            document.querySelector('.home-name').textContent = 'Aston Villa';
-            document.querySelector('.away-name').textContent = 'Newcastle';
+            document.querySelector('.home-name').textContent = 'Leeds United';
+            document.querySelector('.away-name').textContent = 'Manchester United';
         }");
-        var teamName = "Aston Villa";
+        var teamName = "Leeds United";
         await _page!.EvaluateAsync(@"() => {
             const el = document.querySelector('.team-name');
             const click = () => {
@@ -149,6 +149,16 @@ public class HomePageTests
         var compFirst = await _page!.EvaluateAsync<string>("document.querySelector('#pongComputerName').children[0].style.color");
         var compSecond = await _page!.EvaluateAsync<string>("document.querySelector('#pongComputerName').children[1].style.color");
         Assert.That(compFirst, Is.Not.EqualTo(compSecond));
+
+        await Task.Delay(100);
+        var compColor = await _page!.EvaluateAsync<string>("document.querySelector('#pongComputerName').style.color");
+        var ballColor = await _page!.EvaluateAsync<string>(@"() => {
+            const canvas = document.querySelector('#pongCanvas');
+            const ctx = canvas.getContext('2d');
+            const data = ctx.getImageData(canvas.width / 2, canvas.height / 2, 1, 1).data;
+            return `rgb(${data[0]}, ${data[1]}, ${data[2]})`;
+        }");
+        Assert.That(ballColor, Is.EqualTo(compColor));
     }
 
     [Test]

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -329,10 +329,12 @@ window.app = (() => {
         overlay.dataset.computerPaddleHeight = computerPaddleHeight;
         let playerY = canvas.height / 2 - playerPaddleHeight / 2;
         let computerY = canvas.height / 2 - computerPaddleHeight / 2;
+        const initialBallSpeed = 2;
+        const speedIncrease = 1.05;
         let ballX = canvas.width / 2;
         let ballY = canvas.height / 2;
-        let ballVX = 3;
-        let ballVY = 3;
+        let ballVX = initialBallSpeed;
+        let ballVY = initialBallSpeed;
         let playerScore = 0;
         let compScore = 0;
         let running = true;
@@ -373,8 +375,9 @@ window.app = (() => {
         function resetBall() {
             ballX = canvas.width / 2;
             ballY = canvas.height / 2;
-            ballVX = -ballVX;
-            ballVY = 3 * (Math.random() > 0.5 ? 1 : -1);
+            const dir = -Math.sign(ballVX) || 1;
+            ballVX = dir * initialBallSpeed;
+            ballVY = initialBallSpeed * (Math.random() > 0.5 ? 1 : -1);
         }
 
         canvas.addEventListener('touchmove', e => {
@@ -394,8 +397,8 @@ window.app = (() => {
 
             if (ballX <= paddleWidth) {
                 if (ballY > playerY && ballY < playerY + playerPaddleHeight) {
-                    ballVX = -ballVX;
-                    ballVY += (Math.random() - 0.5);
+                    ballVX = -ballVX * speedIncrease;
+                    ballVY = ballVY * speedIncrease + (Math.random() - 0.5);
                 } else {
                     compScore++;
                     compScoreEl.textContent = compScore;
@@ -405,8 +408,8 @@ window.app = (() => {
 
             if (ballX >= canvas.width - paddleWidth) {
                 if (ballY > computerY && ballY < computerY + computerPaddleHeight) {
-                    ballVX = -ballVX;
-                    ballVY += (Math.random() - 0.5);
+                    ballVX = -ballVX * speedIncrease;
+                    ballVY = ballVY * speedIncrease + (Math.random() - 0.5);
                 } else {
                     playerScore++;
                     playerScoreEl.textContent = playerScore;
@@ -427,8 +430,9 @@ window.app = (() => {
             ctx.fillRect(0, playerY, paddleWidth, playerPaddleHeight);
             ctx.fillStyle = computerFg;
             ctx.fillRect(canvas.width - paddleWidth, computerY, paddleWidth, computerPaddleHeight);
+            const ballColor = ballX < canvas.width / 2 ? playerFg : computerFg;
             ctx.beginPath();
-            ctx.fillStyle = '#fff';
+            ctx.fillStyle = ballColor;
             ctx.arc(ballX, ballY, 3, 0, Math.PI * 2);
             ctx.fill();
         }


### PR DESCRIPTION
## Summary
- Ensure pong ball contrasts with team backgrounds by coloring it to match the active side's foreground color
- Start rallies at a slower speed and gradually accelerate after paddle hits
- Verify ball color matches opponent foreground in UI tests

## Testing
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a8d70c199883288d0b34ea44412b9b