### PR TITLE
Add sliding puzzle easter egg

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -121,6 +121,7 @@ else if (_fixtures.Response.Any())
     private List<GameWeek>? _gameWeeks;
     private readonly Dictionary<int, PredictionInput> _predictions = new();
     private DateRange _selectedRange = new(null, null);
+    private int _clearClickCount;
 
     [Parameter] public string? Season { get; set; }
     [Parameter] public int? Week { get; set; }
@@ -248,17 +249,44 @@ else if (_fixtures.Response.Any())
 
     private async Task ClearScores()
     {
-        if (_fixtures == null) return;
-        foreach (var f in _fixtures.Response)
+        _clearClickCount++;
+
+        if (_fixtures != null)
         {
-            var pred = _predictions[f.Fixture.Id];
-            if (f.Score?.Fulltime.Home == null)
-                pred.Home = null;
-            if (f.Score?.Fulltime.Away == null)
-                pred.Away = null;
+            foreach (var f in _fixtures.Response)
+            {
+                var pred = _predictions[f.Fixture.Id];
+                if (f.Score?.Fulltime.Home == null)
+                    pred.Home = null;
+                if (f.Score?.Fulltime.Away == null)
+                    pred.Away = null;
+            }
         }
 
         await Js.InvokeVoidAsync("localStorage.removeItem", PredictionsStorageKey);
+        await MaybeShowSlidingPuzzleAsync();
+    }
+
+    private Task MaybeShowSlidingPuzzleAsync()
+    {
+        if (_clearClickCount < 4)
+            return Task.CompletedTask;
+
+        _clearClickCount = 0;
+        return ShowSlidingPuzzleAsync();
+    }
+
+    private Task ShowSlidingPuzzleAsync()
+    {
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
+        };
+
+        DialogService.Show<SlidingPuzzleDialog>("Sliding Puzzle", options);
+        return Task.CompletedTask;
     }
 
     private async Task SavePredictions()

--- a/Predictorator/Components/SlidingPuzzleDialog.razor
+++ b/Predictorator/Components/SlidingPuzzleDialog.razor
@@ -1,0 +1,153 @@
+@using System.Linq
+
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.h6" Align="Align.Center" Class="mb-2">Sliding Puzzle</MudText>
+        @if (_solved)
+        {
+            <div class="sliding-puzzle-solved">
+                <MudText Typo="Typo.subtitle1" Align="Align.Center">Puzzle complete!</MudText>
+                <img src="@PuzzleImage" alt="Completed DG sliding puzzle" class="sliding-puzzle-solved-image" />
+            </div>
+        }
+        else
+        {
+            <div class="sliding-puzzle-container">
+                <MudText Typo="Typo.subtitle2" Align="Align.Center">
+                    Slide the tiles into the empty space to reveal the full picture.
+                </MudText>
+                <div class="sliding-puzzle-grid" role="grid" aria-label="DG sliding puzzle">
+                    @for (var index = 0; index < TileCount; index++)
+                    {
+                        var tile = _tiles[index];
+                        if (tile == BlankTile)
+                        {
+                            <div class="sliding-puzzle-blank" role="presentation"></div>
+                        }
+                        else
+                        {
+                            <button type="button"
+                                    class="sliding-puzzle-tile"
+                                    style="@GetTileStyle(tile)"
+                                    @onclick="@(() => MoveTile(index))"
+                                    aria-label="@GetTileLabel(tile)">
+                            </button>
+                        }
+                    }
+                </div>
+            </div>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Color="Color.Secondary">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private const int GridSize = 4;
+    private const int TileCount = GridSize * GridSize;
+    private const int BlankTile = TileCount - 1;
+    private const string PuzzleImage = "images/puzzles/dg.jpg";
+
+    private readonly int[] _tiles = new int[TileCount];
+    private readonly Random _random = new();
+    private int _blankIndex;
+    private bool _solved;
+
+    [CascadingParameter] private MudDialogInstance DialogInstance { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        ShuffleTiles();
+    }
+
+    private void ShuffleTiles()
+    {
+        var values = Enumerable.Range(0, TileCount).ToArray();
+        do
+        {
+            Shuffle(values);
+        } while (!IsSolvable(values) || IsSolved(values));
+
+        Array.Copy(values, _tiles, TileCount);
+        _blankIndex = Array.IndexOf(_tiles, BlankTile);
+        _solved = false;
+    }
+
+    private void Shuffle(int[] values)
+    {
+        for (var i = values.Length - 1; i > 0; i--)
+        {
+            var j = _random.Next(i + 1);
+            (values[i], values[j]) = (values[j], values[i]);
+        }
+    }
+
+    private bool IsSolvable(int[] values)
+    {
+        var inversions = 0;
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i] == BlankTile)
+                continue;
+
+            for (var j = i + 1; j < values.Length; j++)
+            {
+                if (values[j] == BlankTile)
+                    continue;
+
+                if (values[i] > values[j])
+                    inversions++;
+            }
+        }
+
+        var blankRowFromBottom = GridSize - (Array.IndexOf(values, BlankTile) / GridSize);
+        return (inversions + blankRowFromBottom) % 2 == 0;
+    }
+
+    private static bool IsSolved(int[] values)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i] != i)
+                return false;
+        }
+
+        return true;
+    }
+
+    private void MoveTile(int index)
+    {
+        if (_solved || !IsAdjacent(index, _blankIndex))
+            return;
+
+        (_tiles[index], _tiles[_blankIndex]) = (_tiles[_blankIndex], _tiles[index]);
+        _blankIndex = index;
+        _solved = IsSolved(_tiles);
+    }
+
+    private static bool IsAdjacent(int first, int second)
+    {
+        var firstRow = first / GridSize;
+        var firstCol = first % GridSize;
+        var secondRow = second / GridSize;
+        var secondCol = second % GridSize;
+
+        var sameRow = firstRow == secondRow && Math.Abs(firstCol - secondCol) == 1;
+        var sameColumn = firstCol == secondCol && Math.Abs(firstRow - secondRow) == 1;
+        return sameRow || sameColumn;
+    }
+
+    private static string GetTileLabel(int tile) => $"Tile {tile + 1}";
+
+    private static string GetTileStyle(int tile)
+    {
+        var row = tile / GridSize;
+        var column = tile % GridSize;
+        var x = -100 * column;
+        var y = -100 * row;
+        return $"background-position: {x}% {y}%;";
+    }
+
+    private void Close() => DialogInstance.Close();
+}

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -130,6 +130,67 @@ html, body {
     margin-bottom: 8px;
 }
 
+.sliding-puzzle-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.sliding-puzzle-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 4px;
+    width: min(320px, 80vw);
+}
+
+.sliding-puzzle-tile,
+.sliding-puzzle-blank {
+    aspect-ratio: 1;
+    width: 100%;
+    border-radius: 6px;
+    border: 1px solid var(--mud-palette-divider);
+}
+
+.sliding-puzzle-tile {
+    background-image: url('/images/puzzles/dg.jpg');
+    background-repeat: no-repeat;
+    background-size: 400% 400%;
+    background-color: var(--mud-palette-surface);
+    cursor: pointer;
+    display: block;
+    padding: 0;
+    transition: transform 0.15s ease;
+}
+
+.sliding-puzzle-tile:hover {
+    transform: scale(1.02);
+}
+
+.sliding-puzzle-tile:focus-visible {
+    outline: 3px solid var(--mud-palette-primary);
+    outline-offset: 2px;
+}
+
+.sliding-puzzle-blank {
+    background-color: var(--mud-palette-background);
+    border-style: dashed;
+}
+
+.sliding-puzzle-solved {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.sliding-puzzle-solved-image {
+    max-width: min(320px, 80vw);
+    width: 100%;
+    border-radius: 8px;
+    box-shadow: var(--mud-elevation-6);
+}
+
 @media (max-width: 600px) {
     .fixture-line {
         grid-template-columns: 1fr 20px 2rem 0.5rem 2rem 20px 1fr;


### PR DESCRIPTION
## Summary
- track repeated Clear Predictions clicks and open the sliding puzzle dialog
- implement the DG sliding puzzle dialog with solvable shuffling and solved view
- style the puzzle tiles and solved state

## Testing
- dotnet build Predictorator.sln -warnaserror
- dotnet test Predictorator.sln

------
https://chatgpt.com/codex/tasks/task_e_68cc544f61f88328a219601db6a58cc1