### PR TITLE
Handle touch input for sliding puzzle

### DIFF
--- a/Predictorator.Tests/SlidingPuzzleDialogBUnitTests.cs
+++ b/Predictorator.Tests/SlidingPuzzleDialogBUnitTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using Bunit;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor.Services;
+using Predictorator.Components;
+
+namespace Predictorator.Tests;
+
+public class SlidingPuzzleDialogBUnitTests
+{
+    [Fact]
+    public async Task TouchStart_Moves_Tile_Into_Blank_Space()
+    {
+        await using var ctx = new BunitContext();
+        ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+        ctx.Services.AddMudServices();
+
+        var cut = ctx.Render<SlidingPuzzleDialog>();
+
+        var instance = cut.Instance;
+        var tilesField = typeof(SlidingPuzzleDialog).GetField("_tiles", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var blankIndexField = typeof(SlidingPuzzleDialog).GetField("_blankIndex", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var solvedField = typeof(SlidingPuzzleDialog).GetField("_solved", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var tiles = (int[])tilesField.GetValue(instance)!;
+        var arrangement = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 14 };
+        Array.Copy(arrangement, tiles, arrangement.Length);
+        blankIndexField.SetValue(instance, 14);
+        solvedField.SetValue(instance, false);
+
+        cut.Render();
+
+        var touchMethod = typeof(SlidingPuzzleDialog).GetMethod("OnTileTouchStart", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(touchMethod);
+
+        touchMethod!.Invoke(instance, new object[] { 15, new TouchEventArgs() });
+
+        var blankIndex = (int)blankIndexField.GetValue(instance)!;
+        Assert.Equal(15, blankIndex);
+    }
+}

--- a/Predictorator/Components/SlidingPuzzleDialog.razor
+++ b/Predictorator/Components/SlidingPuzzleDialog.razor
@@ -32,6 +32,7 @@
                                     style="@GetTileStyle(tile)"
                                     @onclick="@(() => MoveTile(index))"
                                     @onpointerdown="@(args => OnTilePointerDown(index, args))"
+                                    @ontouchstart="@(args => OnTileTouchStart(index, args))"
                                     aria-label="@GetTileLabel(tile)">
                             </button>
                         }
@@ -134,6 +135,11 @@
         {
             MoveTile(index);
         }
+    }
+
+    private void OnTileTouchStart(int index, TouchEventArgs args)
+    {
+        MoveTile(index);
     }
 
     private static bool IsAdjacent(int first, int second)


### PR DESCRIPTION
## Summary
- add a touchstart handler to sliding puzzle tiles so taps on mobile move pieces
- add a bUnit test that configures the board and verifies invoking the touch handler moves the blank

## Testing
- dotnet test Predictorator.sln

------
https://chatgpt.com/codex/tasks/task_e_68cc6036d5b08328b00f10169f921eb6