### PR TITLE
Accelerate pong ball speed

### DIFF
--- a/Predictorator.Tests/PongGameTests.cs
+++ b/Predictorator.Tests/PongGameTests.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Predictorator.Tests;
+
+public class PongGameTests
+{
+    [Fact]
+    public void SpeedIncrease_Should_Be_Greater_Than_BaseValue()
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var scriptPath = Path.Combine(root, "Predictorator", "wwwroot", "js", "site.js");
+        Assert.True(File.Exists(scriptPath), "site.js not found");
+
+        var script = File.ReadAllText(scriptPath);
+        var match = Regex.Match(script, @"const speedIncrease = ([0-9.]+);");
+        Assert.True(match.Success, "speedIncrease constant not found");
+
+        var value = double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        Assert.True(value >= 1.1, $"Expected speedIncrease >= 1.1 but was {value}");
+    }
+}
+

--- a/Predictorator/wwwroot/js/site.js
+++ b/Predictorator/wwwroot/js/site.js
@@ -330,7 +330,7 @@ window.app = (() => {
         let playerY = canvas.height / 2 - playerPaddleHeight / 2;
         let computerY = canvas.height / 2 - computerPaddleHeight / 2;
         const initialBallSpeed = 2;
-        const speedIncrease = 1.05;
+        const speedIncrease = 1.2;
         let ballX = canvas.width / 2;
         let ballY = canvas.height / 2;
         let ballVX = initialBallSpeed;


### PR DESCRIPTION
## Summary
- increase the pong ball's speed multiplier so rallies escalate faster
- add a regression test to ensure the pong ball's speed multiplier stays above the baseline

## Testing
- `dotnet format Predictorator.Tests/Predictorator.Tests.csproj --include PongGameTests.cs --verbosity normal`
- `dotnet build Predictorator.sln -warnaserror`
- `dotnet test Predictorator.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a8e5f6e66883289da2f10f8a744924