### PR TITLE
Fix sliding puzzle rendering and modal title

### DIFF
--- a/Predictorator/Components/Pages/Index.razor
+++ b/Predictorator/Components/Pages/Index.razor
@@ -285,7 +285,7 @@ else if (_fixtures.Response.Any())
             FullWidth = true
         };
 
-        DialogService.Show<SlidingPuzzleDialog>("Sliding Puzzle", options);
+        DialogService.Show<SlidingPuzzleDialog>("Find the Player", options);
         return Task.CompletedTask;
     }
 

--- a/Predictorator/Components/SlidingPuzzleDialog.razor
+++ b/Predictorator/Components/SlidingPuzzleDialog.razor
@@ -1,8 +1,9 @@
 @using System.Linq
+@using Microsoft.AspNetCore.Components.Web
 
 <MudDialog>
     <DialogContent>
-        <MudText Typo="Typo.h6" Align="Align.Center" Class="mb-2">Sliding Puzzle</MudText>
+        <MudText Typo="Typo.h6" Align="Align.Center" Class="mb-2">Find the Player</MudText>
         @if (_solved)
         {
             <div class="sliding-puzzle-solved">
@@ -30,6 +31,7 @@
                                     class="sliding-puzzle-tile"
                                     style="@GetTileStyle(tile)"
                                     @onclick="@(() => MoveTile(index))"
+                                    @onpointerdown="@(args => OnTilePointerDown(index, args))"
                                     aria-label="@GetTileLabel(tile)">
                             </button>
                         }
@@ -102,7 +104,7 @@
         }
 
         var blankRowFromBottom = GridSize - (Array.IndexOf(values, BlankTile) / GridSize);
-        return (inversions + blankRowFromBottom) % 2 == 0;
+        return (blankRowFromBottom % 2) != (inversions % 2);
     }
 
     private static bool IsSolved(int[] values)
@@ -126,6 +128,14 @@
         _solved = IsSolved(_tiles);
     }
 
+    private void OnTilePointerDown(int index, PointerEventArgs args)
+    {
+        if (args.PointerType is not null && string.Equals(args.PointerType, "touch", StringComparison.OrdinalIgnoreCase))
+        {
+            MoveTile(index);
+        }
+    }
+
     private static bool IsAdjacent(int first, int second)
     {
         var firstRow = first / GridSize;
@@ -144,9 +154,10 @@
     {
         var row = tile / GridSize;
         var column = tile % GridSize;
-        var x = -100 * column;
-        var y = -100 * row;
-        return $"background-position: {x}% {y}%;";
+        var step = 100d / (GridSize - 1);
+        var x = column * step;
+        var y = row * step;
+        return FormattableString.Invariant($"background-position: {x}% {y}%;");
     }
 
     private void Close() => DialogInstance.Close();

--- a/Predictorator/wwwroot/css/site.css
+++ b/Predictorator/wwwroot/css/site.css
@@ -160,6 +160,7 @@ html, body {
     cursor: pointer;
     display: block;
     padding: 0;
+    touch-action: manipulation;
     transition: transform 0.15s ease;
 }
 


### PR DESCRIPTION
## Summary
- update the sliding puzzle dialog header and invocation title to "Find the Player"
- correct background positioning, solvability parity, and add touch pointer handling for the puzzle tiles
- tweak tile styling to improve touch responsiveness

## Testing
- dotnet test Predictorator.sln

------
https://chatgpt.com/codex/tasks/task_e_68cc5ae122208328a80eae66e37329e0